### PR TITLE
Support NumPy constant-trade-level NAV conversion

### DIFF
--- a/src/qis/perfstats/returns.py
+++ b/src/qis/perfstats/returns.py
@@ -759,7 +759,8 @@ def returns_to_nav(returns: Union[np.ndarray, pd.Series, pd.DataFrame],
     # Compute NAV using arithmetic or geometric compounding
     if constant_trade_level:
         if isinstance(returns, np.ndarray):
-            strategy_nav = np.cumsum(returns, axis=0) + 1.0
+            strategy_nav = np.nancumsum(returns, axis=0) + 1.0
+            strategy_nav = np.where(np.isnan(returns), np.nan, strategy_nav)
         else:
             strategy_nav = returns.cumsum(skipna=True, axis=0).add(1.0)
     else:

--- a/src/qis/perfstats/returns.py
+++ b/src/qis/perfstats/returns.py
@@ -758,7 +758,10 @@ def returns_to_nav(returns: Union[np.ndarray, pd.Series, pd.DataFrame],
 
     # Compute NAV using arithmetic or geometric compounding
     if constant_trade_level:
-        strategy_nav = returns.cumsum(skipna=True, axis=0).add(1.0)
+        if isinstance(returns, np.ndarray):
+            strategy_nav = np.cumsum(returns, axis=0) + 1.0
+        else:
+            strategy_nav = returns.cumsum(skipna=True, axis=0).add(1.0)
     else:
         if isinstance(returns, np.ndarray):
             strategy_nav = np.cumprod(1.0+returns, axis=0)

--- a/src/qis/perfstats/tests/returns_numpy_test.py
+++ b/src/qis/perfstats/tests/returns_numpy_test.py
@@ -95,6 +95,38 @@ def test_numpy_constant_trade_level_accumulates_each_column() -> None:
     np.testing.assert_array_equal(returns, original_returns)
 
 
+def test_numpy_constant_trade_level_preserves_and_resumes_missing_histories() -> None:
+    """Preserve missing observations without contaminating later additive NAVs.
+
+    The columns cover a return missing between observations, a ragged start plus a later gap,
+    and a history that never starts. Each observed return accumulates against its column's fixed
+    unit notional, while the caller-owned missing observations remain missing in the output.
+    """
+    returns = np.array([
+        [0.00, np.nan, np.nan],
+        [0.10, 0.20, np.nan],
+        [np.nan, -0.10, np.nan],
+        [0.05, np.nan, np.nan],
+        [-0.02, 0.03, np.nan],
+    ])
+    original_returns = returns.copy()
+    expected_nav = np.array([
+        [1.00, np.nan, np.nan],
+        [1.10, 1.20, np.nan],
+        [np.nan, 1.10, np.nan],
+        [1.15, np.nan, np.nan],
+        [1.13, 1.13, np.nan],
+    ])
+
+    actual_nav = returns_to_nav(
+        returns=returns,
+        constant_trade_level=True,
+    )
+
+    _assert_array_close(actual_nav, expected_nav)
+    np.testing.assert_array_equal(returns, original_returns)
+
+
 # =============================================================================
 # Option composition
 # =============================================================================

--- a/src/qis/perfstats/tests/returns_numpy_test.py
+++ b/src/qis/perfstats/tests/returns_numpy_test.py
@@ -1,0 +1,140 @@
+"""NumPy coverage for converting returns to constant-trade-level NAVs.
+
+``returns_to_nav`` accepts both pandas objects and NumPy arrays. A constant trade level changes
+the economic calculation from geometric compounding to additive accumulation against a fixed
+notional. These tests use small arrays whose expected paths can be calculated directly, keeping
+the NumPy implementation independent from the already-tested pandas branch.
+"""
+# packages
+import numpy as np
+from numpy.typing import NDArray
+
+# qis
+from qis.perfstats.returns import returns_to_nav
+
+
+# =============================================================================
+# Shared deterministic references
+# =============================================================================
+_TOLERANCE = 1e-12
+
+
+def _make_two_asset_returns() -> NDArray[np.float64]:
+    """Create a two-asset return matrix with offsetting final observations.
+
+    Returns:
+        A new array with time on axis 0 and assets on axis 1.
+    """
+    return np.array([
+        [0.00, 0.00],
+        [0.10, 0.20],
+        [-0.05, -0.10],
+    ])
+
+
+def _assert_array_close(actual: object, expected: NDArray[np.float64]) -> None:
+    """Assert that a public conversion result is the expected NumPy array.
+
+    Args:
+        actual: Result returned under the current pandas-only output annotation.
+        expected: Independently calculated array reference.
+    """
+    # The runtime already returns an ndarray for ordinary NumPy input, although the production
+    # return annotation has not yet been widened to express that established behavior.
+    assert isinstance(actual, np.ndarray)
+    np.testing.assert_allclose(
+        actual,
+        expected,
+        rtol=_TOLERANCE,
+        atol=_TOLERANCE,
+    )
+
+
+# =============================================================================
+# Additive accumulation and shape
+# =============================================================================
+def test_numpy_constant_trade_level_accumulates_one_dimensional_returns() -> None:
+    """Accumulate a one-dimensional return path against a fixed unit notional.
+
+    A constant trade level adds each return to the same starting notional instead of multiplying
+    gross-return factors. The direct cumulative returns are ``0.00, 0.10, 0.05``, so adding the
+    unit starting NAV produces ``1.00, 1.10, 1.05``.
+    """
+    returns = np.array([0.00, 0.10, -0.05])
+    expected_nav = np.array([1.00, 1.10, 1.05])
+
+    actual_nav = returns_to_nav(
+        returns=returns,
+        constant_trade_level=True,
+    )
+
+    _assert_array_close(actual_nav, expected_nav)
+
+
+def test_numpy_constant_trade_level_accumulates_each_column() -> None:
+    """Accumulate a two-dimensional array independently along its time axis.
+
+    Each column represents one asset. Axis-0 cumulative sums must finish at ``1.05`` and ``1.10``
+    respectively, without flattening or combining the cross-section. The caller-owned matrix is
+    also retained exactly because NAV conversion must not consume or rewrite source returns.
+    """
+    returns = _make_two_asset_returns()
+    original_returns = returns.copy()
+    expected_nav = np.array([
+        [1.00, 1.00],
+        [1.10, 1.20],
+        [1.05, 1.10],
+    ])
+
+    actual_nav = returns_to_nav(
+        returns=returns,
+        constant_trade_level=True,
+    )
+
+    _assert_array_close(actual_nav, expected_nav)
+    np.testing.assert_array_equal(returns, original_returns)
+
+
+# =============================================================================
+# Option composition
+# =============================================================================
+def test_numpy_constant_trade_level_scales_each_column_to_initial_value() -> None:
+    """Scale each additive array column from one to its requested initial value.
+
+    Before scaling, the two columns follow unit-based paths ending at ``1.05`` and ``1.10``.
+    Multipliers of 100 and 200 therefore produce terminal values of 105 and 220. This verifies
+    that the new accumulation branch continues through the existing per-column scaling path.
+    """
+    returns = _make_two_asset_returns()
+    expected_nav = np.array([
+        [100.0, 200.0],
+        [110.0, 240.0],
+        [105.0, 220.0],
+    ])
+
+    actual_nav = returns_to_nav(
+        returns=returns,
+        init_value=np.array([100.0, 200.0]),
+        constant_trade_level=True,
+    )
+
+    _assert_array_close(actual_nav, expected_nav)
+
+
+def test_numpy_constant_trade_level_converts_log_returns_before_accumulating() -> None:
+    """Convert log returns to simple returns before fixed-notional accumulation.
+
+    Log gross factors ``1.00, 1.10, 0.95`` represent simple returns ``0.00, 0.10, -0.05``.
+    Additive accumulation must therefore reproduce the direct ``1.00, 1.10, 1.05`` reference,
+    rather than geometrically compounding the factors to ``1.045``.
+    """
+    log_returns = np.log(np.array([1.00, 1.10, 0.95]))
+    expected_nav = np.array([1.00, 1.10, 1.05])
+
+    actual_nav = returns_to_nav(
+        returns=log_returns,
+        constant_trade_level=True,
+        is_log_returns=True,
+    )
+
+    _assert_array_close(actual_nav, expected_nav)


### PR DESCRIPTION
## Summary

- supports `np.ndarray` inputs when `constant_trade_level=True`;
- adds five deterministic regression tests covering 1-D and 2-D arrays,
  per-column initial-value scaling, log-return conversion, input preservation, and ragged
  missing histories.

## Behavior

NumPy returns now accumulate additively along axis 0 against a fixed unit notional, matching the
existing pandas constant-trade-level convention. Missing observations remain missing without
contaminating later observations in the same column. Pandas behavior, NumPy geometric compounding,
public signatures, defaults, exports, and dependencies are unchanged.

## Regression evidence

Before the first fix, four cases raised `TypeError` because the NumPy array was sent to the
pandas-only `cumsum(skipna=True).add(1.0)` path. A fifth ragged-array regression then showed that
`np.cumsum` permanently propagated a leading or intermittent NaN. The final implementation uses
`np.nancumsum` and restores the original missing positions, matching the pandas skip-and-resume
calculation. The expected paths were also checked against an independent pandas reference.

## Verification

- `pytest src/qis/perfstats/tests/returns_numpy_test.py -v` — 5 passed
- combined PR 1/2/3 boundary files — 21 passed
- `pytest src/qis/perfstats/ -v` — 58 passed, 3 warnings
- `pytest src/qis/` — 1403 passed, 19 warnings on the original contribution
- `pyright src/qis/perfstats/tests/returns_numpy_test.py` — 0 errors, 0 warnings, 0 informations
- `ruff check src/qis/perfstats/tests/returns_numpy_test.py` — passed with Ruff 0.14.2
- changed-line lint — passed; 0 violations across 2 changed files
- independent pandas `skipna=True` calculation for ragged NumPy histories — passed
- Sphinx `-W`, public API, dependency, and `git diff --check main...HEAD` checks — passed
- `interrogate src/qis` — passed at 68.5% against a 68% threshold

## Scope

- two files; no public signature, default, export, dependency, or version change
- NumPy terminal-value scaling, `log_returns_to_nav(np_array)`, and annotations remain
  intentionally deferred