### PR TITLE
Correct drawdown episode boundaries and recovery status

### DIFF
--- a/src/qis/perfstats/perf_stats.py
+++ b/src/qis/perfstats/perf_stats.py
@@ -34,7 +34,7 @@ statistics belong in ``qis/perfstats/regime_classifier.py``.
 import numpy as np
 import pandas as pd
 from scipy.stats import kurtosis, skew
-from typing import Callable, Union, Dict, Tuple, Any, Optional, Literal
+from typing import Callable, Union, Tuple, Optional, Literal
 
 # qis
 import qis.utils.regression as ols
@@ -755,77 +755,69 @@ def compute_drawdowns_stats_table(price: pd.Series,
                                   ) -> pd.DataFrame:
     """Compute a sorted table of drawdown episodes and their statistics.
 
-    Splits the running drawdown series into NaN-separated blocks (each block is one
-    drawdown episode from peak to recovery), computes summary statistics per block,
-    sorts by max drawdown depth and optionally truncates to the worst N.
-
-    Block detection uses a pandas-version-stable groupby on a cumulative-sum index
-    rather than relying on SparseArray internals (which have shifted across pandas
-    releases).
+    Each episode starts when its running peak level was first reached immediately before
+    prices fall and ends at either the observation that recovers that peak or the final
+    underwater observation. Episodes are sorted by maximum drawdown depth, then by start
+    date to resolve equal depths.
 
     Args:
         price: Price level Series.
         max_num: Maximum number of drawdown episodes to return (worst N).
         freq: Frequency to rebase to before block detection. Default 'D' (calendar
-            days) gives recovery times in wall-clock days. Pass None to skip rebasing.
+            days) gives durations in wall-clock days. Pass None to count durations on
+            the original observation grid.
 
     Returns:
         DataFrame sorted by max_dd ascending, with columns:
         start, trough, end, max_dd, days_dd, days_to_trough, days_recovery,
         peak, bottom, recovery, is_recovered.
     """
+    columns = ['start', 'trough', 'end', 'max_dd', 'days_dd', 'days_to_trough',
+               'days_recovery', 'peak', 'bottom', 'recovery', 'is_recovered']
+    sampled_price = price.copy(deep=True)
     if freq is not None:
-        price = price.asfreq(freq, method='ffill')
-    max_dd, time_under_water = compute_rolling_drawdown_time_under_water(prices=price)
-    # Replace zeros with NaN so that NaN-separated blocks delimit drawdown episodes.
-    max_dd = max_dd.replace({0.0: np.nan})
-    time_under_water = time_under_water.replace({0.0: np.nan})
+        sampled_price = sampled_price.asfreq(freq, method='ffill')
+    sampled_price = sampled_price.ffill()
+    drawdown = compute_rolling_drawdowns(prices=sampled_price)
+    underwater_positions = np.flatnonzero(drawdown.lt(0.0).to_numpy())
+    if underwater_positions.size == 0:
+        return pd.DataFrame(columns=columns)
 
-    # Pack the three series side-by-side for per-block slicing.
-    joint = pd.concat([max_dd.rename('max_dd'), time_under_water.rename('days'), price],
-                      axis=1, sort=True)
+    split_points = np.flatnonzero(np.diff(underwater_positions) > 1) + 1
+    episodes = np.split(underwater_positions, split_points)
+    outputs = []
+    for episode in episodes:
+        first_underwater = int(episode[0])
+        prior_peaks = np.flatnonzero(drawdown.iloc[:first_underwater].eq(0.0).to_numpy())
+        if prior_peaks.size == 0:
+            continue
+        peak_position = int(prior_peaks[-1])
+        peak_value = sampled_price.iloc[peak_position]
+        while (peak_position > 0
+               and sampled_price.iloc[peak_position - 1] == peak_value
+               and drawdown.iloc[peak_position - 1] == 0.0):
+            peak_position -= 1
+        last_underwater = int(episode[-1])
+        recovery_position = last_underwater + 1
+        is_recovered = recovery_position < len(drawdown) and bool(
+            drawdown.iloc[recovery_position] >= 0.0
+        )
+        end_position = recovery_position if is_recovered else last_underwater
+        trough_position = int(episode[np.argmin(drawdown.iloc[episode].to_numpy())])
+        outputs.append(dict(start=sampled_price.index[peak_position],
+                            trough=sampled_price.index[trough_position],
+                            end=sampled_price.index[end_position],
+                            max_dd=drawdown.iloc[trough_position],
+                            days_dd=float(end_position - peak_position),
+                            days_to_trough=float(trough_position - peak_position),
+                            days_recovery=float(end_position - trough_position),
+                            peak=sampled_price.iloc[peak_position],
+                            bottom=sampled_price.iloc[trough_position],
+                            recovery=sampled_price.iloc[end_position],
+                            is_recovered=is_recovered))
 
