### PR TITLE
Add an option to override trading days/year in get_period_days()

### DIFF
--- a/qis/utils/dates.py
+++ b/qis/utils/dates.py
@@ -28,6 +28,9 @@ CALENDAR_DAYS_IN_MONTH = 30
 CALENDAR_DAYS_PER_YEAR_SHARPE = 365.25  # for total return computations for Sharpe
 
 
+DEFAULT_TRADING_YEAR_DAYS = 252  # How mny trading days we assume per year, see get_period_days()
+
+
 def get_current_time_with_tz(tz: Optional[str] = 'UTC',
                              days_offset: int = None,
                              normalize: bool = True,
@@ -67,7 +70,7 @@ def get_period_days(freq: str = 'B',
     an_f will return the number of period in year
     consistent with using 252 for vol annualization
     """
-    an_days = 365 if is_calendar else 252
+    an_days = 365 if is_calendar else DEFAULT_TRADING_YEAR_DAYS
     if freq in ['1M']:
         days = 1.0 / 24.0 / 60.0
         an_f = an_days * 24.0 * 60.0
@@ -117,7 +120,7 @@ def get_period_days(freq: str = 'B',
         days = an_days
         an_f = 1.0
     else:
-        raise TypeError(f'freq={freq} is not impelemnted')
+        raise TypeError(f'freq={freq} is not implemented')
 
     return days, an_f
 


### PR DESCRIPTION
- This patch allows you to override the default number of trading days per year with a module global variable
- Currently, it is very difficult for OptimalPortfolios to uses  24/7 calendar like crypto for trading with 365 days, because most of the entry point functions lack the options to pass around the `is_calendar` or `days_per_year` or similar
- I also tried to change the code so that the number of days would have been passed through function arguments in the stack, but I had to modify the code in ~20 places and it became a bit of a mess and thus opted for a global variable
 
Example:

```python
def main():

    from qis.utils import dates
    dates.DEFAULT_TRADING_YEAR_DAYS = 356

```