### PR TITLE
Make all-NaN drawdown reductions warning-free

### DIFF
--- a/src/qis/perfstats/perf_stats.py
+++ b/src/qis/perfstats/perf_stats.py
@@ -704,12 +704,13 @@ def compute_max_current_drawdown(prices: Union[pd.DataFrame, pd.Series]
         elements are scalar floats.
     """
     max_dd_data = compute_rolling_drawdowns(prices=prices)
+    # fmin.reduce keeps nanmin's finite results but does not warn for an all-NaN slice.
     if isinstance(prices, pd.DataFrame):
-        max_dds = np.nanmin(max_dd_data.to_numpy(), axis=0)
+        max_dds = np.fmin.reduce(max_dd_data.to_numpy(), axis=0)
         current_dds = max_dd_data.iloc[-1, :].to_numpy()
     else:
         # Series case: return scalars (not arrays) to match the actual return shape.
-        max_dds = float(np.nanmin(max_dd_data.to_numpy()))
+        max_dds = float(np.fmin.reduce(max_dd_data.to_numpy()))
         current_dds = float(max_dd_data.iloc[-1])
     return max_dds, current_dds
 

--- a/src/qis/perfstats/tests/drawdown_reduction_test.py
+++ b/src/qis/perfstats/tests/drawdown_reduction_test.py
@@ -1,0 +1,133 @@
+"""Regression coverage for maximum and current drawdown reductions.
+
+Maximum drawdown is the minimum running drawdown over an observed price history, while current
+drawdown is the final running drawdown after the established forward-fill convention. All-missing
+histories have neither value, so both results are NaN and must not emit a reduction warning. The
+short deterministic paths below keep every expected reduction independently calculable.
+"""
+
+import warnings
+from typing import cast
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+
+# qis
+from qis.perfstats.perf_stats import compute_max_current_drawdown
+
+
+# =============================================================================
+# Shared deterministic fixtures
+# =============================================================================
+
+_DATES = pd.date_range('2024-01-01', periods=4, freq='D')
+
+_TOLERANCE = 1e-12
+
+
+def _mixed_prices() -> pd.DataFrame:
+    """Create finite, missing, ragged, trailing-gap, and constant price histories.
+
+    Returns:
+        New price DataFrame whose columns exercise distinct drawdown reductions.
+    """
+    return pd.DataFrame(
+        {
+            'recovered': (100.0, 80.0, 100.0, 90.0),
+            'missing': (np.nan, np.nan, np.nan, np.nan),
+            'ragged': (np.nan, 200.0, 100.0, 150.0),
+            'trailing_gap': (100.0, 80.0, np.nan, np.nan),
+            'constant': (5.0, 5.0, 5.0, 5.0),
+        },
+        index=_DATES,
+    )
+
+
+def _assert_array_close(actual: object, expected: NDArray[np.float64]) -> None:
+    """Compare a public result with a shape-sensitive numerical reference.
+
+    Args:
+        actual: Value returned by ``compute_max_current_drawdown``.
+        expected: Independently calculated array in input-column order.
+    """
+    assert isinstance(actual, np.ndarray)
+    actual_array = cast(NDArray[np.float64], actual)
+    assert actual_array.shape == expected.shape
+    np.testing.assert_allclose(
+        actual_array,
+        expected,
+        rtol=0.0,
+        atol=_TOLERANCE,
+        equal_nan=True,
+    )
+
+
+# =============================================================================
+# Missing-history reductions
+# =============================================================================
+
+def test_compute_max_current_drawdown_all_nan_series_is_warning_free() -> None:
+    """Return scalar NaNs without warning when no price has ever been observed.
+
+    An all-missing Series has no running peak, historical drawdown, or final drawdown. Both public
+    results are therefore scalar NaNs. Treating ``RuntimeWarning`` as an error ensures an all-NaN
+    reduction cannot silently reappear while the original input verifies caller ownership.
+    """
+    prices = pd.Series(np.nan, index=_DATES, name='missing')
+    original_prices = prices.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', RuntimeWarning)
+        maximum_drawdown, current_drawdown = compute_max_current_drawdown(prices=prices)
+
+    assert isinstance(maximum_drawdown, float)
+    assert isinstance(current_drawdown, float)
+    assert np.isnan(maximum_drawdown)
+    assert np.isnan(current_drawdown)
+    pd.testing.assert_series_equal(prices, original_prices)
+
+
+def test_compute_max_current_drawdown_reduces_mixed_dataframe_columns() -> None:
+    """Preserve finite and missing reductions when one column is entirely NaN.
+
+    The recovered path has maximum/current drawdowns of -20%/-10%; the ragged path has
+    -50%/-25%; the trailing gap retains -20% for both values; and the constant path remains at
+    zero. The missing column contributes NaN in the same column position without warning.
+    """
+    prices = _mixed_prices()
+    original_prices = prices.copy(deep=True)
+    expected_maximum = np.asarray((-0.20, np.nan, -0.50, -0.20, 0.0), dtype=float)
+    expected_current = np.asarray((-0.10, np.nan, -0.25, -0.20, 0.0), dtype=float)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error', RuntimeWarning)
+        maximum_drawdowns, current_drawdowns = compute_max_current_drawdown(prices=prices)
+
+    _assert_array_close(maximum_drawdowns, expected_maximum)
+    _assert_array_close(current_drawdowns, expected_current)
+    pd.testing.assert_frame_equal(prices, original_prices)
+
+
+# =============================================================================
+# Shape consistency
+# =============================================================================
+
+def test_compute_max_current_drawdown_matches_series_and_dataframe_values() -> None:
+    """Keep finite Series and one-column DataFrame values identical across return shapes.
+
+    Prices ``100, 80, 100, 90`` produce running drawdowns ``0%, -20%, 0%, -10%`` directly. The
+    Series contract returns scalar floats and the one-column DataFrame contract returns one-element
+    arrays, but both must report the same -20% maximum and -10% current drawdown.
+    """
+    prices = _mixed_prices()['recovered']
+
+    series_maximum, series_current = compute_max_current_drawdown(prices=prices)
+    frame_maximum, frame_current = compute_max_current_drawdown(prices=prices.to_frame())
+
+    assert isinstance(series_maximum, float)
+    assert isinstance(series_current, float)
+    np.testing.assert_allclose(series_maximum, -0.20, rtol=0.0, atol=_TOLERANCE)
+    np.testing.assert_allclose(series_current, -0.10, rtol=0.0, atol=_TOLERANCE)
+    _assert_array_close(frame_maximum, np.asarray((-0.20,), dtype=float))
+    _assert_array_close(frame_current, np.asarray((-0.10,), dtype=float))


### PR DESCRIPTION
## Summary

- make all-NaN maximum-drawdown reductions warning-free for Series and DataFrame inputs;
- preserve finite, ragged, trailing-missing and constant-history results;
- add deterministic offline regressions with independently calculated maximum/current drawdowns.

## Behavior

`compute_max_current_drawdown()` continues to return `(NaN, NaN)` for an all-missing Series and NaN in the corresponding positions for an all-missing DataFrame column.

The change removes only `RuntimeWarning: All-NaN slice encountered`; calculated values, scalar/array return shapes, column order, caller ownership and empty-input behavior are unchanged. No public signature changes.

## Regression evidence

With `RuntimeWarning` promoted to an error, the new all-NaN Series and mixed-DataFrame tests failed before the correction, while the finite Series/DataFrame consistency test passed.

The mixed frame independently checks:

- recovered: -20% maximum, -10% current;
- all-missing: NaN maximum and current;
- ragged: -50% maximum, -25% current;
- trailing-missing: -20% maximum and current;
- constant: 0% maximum and current.

The implementation calls `np.fmin.reduce()` directly. This is the same reduction NumPy's `np.nanmin()` uses internally before it separately emits the all-NaN warning.

## Verification

- focused PR 8 regressions: 3 passed
- combined accepted PR 7 and PR 8 regressions: 9 passed
- perfstats: 76 passed, no warnings
- full suite: 1492 passed, 16 third-party seaborn/Matplotlib warnings
- Ruff: passed
- Pyright: 0 errors
- `git diff --check`: passed

## Scope

Two files are changed: `compute_max_current_drawdown()` and its focused regression module. No unrelated performance-statistics path is changed.