-    def process_bslice(bslice: pd.DataFrame) -> Dict[str, Any]:
-        """Compute summary statistics for a single drawdown episode slice."""
-        max_idx = np.argmin(bslice['max_dd'].to_numpy())
-        # An episode is recovered if the price at the end of the block has returned
-        # to or above the peak at the start of the block.
-        is_recovered = bool(bslice[price.name].iloc[-1] >= bslice[price.name].iloc[0])
-        out = dict(start=bslice.index[0],
-                   trough=bslice.index[max_idx],
-                   end=bslice.index[-1],
-                   max_dd=bslice['max_dd'].iloc[max_idx],
-                   days_dd=bslice['days'].iloc[-1],
-                   days_to_trough=bslice['days'].iloc[max_idx],
-                   days_recovery=bslice['days'].iloc[-1]-bslice['days'].iloc[max_idx],
-                   peak=bslice[price.name].iloc[0],
-                   bottom=bslice[price.name].iloc[max_idx],
-                   recovery=bslice[price.name].iloc[-1],
-                   is_recovered=is_recovered)
-        return out
-
-    # ── Pandas-version-stable block detection ──
-    # Mark observations that are "in drawdown" (max_dd is not NaN). Each NaN
-    # increments a counter; consecutive non-NaN values share the same counter
-    # value, giving us a natural group key per drawdown episode.
-    is_in_dd = max_dd.notna()
-    # cumsum on the negated mask: each True in (~is_in_dd) bumps the counter,
-    # so all observations within a single drawdown share the same group id.
-    block_id = (~is_in_dd).cumsum()
-    # Group only the in-drawdown rows; each group is one episode.
-    outputs = {}
-    for bid, bslice in joint[is_in_dd].groupby(block_id[is_in_dd]):
-        if not bslice.empty:
-            outputs[bid] = process_bslice(bslice=bslice)
-
-    df = pd.DataFrame.from_dict(outputs, orient='index')
-    if df.empty:
-        # No drawdown episodes — return empty table with expected columns
-        return pd.DataFrame(columns=['start', 'trough', 'end', 'max_dd', 'days_dd',
-                                     'days_to_trough', 'days_recovery', 'peak',
-                                     'bottom', 'recovery', 'is_recovered'])
-
-    df = df.sort_values(by='max_dd')
+    df = pd.DataFrame(outputs, columns=columns)
+    df = df.sort_values(by=['max_dd', 'start'], kind='mergesort').reset_index(drop=True)
     if max_num is not None:
         df = df.iloc[:max_num, :]
     return df

