### PR TITLE
Clean actionable pytest warnings and skips

### DIFF
--- a/src/qis/plots/boxplot.py
+++ b/src/qis/plots/boxplot.py
@@ -92,7 +92,12 @@ def plot_box(df: Union[pd.Series, pd.DataFrame],
         if hue is None:
             palette = put.get_data_group_colors(df=df, x=x, y=y)
         else:
-            n_colors = len(hue_order) if hue_order is not None else df[hue].nunique()
+            if hue_order is not None:
+                n_colors = len(hue_order)
+            elif isinstance(df[hue].dtype, pd.CategoricalDtype):
+                n_colors = len(df[hue].cat.categories)
+            else:
+                n_colors = df[hue].nunique()
             palette = put.get_n_colors(n=n_colors)
 
     sns.boxplot(x=x, y=y, data=df,

--- a/src/qis/plots/boxplot.py
+++ b/src/qis/plots/boxplot.py
@@ -92,7 +92,8 @@ def plot_box(df: Union[pd.Series, pd.DataFrame],
         if hue is None:
             palette = put.get_data_group_colors(df=df, x=x, y=y)
         else:
-            palette = put.get_n_colors(n=len(df[x].unique()))
+            n_colors = len(hue_order) if hue_order is not None else df[hue].nunique()
+            palette = put.get_n_colors(n=n_colors)
 
     sns.boxplot(x=x, y=y, data=df,
                 hue=hue or x,

--- a/src/qis/plots/tests/boxplot_test.py
+++ b/src/qis/plots/tests/boxplot_test.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
+import pytest
 from enum import Enum
 import qis.utils.df_melt as dfm
 import qis.plots.utils as put
@@ -8,6 +10,50 @@ from qis.plots.boxplot import (plot_box, df_boxplot_by_classification_var,
                                df_dict_boxplot_by_columns, df_boxplot_by_index,
                                df_boxplot_by_columns)
 
+
+
+@pytest.mark.parametrize(
+    ('hue_order', 'expected_n_colors'),
+    [
+        (None, 3),
+        (['h2', 'h1', 'h0', 'missing'], 4),
+    ],
+    ids=['observed-hues', 'explicit-hue-order'],
+)
+def test_plot_box_palette_matches_hue_cardinality(
+        monkeypatch: pytest.MonkeyPatch,
+        hue_order: list[str] | None,
+        expected_n_colors: int,
+        ) -> None:
+    """Size the categorical palette from the hue categories.
+
+    Args:
+        monkeypatch: Pytest fixture used to record the requested palette size.
+        hue_order: Explicit hue order, or None to use the observed hue values.
+        expected_n_colors: Expected number of categorical palette colors.
+    """
+    data = pd.DataFrame({
+        'x': ['left'] * 3 + ['right'] * 3,
+        'hue': ['h0', 'h1', 'h2'] * 2,
+        'value': np.arange(6, dtype=float),
+    })
+    requested_sizes: list[int] = []
+    original_get_n_colors = put.get_n_colors
+
+    def capture_palette_size(n: int):
+        requested_sizes.append(n)
+        return original_get_n_colors(n=n)
+
+    monkeypatch.setattr(put, 'get_n_colors', capture_palette_size)
+    monkeypatch.setattr(sns, 'boxplot', lambda **kwargs: None)
+    fig, ax = plt.subplots()
+    try:
+        plot_box(df=data, x='x', y='value', hue='hue', hue_order=hue_order,
+                 legend_loc=None, ax=ax)
+    finally:
+        plt.close(fig)
+
+    assert requested_sizes == [expected_n_colors]
 
 
 class LocalTests(Enum):

--- a/src/qis/plots/tests/boxplot_test.py
+++ b/src/qis/plots/tests/boxplot_test.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -54,6 +55,44 @@ def test_plot_box_palette_matches_hue_cardinality(
         plt.close(fig)
 
     assert requested_sizes == [expected_n_colors]
+
+
+def test_plot_box_palette_includes_unused_categorical_hues(
+        monkeypatch: pytest.MonkeyPatch,
+        ) -> None:
+    """Keep one palette color for every declared categorical hue.
+
+    Args:
+        monkeypatch: Pytest fixture used to record the requested palette size.
+    """
+    data = pd.DataFrame({
+        'x': ['left', 'left', 'middle', 'middle', 'right', 'right'],
+        'hue': pd.Categorical(
+            ['h0', 'h1', 'h0', 'h1', 'h0', 'h1'],
+            categories=['h0', 'h1', 'unused'],
+        ),
+        'value': np.arange(6, dtype=float),
+    })
+    requested_sizes: list[int] = []
+    original_get_n_colors = put.get_n_colors
+
+    def capture_palette_size(n: int):
+        requested_sizes.append(n)
+        return original_get_n_colors(n=n)
+
+    monkeypatch.setattr(put, 'get_n_colors', capture_palette_size)
+    fig, ax = plt.subplots()
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            plot_box(df=data, x='x', y='value', hue='hue', legend_loc=None, ax=ax)
+        palette_warnings = [warning for warning in caught
+                            if 'palette list has fewer values' in str(warning.message)]
+    finally:
+        plt.close(fig)
+
+    assert requested_sizes == [3]
+    assert palette_warnings == []
 
 
 class LocalTests(Enum):

--- a/src/qis/plots/tests/plot_smoke_test.py
+++ b/src/qis/plots/tests/plot_smoke_test.py
@@ -126,6 +126,10 @@ def _call_kwargs(name: str, fx: Fixtures) -> dict:
     Raises:
         KeyError: if the function needs an argument that has no fixture
     """
+    if name == 'plot_exposures_strategy_vs_benchmark_stack':
+        return dict(strategy_exposures=fx.exposures, benchmark_exposures=fx.exposures,
+                    axs=plt.subplots(1, 2)[1])
+
     explicit = {
         'plot_box': dict(df=fx.returns, x=fx.returns.columns[0], y=fx.returns.columns[1]),
         'plot_brinson_attribution_table': dict(zip(
@@ -139,9 +143,6 @@ def _call_kwargs(name: str, fx: Fixtures) -> dict:
         'plot_corr_matrix_from_covar': dict(covar=fx.covar),
         'plot_data_timeseries': dict(data=fx.prices),
         'plot_df_table_with_ci': dict(df=fx.small_table, df_ci=fx.small_table.abs()),
-        'plot_exposures_strategy_vs_benchmark_stack': dict(
-            strategy_exposures=fx.exposures, benchmark_exposures=fx.exposures,
-            axs=plt.subplots(1, 2)[1]),
         'plot_histplot2d': dict(df=fx.two_columns),
         # each value is an x/y frame: first column is x, second is y
         'plot_lines_list': dict(xy_datas={'a': fx.returns.iloc[:, :2].reset_index(drop=True),
@@ -221,4 +222,5 @@ def test_every_exported_plot_function_is_covered(fx: Fixtures) -> None:
             _call_kwargs(name=name, fx=fx)
         except KeyError:
             uncovered.append(name)
+    plt.close('all')
     assert uncovered == [], f"exported plot functions with no fixture: {uncovered!r}"

--- a/src/qis/plots/tests/plot_smoke_test.py
+++ b/src/qis/plots/tests/plot_smoke_test.py
@@ -126,6 +126,9 @@ def _call_kwargs(name: str, fx: Fixtures) -> dict:
     Raises:
         KeyError: if the function needs an argument that has no fixture
     """
+    # Build this axes fixture lazily. Putting plt.subplots() in the explicit dictionary would
+    # create an unused figure during every fixture lookup because dictionary values are evaluated
+    # eagerly.
     if name == 'plot_exposures_strategy_vs_benchmark_stack':
         return dict(strategy_exposures=fx.exposures, benchmark_exposures=fx.exposures,
                     axs=plt.subplots(1, 2)[1])

--- a/src/qis/portfolio/portfolio_data.py
+++ b/src/qis/portfolio/portfolio_data.py
@@ -686,7 +686,9 @@ class PortfolioData:
         pnl = self.get_instruments_pnl(time_period=time_period)
         # portfolio_pnl = pnl.sum(axis=1)
 
-        pnl_risk = np.nanstd(pnl.replace({0.0: np.nan}), axis=0)
+        pnl_values = pnl.replace({0.0: np.nan}).to_numpy()
+        pnl_risk = np.array([np.nan if np.isnan(values).all() else np.nanstd(values)
+                             for values in pnl_values.T])
         # portfolio_pnl_risk = np.nanstd(portfolio_pnl.replace({0.0: np.nan}), axis=0)
         # pnl_risk_ratio = pnl_risk / portfolio_pnl_risk
         pnl_risk_ratio = pnl_risk / np.nansum(pnl_risk)

--- a/src/qis/portfolio/portfolio_data.py
+++ b/src/qis/portfolio/portfolio_data.py
@@ -687,6 +687,7 @@ class PortfolioData:
         # portfolio_pnl = pnl.sum(axis=1)
 
         pnl_values = pnl.replace({0.0: np.nan}).to_numpy()
+        # np.nanstd warns on an all-NaN instrument; NaN is the intended risk for that column.
         pnl_risk = np.array([np.nan if np.isnan(values).all() else np.nanstd(values)
                              for values in pnl_values.T])
         # portfolio_pnl_risk = np.nanstd(portfolio_pnl.replace({0.0: np.nan}), axis=0)

--- a/src/qis/portfolio/tests/attribution_reduction_test.py
+++ b/src/qis/portfolio/tests/attribution_reduction_test.py
@@ -34,7 +34,8 @@ ONE_SIDED = pd.Series([5.0, 3.0, 1.0, 0.4, 0.1, 0.05], index=list('abcdef'))
 
 def build_portfolio_data() -> qis.PortfolioData:
     """an equal-weight portfolio over the seeded synthetic panel"""
-    prices = qis.TimePeriod('31Dec2020', '31Dec2025').locate(generate_synthetic_prices())
+    prices = qis.TimePeriod('31Dec2020', '31Dec2025').locate(
+        generate_synthetic_prices(apply_quirks=False))
     weights = pd.DataFrame(1.0 / len(prices.columns), index=prices.index, columns=prices.columns)
     return qis.backtest_model_portfolio(prices=prices, weights=weights.iloc[::21, :],
                                         ticker='Test portfolio')

--- a/src/qis/portfolio/tests/attribution_reduction_test.py
+++ b/src/qis/portfolio/tests/attribution_reduction_test.py
@@ -33,7 +33,7 @@ ONE_SIDED = pd.Series([5.0, 3.0, 1.0, 0.4, 0.1, 0.05], index=list('abcdef'))
 
 
 def build_portfolio_data() -> qis.PortfolioData:
-    """an equal-weight portfolio over the seeded synthetic panel"""
+    """an equal-weight portfolio over a quirk-free seeded panel for reduction-only tests"""
     prices = qis.TimePeriod('31Dec2020', '31Dec2025').locate(
         generate_synthetic_prices(apply_quirks=False))
     weights = pd.DataFrame(1.0 / len(prices.columns), index=prices.index, columns=prices.columns)

--- a/src/qis/portfolio/tests/attribution_reduction_test.py
+++ b/src/qis/portfolio/tests/attribution_reduction_test.py
@@ -13,6 +13,7 @@ trusting them, so a matplotlib release that invalidates either fails here rather
 a report. The rest pin the reduction's arithmetic and its wiring.
 """
 # packages
+import warnings
 import matplotlib
 matplotlib.use('Agg')  # noqa: E402  - a headless backend, set before pyplot is imported
 import numpy as np
@@ -59,6 +60,38 @@ def test_performance_attribution_uses_instrument_display_names() -> None:
 
     assert pnl.index.tolist() == list(names.values())
     assert pnl_risk.index.tolist() == list(names.values())
+
+
+def test_pnl_risk_attribution_handles_all_zero_instrument_without_warning(
+        monkeypatch: pytest.MonkeyPatch,
+        ) -> None:
+    """Preserve finite risk shares when one instrument has only zero P&L.
+
+    Args:
+        monkeypatch: Pytest fixture used to provide deterministic instrument P&L.
+    """
+    portfolio_data = build_portfolio_data()
+    pnl = pd.DataFrame({
+        'all_zero': [0.0, 0.0, 0.0, 0.0],
+        'unit_risk': [1.0, -1.0, 1.0, -1.0],
+        'double_risk': [2.0, -2.0, 2.0, -2.0],
+    })
+    monkeypatch.setattr(
+        portfolio_data,
+        'get_instruments_pnl',
+        lambda time_period=None: pnl,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', RuntimeWarning)
+        actual = portfolio_data.get_instruments_pnl_risk_attribution()
+
+    expected = pd.Series(
+        [np.nan, 1.0 / 3.0, 2.0 / 3.0],
+        index=pnl.columns,
+        name=portfolio_data.nav.name,
+    )
+    pd.testing.assert_series_equal(actual, expected)
 
 
 def test_brinson_keeps_canonical_alignment_with_display_names() -> None:

--- a/src/qis/portfolio/tests/legend_capacity_test.py
+++ b/src/qis/portfolio/tests/legend_capacity_test.py
@@ -146,8 +146,14 @@ def test_multi_asset_factsheet_validates_capacity(monkeypatch: pytest.MonkeyPatc
     fig = qis.generate_multi_asset_factsheet(prices=prices, benchmark=prices.columns[0],
                                              time_period=time_period)
     plt.close(fig)
-    assert len(calls) == 1
-    assert calls[0]['n_legend_entries'] == len(prices.columns)
+    assert calls == [{
+        'n_legend_entries': len(prices.columns),
+        'figsize': A4_PORTRAIT,
+        'fontsize': 5,
+        'panel_rows': 2,
+        'gridspec_rows': 14,
+        'report_name': 'multi-asset factsheet',
+    }]
 
 
 class LocalTest:

--- a/src/qis/portfolio/tests/legend_capacity_test.py
+++ b/src/qis/portfolio/tests/legend_capacity_test.py
@@ -135,20 +135,19 @@ def test_validate_legend_capacity_suggestions_clear_the_guard() -> None:
                                     panel_rows=2, gridspec_rows=14) >= 22
 
 
-def test_multi_asset_factsheet_warns() -> None:
-    """the guard is wired into generate_multi_asset_factsheet and is quiet on an A4 page"""
+def test_multi_asset_factsheet_validates_capacity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """the guard is wired into generate_multi_asset_factsheet"""
     prices = qis.TimePeriod('31Dec2020', '31Dec2025').locate(generate_synthetic_prices())
     time_period = qis.get_time_period(prices)
-    # 10 assets sit inside the A4 capacity of 13
-    fig = assert_no_capacity_warning(qis.generate_multi_asset_factsheet,
-                                     prices=prices, benchmark=prices.columns[0],
-                                     time_period=time_period)
+    calls = []
+    monkeypatch.setattr(
+        'qis.portfolio.reports.multi_assets_factsheet.validate_legend_capacity',
+        lambda **kwargs: calls.append(kwargs))
+    fig = qis.generate_multi_asset_factsheet(prices=prices, benchmark=prices.columns[0],
+                                             time_period=time_period)
     plt.close(fig)
-    # the same 10 assets do not fit a half-height page, whose capacity is 5
-    with pytest.warns(UserWarning, match=CAPACITY_WARNING):
-        fig = qis.generate_multi_asset_factsheet(prices=prices, benchmark=prices.columns[0],
-                                                 time_period=time_period, figsize=(8.3, 5.85))
-    plt.close(fig)
+    assert len(calls) == 1
+    assert calls[0]['n_legend_entries'] == len(prices.columns)
 
 
 class LocalTest:

--- a/src/qis/portfolio/tests/test_backtester_weights_consistency.py
+++ b/src/qis/portfolio/tests/test_backtester_weights_consistency.py
@@ -138,8 +138,10 @@ def test_lag_is_counted_in_observations_not_calendar_days(clean_prices: pd.DataF
     weights = pd.DataFrame(np.array([[0.6, 0.4]] * len(clean_prices.index)),
                            index=clean_prices.index, columns=clean_prices.columns)
     for lag in [1, 2, 3]:
-        portfolio_data = qis.backtest_model_portfolio(prices=clean_prices, weights=weights,
-                                                     weight_implementation_lag=lag)
+        with pytest.warns(
+                UserWarning, match='weight dates trade past the end of the price history'):
+            portfolio_data = qis.backtest_model_portfolio(prices=clean_prices, weights=weights,
+                                                         weight_implementation_lag=lag)
         is_rebalancing = portfolio_data.is_rebalancing
         traded_dates = is_rebalancing[is_rebalancing == True].index
         assert len(traded_dates) == len(weights.index) - lag, f"rows lost at lag={lag}"
@@ -156,8 +158,10 @@ def test_lag_does_not_touch_instrument_returns(clean_prices: pd.DataFrame) -> No
     weights = pd.DataFrame(np.array([[0.6, 0.4]] * len(clean_prices.index)),
                            index=clean_prices.index, columns=clean_prices.columns)
     unlagged = qis.backtest_model_portfolio(prices=clean_prices, weights=weights)
-    lagged = qis.backtest_model_portfolio(prices=clean_prices, weights=weights,
-                                          weight_implementation_lag=2)
+    with pytest.warns(
+            UserWarning, match='weight dates trade past the end of the price history'):
+        lagged = qis.backtest_model_portfolio(prices=clean_prices, weights=weights,
+                                              weight_implementation_lag=2)
     assert unlagged.prices.equals(lagged.prices)
     assert np.allclose(qis.to_returns(unlagged.prices, drop_first=True).to_numpy(),
                        qis.to_returns(lagged.prices, drop_first=True).to_numpy())

--- a/src/qis/portfolio/tests/tracking_error_report_test.py
+++ b/src/qis/portfolio/tests/tracking_error_report_test.py
@@ -169,7 +169,9 @@ def test_covariance_only_model_preserves_pre_existing_output_keys(report_inputs)
 def test_complete_factor_model_adds_panels_and_supplies_missing_covariance(
         report_inputs) -> None:
     universe, _, without_covar, _, factor_model = report_inputs
-    figs, dfs = _run_report(without_covar, universe, factor_model)
+    with matplotlib.rc_context({'figure.max_open_warning': 20}):
+        with pytest.warns(RuntimeWarning, match='More than 20 figures have been opened'):
+            figs, dfs = _run_report(without_covar, universe, factor_model)
     try:
         assert {'tre_decomposition', 'factor_exposures'} <= set(figs)
         assert {'tre_decomposition', 'factor_exposures'} <= set(dfs)

--- a/src/qis/portfolio/tests/tracking_error_report_test.py
+++ b/src/qis/portfolio/tests/tracking_error_report_test.py
@@ -169,6 +169,10 @@ def test_covariance_only_model_preserves_pre_existing_output_keys(report_inputs)
 def test_complete_factor_model_adds_panels_and_supplies_missing_covariance(
         report_inputs) -> None:
     universe, _, without_covar, _, factor_model = report_inputs
+    # The complete factor-model report intentionally creates and returns 22 figures in one call.
+    # Matplotlib warns when the 21st figure opens, before this test receives the figure dictionary
+    # and can close it. Pin the default threshold to make the warning deterministic, assert it here,
+    # and close every returned figure in the finally block below.
     with matplotlib.rc_context({'figure.max_open_warning': 20}):
         with pytest.warns(RuntimeWarning, match='More than 20 figures have been opened'):
             figs, dfs = _run_report(without_covar, universe, factor_model)

--- a/src/qis/tests/test_core_api.py
+++ b/src/qis/tests/test_core_api.py
@@ -94,29 +94,27 @@ def test_pending_list_is_a_subset_of_the_core() -> None:
     assert not stray, f"PENDING_DOCSTRINGS names non-core symbols: {stray}"
 
 
-@pytest.mark.parametrize('name', sorted(set(core_api_names()) - PENDING_DOCSTRINGS
-                                        - set(PROSE_DOCUMENTED)))
+@pytest.mark.parametrize('name', sorted(name for name in set(core_api_names())
+                                        - PENDING_DOCSTRINGS - set(PROSE_DOCUMENTED)
+                                        if _documentable(name)))
 def test_core_symbol_is_documented(name: str) -> None:
     """a core symbol carries an Args or Attributes block."""
-    if not _documentable(name):
-        pytest.skip(f"{name} is a constant, not a callable")
     assert _is_documented(getattr(qis, name)), (
         f"qis.{name} is core but has no Args:/Attributes: block. Write it, or move the name "
         f"out of CORE_API if it is not core after all")
 
 
-@pytest.mark.parametrize('name', sorted(PENDING_DOCSTRINGS))
-def test_pending_symbol_is_still_undocumented(name: str) -> None:
+def test_pending_symbols_are_still_undocumented() -> None:
     """
     the backlog must shrink when work lands.
 
     A name here that is now documented means the docstring was written and the list not updated.
     Remove it from PENDING_DOCSTRINGS; the check above then holds it documented forever.
     """
-    if not _documentable(name):
-        pytest.skip(f"{name} is a constant, not a callable")
-    assert not _is_documented(getattr(qis, name)), (
-        f"qis.{name} is documented now - remove it from PENDING_DOCSTRINGS")
+    for name in sorted(PENDING_DOCSTRINGS):
+        assert _documentable(name), f"{name} is a constant, not a callable"
+        assert not _is_documented(getattr(qis, name)), (
+            f"qis.{name} is documented now - remove it from PENDING_DOCSTRINGS")
 
 
 def test_capability_groups_are_named() -> None:
@@ -150,7 +148,9 @@ def _documented_argument_names(obj: Any) -> List[str]:
     return re.findall(r'^    (\w+):', block.group(1), flags=re.M)
 
 
-@pytest.mark.parametrize('name', sorted(set(core_api_names()) - set(PROSE_DOCUMENTED)))
+@pytest.mark.parametrize('name', sorted(
+    name for name in set(core_api_names()) - set(PROSE_DOCUMENTED)
+    if _documentable(name) and len(_documented_argument_names(getattr(qis, name))) > 0))
 def test_documented_arguments_exist(name: str) -> None:
     """
     an Args: block cannot name an argument the function does not take.
@@ -159,12 +159,8 @@ def test_documented_arguments_exist(name: str) -> None:
     argument that does not exist; here it is a docstring doing the same, which is worse,
     because a reader has no way to find out except by trying it.
     """
-    if not _documentable(name):
-        pytest.skip(f"{name} is a constant, not a callable")
     obj = getattr(qis, name)
     documented = _documented_argument_names(obj)
-    if len(documented) == 0:
-        pytest.skip(f"{name} has no Args: block")
     try:
         parameters = set(inspect.signature(getattr(obj, 'py_func', obj)).parameters)
     except (ValueError, TypeError):

--- a/src/qis/tests/test_documentation.py
+++ b/src/qis/tests/test_documentation.py
@@ -174,9 +174,10 @@ def test_generated_prefix_is_exercised(prefix: str) -> None:
 @pytest.mark.parametrize('link', ALL_LINKS, ids=LINK_IDS)
 def test_internal_link_resolves(link: Link) -> None:
     """a link into this repository points at a file or directory that is here."""
-    if any(link.target.startswith(prefix) for prefix in GENERATED_PREFIXES):
-        pytest.skip(f'{link.target} is written by docs/conf.py at build time')
     resolved = REPO_ROOT.joinpath(link.target)
+    if (any(link.target.startswith(prefix) for prefix in GENERATED_PREFIXES)
+            and not resolved.exists()):
+        pytest.skip(f'{link.target} is written by docs/conf.py at build time')
     assert resolved.exists(), (
         f"{link.document} links to {link.target}, which does not exist. "
         f"Written as {link.raw!r}")

--- a/src/qis/tests/test_paper_audit.py
+++ b/src/qis/tests/test_paper_audit.py
@@ -25,7 +25,7 @@ red in the first three days and caught nothing either time: once because two wor
 a proxy moves but the claim stays true is the kind that gets routed around, which is the same
 reason the lint job in ``.github/workflows/ci.yml`` gates changed lines rather than whole files.
 The unquoted metrics are still measured, still recorded and still refreshed; nothing asserts on
-them.
+their values.
 
 A **recorded** metric needs ``git`` or a network clone of a consumer repository. Neither may run
 in a test, so those are checked for presence and provenance rather than recomputed. Refresh them
@@ -131,15 +131,27 @@ def test_record_exists_and_names_its_commit() -> None:
 LIVE_METRICS: List[str] = sorted(_live_measurements()) if IS_REPOSITORY_CHECKOUT else []
 
 
-@pytest.mark.parametrize('metric', LIVE_METRICS)
-def test_live_metric_matches_the_record(metric: str) -> None:
+def test_live_metrics_are_recorded() -> None:
+    """every metric measured here remains present in the generated record."""
+    record = _record()
+    missing = sorted(set(LIVE_METRICS) - set(record['metrics']))
+    assert not missing, f'{missing} are measured here but absent from the record; regenerate it'
+
+
+def _quoted_live_metrics() -> List[str]:
+    """live metrics whose values are quoted in the paper."""
+    record = _record()
+    return [metric for metric in LIVE_METRICS
+            if record['metrics'].get(metric, {}).get('paper_phrase') is not None]
+
+
+QUOTED_LIVE_METRICS: List[str] = _quoted_live_metrics() if IS_REPOSITORY_CHECKOUT else []
+
+
+@pytest.mark.parametrize('metric', QUOTED_LIVE_METRICS)
+def test_quoted_live_metric_matches_the_record(metric: str) -> None:
     """a metric the paper quotes still has the value the record and the paper carry."""
     record = _record()
-    assert metric in record['metrics'], (
-        f'{metric} is measured here but absent from the record; regenerate it')
-    if record['metrics'][metric].get('paper_phrase') is None:
-        pytest.skip(f'{metric} is recorded but not quoted in paper.md, so drift in it cannot '
-                    f'make the manuscript wrong')
     recorded = record['metrics'][metric]['value']
     measured = _live_measurements()[metric]
     assert measured == recorded, (

--- a/src/qis/tests/test_reporting_conventions.py
+++ b/src/qis/tests/test_reporting_conventions.py
@@ -314,7 +314,8 @@ def _render_portfolio_report(report_kind, p_strategy, mpd, benchmark_prices, tim
                          ids=['monthly', 'quarterly'])
 def test_portfolio_report_labels(portfolios, prices, report_kind, rf, grid, s_long):
     p_strategy, mpd = portfolios
-    tp = qis.get_time_period(df=prices)  # full history -> long horizon
+    prices = prices.loc[prices.index > prices.index[-1] - pd.DateOffset(years=8)]
+    tp = qis.get_time_period(df=prices)  # eight years -> long horizon
     kw = fetch_default_report_kwargs(time_period=tp, reporting_frequency=rf)
     figs = _render_portfolio_report(report_kind, p_strategy, mpd, prices[['A0']], tp, kw)
     figs = list(figs) if isinstance(figs, (list, tuple)) else [figs]

--- a/src/qis/tests/test_reporting_goldens.py
+++ b/src/qis/tests/test_reporting_goldens.py
@@ -1,31 +1,16 @@
-"""
-Visual-regression (golden-image) tier for the multi-asset factsheet, via pytest-mpl.
+"""Structural layout regression tests for the multi-asset factsheet.
 
-These render the multi-asset report across the reporting-frequency grid and compare the full A4
-figure against committed baseline PNGs - catching layout / overlap / clipping / colour drift that
-the structural title assertions in test_reporting_conventions.py cannot see.
-
-Baseline images are environment-specific (matplotlib and freetype versions change text rendering),
-so generate them in YOUR environment before enabling comparison:
-
-    # 1) create the baselines once (renders and saves them; performs no comparison):
-    pytest src/qis/tests/test_reporting_goldens.py --mpl-generate-path=src/qis/tests/baseline
-
-    # 2) thereafter, compare future renders against them:
-    pytest src/qis/tests/test_reporting_goldens.py --mpl
-
-Without the --mpl flag (a plain `pytest` run) these tests still execute and pass but perform no
-image comparison, so they are safe to leave in the default suite. The RMS `tolerance` below is set
-generously for a dense A4 figure; tighten it once baselines are stable in your environment.
-
-Requires:  pip install pytest-mpl
+The repository does not store environment-specific baseline images. These tests instead render
+the full A4 report across the reporting-frequency grid and pin its panel count and axes geometry.
+Frequency labels and titles are covered by ``test_reporting_conventions.py``.
 """
 import numpy as np
 import pandas as pd
 import matplotlib
 matplotlib.use('Agg')  # deterministic headless rendering
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.figure import Figure
 import pytest
-
 import qis
 from qis import ReportingFrequency
 from qis.portfolio.reports.config import fetch_default_report_kwargs
@@ -44,32 +29,29 @@ def _make_synthetic_prices(n_assets: int = 6, n_years: int = 14, seed: int = 7) 
     return pd.DataFrame(prices, index=idx, columns=[f'A{i}' for i in range(n_assets)])
 
 
-def _multi_asset_figure(reporting_frequency: ReportingFrequency):
+def _multi_asset_figure(reporting_frequency: ReportingFrequency) -> Figure:
     prices = _make_synthetic_prices()
     tp = qis.get_time_period(df=prices)
     kw = fetch_default_report_kwargs(time_period=tp, reporting_frequency=reporting_frequency)
     return generate_multi_asset_factsheet(prices=prices, benchmark='A0', time_period=tp, **kw)
 
 
-# common pytest-mpl settings: package-local baselines, generous RMS tolerance and fixed dpi
-_MPL_KW = dict(baseline_dir='baseline', tolerance=25, savefig_kwargs={'dpi': 80})
+def _assert_figure_layout(figure: Figure) -> None:
+    """the report has its expected panel grid entirely inside the figure."""
+    assert len(figure.axes) == 16
+    for axis in figure.axes:
+        left, bottom, width, height = axis.get_position().bounds
+        assert width > 0.0 and height > 0.0
+        assert left >= 0.0 and bottom >= 0.0
+        assert left + width <= 1.0 and bottom + height <= 1.0
 
 
-@pytest.mark.mpl_image_compare(filename='multi_asset_daily.png', **_MPL_KW)
-def test_golden_multi_asset_daily():
-    return _multi_asset_figure(ReportingFrequency.DAILY)
-
-
-@pytest.mark.mpl_image_compare(filename='multi_asset_weekly.png', **_MPL_KW)
-def test_golden_multi_asset_weekly():
-    return _multi_asset_figure(ReportingFrequency.WEEKLY)
-
-
-@pytest.mark.mpl_image_compare(filename='multi_asset_monthly.png', **_MPL_KW)
-def test_golden_multi_asset_monthly():
-    return _multi_asset_figure(ReportingFrequency.MONTHLY)
-
-
-@pytest.mark.mpl_image_compare(filename='multi_asset_quarterly.png', **_MPL_KW)
-def test_golden_multi_asset_quarterly():
-    return _multi_asset_figure(ReportingFrequency.QUARTERLY)
+@pytest.mark.parametrize('reporting_frequency', list(ReportingFrequency),
+                         ids=[frequency.name.lower() for frequency in ReportingFrequency])
+def test_multi_asset_report_layout(reporting_frequency: ReportingFrequency) -> None:
+    figure = _multi_asset_figure(reporting_frequency)
+    try:
+        figure.canvas.draw()
+        _assert_figure_layout(figure)
+    finally:
+        plt.close(figure)


### PR DESCRIPTION
## Summary

This change cleans actionable warnings and removes avoidable skips from the pytest output.  It:

- sizes box-plot palettes from an explicit `hue_order` or the observed hue
  cardinality, and avoids an all-NaN NumPy reduction warning without changing
  finite P&L-risk results;
- adds regression tests with Google-style docstrings for both palette paths,
  verifying that all-zero P&L remains NaN while finite risk shares remain one-third and
  two-thirds without a `RuntimeWarning`;
- creates smoke-test figures only when needed and closes remaining figures
  after coverage checks;
- uses quirk-free synthetic prices where attribution-reduction behavior—not
  missing-data handling—is under test;
- verifies the multi-asset factsheet calls its legend-capacity guard once with
  the correct entry count, while retaining separate threshold/message tests;
- asserts the expected backtester boundary warning and pins the
  complete-factor-model test's figure threshold at 20, asserting the warning
  produced by its intentional 22 figures and closing them afterward;
- excludes inapplicable core-API documentation cases before parameterization;
- validates generated documentation links whenever the Sphinx-generated files
  exist, skipping them only when those files have not been built;
- requires every live paper metric to remain in the audit record while
  comparing values only for metrics actually quoted in the manuscript;
- shortens a reporting fixture from 14 years to 8 years while preserving the
  long-horizon reporting branch;
- replaces inactive pytest-mpl cases with structural checks that draw every
  reporting-frequency variant and verify its 16 axes remain within the figure.

## Behavior

No public signatures, defaults, dependencies, or package exports change. The
only runtime effects are:

1. `plot_box` selects the correct number of colors when the hue and x-axis
   cardinalities differ. This is an intended visual correction.
2. An all-NaN P&L risk input continues to produce NaN, but no longer calls the
   warning-producing reduction. Results for finite inputs are unchanged.

No warnings are suppressed; one regression test promotes `RuntimeWarning` to an
error to prove the all-NaN warning does not recur. The backtester still emits
its boundary warning, and the tracking-error report still returns 22 figures;
their tests now assert those behaviors and clean up the figures. All other
changes affect tests only.

## Regression evidence

Against the pre-fix implementations, the palette test requested two colors
instead of three or four, and the all-zero P&L test raised NumPy's expected
`RuntimeWarning`. Both pass with the current implementations.

## Verification

- `pytest src/qis/` — 1364 passed, 527 warnings (Python 3.11)
- `sphinx-build -W -b html docs docs/_build/html` — passed
- `python tools/sync_public_api.py --check` — passed
- `python .github/lint_changed_lines.py upstream/main HEAD` — passed
- `python -m pip check` — passed
- `git diff --check` — passed

The 527 remaining warnings are known third-party Seaborn/Matplotlib deprecations.

## Scope

No public API changes, new dependencies, version bump, generated files, or
warning suppression.

## Review note

These changes were diagnosed and verified together as one pytest-output cleanup.
I am happy to split the runtime fixes from the test-harness changes if helpful.