--- a/src/qis/perfstats/tests/drawdown_boundaries_test.py
+++ b/src/qis/perfstats/tests/drawdown_boundaries_test.py
@@ -1,0 +1,204 @@
+"""Regression coverage for complete drawdown episode boundaries.
+
+A drawdown episode begins when its running peak level was first reached immediately before prices
+fall and ends either at the observation that recovers that peak or at the final observation of an
+ongoing drawdown. The fixtures below use short deterministic NAV paths so every date, depth,
+duration, and recovery value can be calculated directly without reusing a QIS drawdown helper.
+"""
+
+import numpy as np
+import pandas as pd
+
+# qis
+from qis.perfstats.perf_stats import compute_drawdowns_stats_table
+
+
+# =============================================================================
+# Shared deterministic fixtures
+# =============================================================================
+
+_DAILY_DATES = pd.date_range('2024-01-01', periods=9, freq='D')
+
+_COMPLETE_AND_ONGOING_NAV = (100.0, 99.0, 50.0, 90.0, 100.0, 110.0, 99.0, 88.0, 90.0)
+_TABLE_COLUMNS = [
+    'start',
+    'trough',
+    'end',
+    'max_dd',
+    'days_dd',
+    'days_to_trough',
+    'days_recovery',
+    'peak',
+    'bottom',
+    'recovery',
+    'is_recovered',
+]
+
+_TOLERANCE = 1e-12
+
+
+def _complete_and_ongoing_prices(name: str | None = 'nav') -> pd.Series:
+    """Create one recovered drawdown followed by one ongoing drawdown.
+
+    Args:
+        name: Optional name assigned to the returned Series.
+
+    Returns:
+        New daily NAV Series containing the two independently specified episodes.
+    """
+    return pd.Series(_COMPLETE_AND_ONGOING_NAV, index=_DAILY_DATES, name=name)
+
+
+def _assert_episode_table(actual: pd.DataFrame, expected: pd.DataFrame) -> None:
+    """Compare a drawdown table while ignoring its non-contractual row index.
+
+    Args:
+        actual: Table returned by ``compute_drawdowns_stats_table``.
+        expected: Independently constructed table in required episode order.
+    """
+    pd.testing.assert_frame_equal(
+        actual.reset_index(drop=True),
+        expected.reset_index(drop=True),
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+
+
+# =============================================================================
+# Complete and ongoing episode boundaries
+# =============================================================================
+
+def test_compute_drawdowns_stats_table_includes_peak_and_recovery_boundaries() -> None:
+    """Report complete boundaries for recovered and ongoing drawdowns.
+
+    The first episode starts at the January 1 peak of 100, reaches 50 on January 3, and recovers
+    to 100 on January 5. Its direct drawdown is ``50 / 100 - 1 = -50%`` over four sampled days.
+    The second starts at the January 6 peak of 110, reaches 88 on January 8, and remains below its
+    peak at 90 on January 9. It is therefore ongoing after three sampled days.
+    """
+    prices = _complete_and_ongoing_prices()
+    original_prices = prices.copy(deep=True)
+    expected = pd.DataFrame(
+        {
+            'start': [_DAILY_DATES[0], _DAILY_DATES[5]],
+            'trough': [_DAILY_DATES[2], _DAILY_DATES[7]],
+            'end': [_DAILY_DATES[4], _DAILY_DATES[8]],
+            'max_dd': [50.0 / 100.0 - 1.0, 88.0 / 110.0 - 1.0],
+            'days_dd': [4.0, 3.0],
+            'days_to_trough': [2.0, 2.0],
+            'days_recovery': [2.0, 1.0],
+            'peak': [100.0, 110.0],
+            'bottom': [50.0, 88.0],
+            'recovery': [100.0, 90.0],
+            'is_recovered': [True, False],
+        },
+        columns=pd.Index(_TABLE_COLUMNS),
+    )
+
+    actual = compute_drawdowns_stats_table(price=prices, freq=None)
+
+    _assert_episode_table(actual, expected)
+    pd.testing.assert_series_equal(prices, original_prices)
+
+
+def test_compute_drawdowns_stats_table_supports_an_unnamed_series() -> None:
+    """Make a Series name irrelevant to episode values and labels.
+
+    A Series name is metadata, not part of the drawdown calculation. Removing ``"nav"`` must
+    therefore produce the same complete table instead of using ``None`` as a failed column lookup.
+    """
+    named = compute_drawdowns_stats_table(price=_complete_and_ongoing_prices(), freq=None)
+
+    unnamed = compute_drawdowns_stats_table(
+        price=_complete_and_ongoing_prices(name=None),
+        freq=None,
+    )
+
+    _assert_episode_table(unnamed, named)
+
+
+# =============================================================================
+# Ordering and empty boundaries
+# =============================================================================
+
+def test_compute_drawdowns_stats_table_orders_equal_depths_by_start_date() -> None:
+    """Resolve equal maximum drawdowns chronologically before applying ``max_num``.
+
+    The path has two exactly 20% recovered drawdowns: 100 to 80 and 120 to 96. Equal depths do not
+    determine an order, so the earlier January 1 episode is the deterministic first row and the
+    episode retained when ``max_num=1``.
+    """
+    dates = _DAILY_DATES[:6]
+    prices = pd.Series((100.0, 80.0, 100.0, 120.0, 96.0, 120.0), index=dates, name='nav')
+
+    actual = compute_drawdowns_stats_table(price=prices, freq=None)
+    limited = compute_drawdowns_stats_table(price=prices, max_num=1, freq=None)
+
+    assert actual['start'].to_list() == [dates[0], dates[3]]
+    assert actual['end'].to_list() == [dates[2], dates[5]]
+    np.testing.assert_allclose(
+        actual['max_dd'].to_numpy(),
+        np.asarray((80.0 / 100.0 - 1.0, 96.0 / 120.0 - 1.0)),
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    assert actual['is_recovered'].to_list() == [True, True]
+    assert limited['start'].to_list() == [dates[0]]
+
+
+def test_compute_drawdowns_stats_table_returns_empty_schema_without_an_episode() -> None:
+    """Return the documented empty schema for monotonic and one-observation histories.
+
+    A strictly increasing NAV never falls below its running peak, and a single observation cannot
+    form a peak-to-trough interval. Neither input should manufacture an episode or lose the table's
+    documented columns.
+    """
+    monotonic = pd.Series((100.0, 101.0, 102.0), index=_DAILY_DATES[:3], name='nav')
+    one_observation = monotonic.iloc[:1]
+
+    monotonic_table = compute_drawdowns_stats_table(price=monotonic, freq=None)
+    one_observation_table = compute_drawdowns_stats_table(price=one_observation, freq=None)
+
+    assert monotonic_table.empty
+    assert one_observation_table.empty
+    assert monotonic_table.columns.to_list() == _TABLE_COLUMNS
+    assert one_observation_table.columns.to_list() == _TABLE_COLUMNS
+
+
+# =============================================================================
+# Sampling boundaries
+# =============================================================================
+
+def test_compute_drawdowns_stats_table_honors_native_and_requested_sampling() -> None:
+    """Count durations on the requested observation grid without inventing native rows.
+
+    The sparse path has observations on January 1, 3, and 5. With ``freq=None`` those are three
+    native observations, so peak-to-recovery spans two sampled periods. With daily rebasing, the
+    same dates span four daily periods. Both paths retain the same peak, trough, recovery, and 20%
+    depth; only the explicitly requested sampling grid changes the duration.
+    """
+    dates = pd.to_datetime(('2024-01-01', '2024-01-03', '2024-01-05'))
+    prices = pd.Series((100.0, 80.0, 100.0), index=dates, name='nav')
+
+    native = compute_drawdowns_stats_table(price=prices, freq=None)
+    daily = compute_drawdowns_stats_table(price=prices, freq='D')
+
+    for actual in (native, daily):
+        assert actual.loc[actual.index[0], 'start'] == dates[0]
+        assert actual.loc[actual.index[0], 'trough'] == dates[1]
+        assert actual.loc[actual.index[0], 'end'] == dates[2]
+        np.testing.assert_allclose(
+            actual['max_dd'].to_numpy(),
+            np.asarray((80.0 / 100.0 - 1.0,)),
+            rtol=0.0,
+            atol=_TOLERANCE,
+        )
+        assert bool(actual.loc[actual.index[0], 'is_recovered'])
+
+    assert native.loc[native.index[0], 'days_dd'] == 2.0
+    assert native.loc[native.index[0], 'days_to_trough'] == 1.0
+    assert native.loc[native.index[0], 'days_recovery'] == 1.0
+    assert daily.loc[daily.index[0], 'days_dd'] == 4.0
+    assert daily.loc[daily.index[0], 'days_to_trough'] == 2.0
+    assert daily.loc[daily.index[0], 'days_recovery'] == 2.0


### PR DESCRIPTION
## Summary

- report complete drawdown episodes from the running peak through recovery, or through the final observation when the drawdown remains ongoing;
- support unnamed Series, deterministic equal-depth ordering, and native-grid durations with `freq=None`;
- add deterministic offline regressions with independently calculated dates, depths, durations, values, and recovery status.

## Behavior

This intentionally corrects the values returned by `compute_drawdowns_stats_table()`. The previous implementation grouped only strictly underwater rows, so it could omit the peak and recovery, misstate `start`, `end`, `peak`, `recovery`, duration fields and `is_recovered`, and raise `KeyError` for an unnamed Series. The public signature is unchanged.

## Regression evidence

For the recovered path `100, 99, 50, 90, 100`, the old result described only January 2–4, used 99 and 90 as its boundary values, and marked the episode unrecovered. The corrected result spans the January 1 peak through the January 5 recovery, reports a directly calculated -50% maximum drawdown, and marks the episode recovered.

Additional cases cover an ongoing drawdown, equal-depth ordering, `max_num`, no-drawdown inputs, an unnamed Series, caller ownership, and native versus daily sampling.

Fail-before: the new module produced 4 failures and 1 pass. After the correction, all 5 tests pass.

## Verification

- combined accepted PR 6 and PR 7 regressions: 9 passed
- perfstats: 72 passed, no warnings
- full suite: 1486 passed, 16 third-party seaborn/Matplotlib warnings
- Ruff: passed
- Pyright: 0 errors
- `git diff --check`: passed

## Scope

Two files are changed: `compute_drawdowns_stats_table()` and its focused regression module. No public signature or unrelated performance-statistics path is changed.