### PR TITLE
Use available returns for descriptive positive probabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   adjacent provider histories.
 - Made regime frequencies depend on benchmark-classified dates rather than asset missingness or
   DataFrame column order.
+- Made descriptive-table positive probabilities use each asset's non-missing observations rather
+  than the panel's total row count.
 
 ## [5.12.0] - 2026-08-22
 

--- a/src/qis/perfstats/desc_table.py
+++ b/src/qis/perfstats/desc_table.py
@@ -38,6 +38,27 @@ class DescTableType(Enum):
     WITH_MEDIAN = 9
 
 
+def _compute_positive_probability(data: np.ndarray) -> np.ndarray:
+    """Compute each column's positive share over its observed values.
+
+    Args:
+        data: Two-dimensional numerical observations arranged by row and column.
+
+    Returns:
+        Positive-observation probability for each column, or NaN when a column has no
+        observations.
+    """
+    # Missing returns are absent observations, not non-positive outcomes.
+    observed_counts = np.sum(np.logical_not(np.isnan(data)), axis=0)
+    positive_counts = np.sum(np.greater(data, 0.0), axis=0)
+    return np.divide(
+        positive_counts,
+        observed_counts,
+        out=np.full_like(positive_counts, np.nan, dtype=float),
+        where=np.greater(observed_counts, 0),
+    )
+
+
 def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
                        desc_table_type: DescTableType = DescTableType.SHORT,
                        var_format: str = '{:.2f}',
@@ -53,11 +74,14 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
     Values are returned as formatted strings, not numbers, because this feeds the table
     renderer directly — use the underlying statistic functions if the numbers are wanted.
     Columns may contain nans; statistics are computed on the available observations.
+    Positive probabilities divide positive returns by non-missing observations in each column;
+    zero returns are observed and non-positive.
 
     Args:
         df: returns panel, index is time and columns are tickers; a Series is treated as one
             column named after it
-        desc_table_type: which set of statistics to report
+        desc_table_type: which set of statistics to report; positive-probability modes use each
+            column's non-missing observation count as the denominator
         var_format: format applied to the statistics
         annualize_vol: report volatility per annum rather than per period
         is_add_tstat: add the t-statistic of the mean
@@ -112,13 +136,11 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
         descriptive_table = descriptive_table.drop(PerfStat.AVG.to_str(), axis=1)
         descriptive_table = descriptive_table.drop(PerfStat.STD.to_str(), axis=1)
 
-        positive = np.where(np.greater(data_np, 0.0), 1.0, 0.0)
-        prob = np.sum(positive, axis=0) / data_np.shape[0]
+        prob = _compute_positive_probability(data=data_np)
         descriptive_table[PerfStat.POSITIVE.to_str(short=True, short_n=True)] = ['{:.1%}'.format(x) for x in prob]
 
     elif desc_table_type == desc_table_type.WITH_POSITIVE_PROB:
-        positive = np.where(np.greater(data_np, 0.0), 1.0, 0.0)
-        prob = np.sum(positive, axis=0) / data_np.shape[0]
+        prob = _compute_positive_probability(data=data_np)
         descriptive_table[PerfStat.POSITIVE.to_str(short=True, short_n=True)] = ['{:.1%}'.format(x) for x in prob]
 
     elif desc_table_type == desc_table_type.WITH_KURTOSIS:

--- a/src/qis/perfstats/tests/desc_table_positive_probability_test.py
+++ b/src/qis/perfstats/tests/desc_table_positive_probability_test.py
@@ -1,0 +1,164 @@
+"""Regression coverage for positive probabilities with incomplete return histories.
+
+``compute_desc_table`` documents that statistics use available observations. Positive
+probability must therefore divide each asset's positive-return count by that asset's non-missing
+observation count, rather than by the common number of DataFrame rows. A missing return is an
+absent observation, while a supplied zero return is observed and non-positive.
+
+The deterministic fixtures below calculate those ratios directly and exercise both descriptive
+table modes that report them. Series/DataFrame consistency, output labels and order, custom names,
+and caller ownership are included because the function returns a display-ready string table.
+"""
+
+from typing import Protocol, cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# qis
+import qis.perfstats.desc_table as desc_table_module
+from qis.perfstats.desc_table import DescTableType
+
+
+class _DescTableModuleProtocol(Protocol):
+    """Typed test-side interface for the public function exercised below."""
+
+    def compute_desc_table(
+            self,
+            *,
+            df: pd.DataFrame | pd.Series,
+            desc_table_type: DescTableType) -> pd.DataFrame:
+        """Return a formatted descriptive-statistics table."""
+        raise NotImplementedError
+
+
+_DESC_TABLE_MODULE = cast(_DescTableModuleProtocol, desc_table_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures
+# =============================================================================
+
+_DATES = pd.date_range('2024-01-31', periods=4, freq='ME')
+
+_COMPLETE_ASSET = 'Complete Asset'
+_POSITIVE_COLUMN = 'Positive'
+_RAGGED_ASSET = 'Ragged Asset'
+_SPARSE_POSITIVE_ASSET = 'Sparse Positive Asset'
+
+
+def _mixed_history_returns() -> pd.DataFrame:
+    """Create complete and ragged histories with directly countable signs.
+
+    ``Complete Asset`` has two positive returns among four observations, with a supplied zero
+    remaining in the denominator. ``Ragged Asset`` has one positive return among two observed
+    returns. ``Sparse Positive Asset`` has two positive returns and no other observed return.
+
+    Returns:
+        Four-row return panel in the reporting order used by expected output.
+    """
+    return pd.DataFrame(
+        {
+            _RAGGED_ASSET: (np.nan, 0.02, -0.01, np.nan),
+            _COMPLETE_ASSET: (0.01, -0.02, 0.00, 0.03),
+            _SPARSE_POSITIVE_ASSET: (np.nan, 0.04, 0.05, np.nan),
+        },
+        index=_DATES,
+    )
+
+
+def _expected_positive_probabilities() -> pd.Series:
+    """Return independently calculated display values for the shared panel.
+
+    Returns:
+        Positive-probability strings indexed in the original asset order.
+    """
+    return pd.Series(
+        ('50.0%', '50.0%', '100.0%'),
+        index=(_RAGGED_ASSET, _COMPLETE_ASSET, _SPARSE_POSITIVE_ASSET),
+        name=_POSITIVE_COLUMN,
+    )
+
+
+# =============================================================================
+# Available-observation denominator contract
+# =============================================================================
+
+@pytest.mark.parametrize(
+    ('desc_table_type', 'expected_columns'),
+    (
+        (
+            DescTableType.WITH_POSITIVE_PROB,
+            ('Avg', 'Std', _POSITIVE_COLUMN),
+        ),
+        (
+            DescTableType.AVG_WITH_POSITIVE_PROB,
+            (_POSITIVE_COLUMN,),
+        ),
+    ),
+)
+def test_compute_desc_table_positive_probability_uses_available_observations(
+        desc_table_type: DescTableType,
+        expected_columns: tuple[str, ...]) -> None:
+    """Exclude missing returns from each asset's probability denominator.
+
+    The direct ratios are ``1 / 2`` for the ragged asset, ``2 / 4`` for the complete asset, and
+    ``2 / 2`` for the sparse positive asset. The complete fixture also proves that a supplied zero
+    is observed but not positive. Both public table modes must report the same positive column,
+    retain their established surrounding columns, and leave the input unchanged.
+
+    Args:
+        desc_table_type: Positive-probability table mode under test.
+        expected_columns: Complete expected display-column schema for that mode.
+    """
+    returns = _mixed_history_returns()
+    original_returns = returns.copy(deep=True)
+
+    actual = _DESC_TABLE_MODULE.compute_desc_table(
+        df=returns,
+        desc_table_type=desc_table_type,
+    )
+
+    assert tuple(actual.columns) == expected_columns
+    pd.testing.assert_series_equal(
+        actual[_POSITIVE_COLUMN],
+        _expected_positive_probabilities(),
+    )
+    pd.testing.assert_frame_equal(returns, original_returns)
+
+
+# =============================================================================
+# Series/DataFrame consistency and custom naming
+# =============================================================================
+
+def test_compute_desc_table_positive_probability_preserves_named_series_contract() -> None:
+    """Return the same labeled result for equivalent Series and DataFrame inputs.
+
+    The named Series contains one positive and one negative observed return plus two missing
+    dates, giving an independently calculated probability of 50%. Converting that Series to a
+    one-column DataFrame must not change the display table, and neither input may be modified.
+    """
+    returns = pd.Series(
+        (np.nan, 0.02, -0.01, np.nan),
+        index=_DATES,
+        name='Custom Asset',
+    )
+    returns_frame = returns.to_frame()
+    original_returns = returns.copy(deep=True)
+    original_frame = returns_frame.copy(deep=True)
+
+    series_result = _DESC_TABLE_MODULE.compute_desc_table(
+        df=returns,
+        desc_table_type=DescTableType.WITH_POSITIVE_PROB,
+    )
+    frame_result = _DESC_TABLE_MODULE.compute_desc_table(
+        df=returns_frame,
+        desc_table_type=DescTableType.WITH_POSITIVE_PROB,
+    )
+
+    assert series_result.index.tolist() == ['Custom Asset']
+    assert series_result.at['Custom Asset', _POSITIVE_COLUMN] == '50.0%'
+    pd.testing.assert_frame_equal(series_result, frame_result)
+    pd.testing.assert_series_equal(returns, original_returns)
+    pd.testing.assert_frame_equal(returns_frame, original_frame)

--- a/src/qis/perfstats/tests/desc_table_positive_probability_test.py
+++ b/src/qis/perfstats/tests/desc_table_positive_probability_test.py
@@ -42,6 +42,7 @@ _DESC_TABLE_MODULE = cast(_DescTableModuleProtocol, desc_table_module)
 
 _DATES = pd.date_range('2024-01-31', periods=4, freq='ME')
 
+_ALL_MISSING_ASSET = 'All Missing Asset'
 _COMPLETE_ASSET = 'Complete Asset'
 _POSITIVE_COLUMN = 'Positive'
 _RAGGED_ASSET = 'Ragged Asset'
@@ -54,6 +55,7 @@ def _mixed_history_returns() -> pd.DataFrame:
     ``Complete Asset`` has two positive returns among four observations, with a supplied zero
     remaining in the denominator. ``Ragged Asset`` has one positive return among two observed
     returns. ``Sparse Positive Asset`` has two positive returns and no other observed return.
+    ``All Missing Asset`` has no observations and therefore no positive probability.
 
     Returns:
         Four-row return panel in the reporting order used by expected output.
@@ -63,6 +65,7 @@ def _mixed_history_returns() -> pd.DataFrame:
             _RAGGED_ASSET: (np.nan, 0.02, -0.01, np.nan),
             _COMPLETE_ASSET: (0.01, -0.02, 0.00, 0.03),
             _SPARSE_POSITIVE_ASSET: (np.nan, 0.04, 0.05, np.nan),
+            _ALL_MISSING_ASSET: (np.nan, np.nan, np.nan, np.nan),
         },
         index=_DATES,
     )
@@ -75,8 +78,13 @@ def _expected_positive_probabilities() -> pd.Series:
         Positive-probability strings indexed in the original asset order.
     """
     return pd.Series(
-        ('50.0%', '50.0%', '100.0%'),
-        index=(_RAGGED_ASSET, _COMPLETE_ASSET, _SPARSE_POSITIVE_ASSET),
+        ('50.0%', '50.0%', '100.0%', 'nan%'),
+        index=(
+            _RAGGED_ASSET,
+            _COMPLETE_ASSET,
+            _SPARSE_POSITIVE_ASSET,
+            _ALL_MISSING_ASSET,
+        ),
         name=_POSITIVE_COLUMN,
     )
 
@@ -85,6 +93,8 @@ def _expected_positive_probabilities() -> pd.Series:
 # Available-observation denominator contract
 # =============================================================================
 
+@pytest.mark.filterwarnings('ignore:Mean of empty slice:RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:Degrees of freedom <= 0 for slice:RuntimeWarning')
 @pytest.mark.parametrize(
     ('desc_table_type', 'expected_columns'),
     (
@@ -104,9 +114,11 @@ def test_compute_desc_table_positive_probability_uses_available_observations(
     """Exclude missing returns from each asset's probability denominator.
 
     The direct ratios are ``1 / 2`` for the ragged asset, ``2 / 4`` for the complete asset, and
-    ``2 / 2`` for the sparse positive asset. The complete fixture also proves that a supplied zero
-    is observed but not positive. Both public table modes must report the same positive column,
-    retain their established surrounding columns, and leave the input unchanged.
+    ``2 / 2`` for the sparse positive asset. The all-missing asset has a zero denominator and
+    therefore displays ``nan%``. The complete fixture also proves that a supplied zero is observed
+    but not positive. Both public table modes must report the same positive column, retain their
+    established surrounding columns, and leave the input unchanged. Existing all-missing mean and
+    standard-deviation warnings are outside this probability contract and filtered at test scope.
 
     Args:
         desc_table_type: Positive-probability table mode under test.


### PR DESCRIPTION
## Summary

- computes descriptive-table positive probabilities using each asset’s available observations;
- preserves zero as an observed, non-positive return;
- reports a missing probability when a history has no observations;
- adds deterministic offline Series/DataFrame regression coverage for ragged, complete, sparse, and all-missing histories.

## Behavior

`compute_desc_table()` now excludes missing returns from positive-probability denominators in both `WITH_POSITIVE_PROB` and `AVG_WITH_POSITIVE_PROB`.

Complete histories are unchanged. A column with no observed returns has a missing positive probability. Public signatures, defaults, formats, and exports are unchanged.

## Before/after regression evidence

For `[NaN, 2%, -1%, NaN]`, one of the two observed returns is positive, so the expected probability is `1 / 2 = 50.0%`. The previous implementation divided by all four rows and returned `25.0%`.

The multi-column fixture independently verifies:

- Ragged: `1 / 2 = 50.0%` (previously `25.0%`)
- Complete: `2 / 4 = 50.0%` (unchanged; zero remains observed and non-positive)
- Sparse positive: `2 / 2 = 100.0%` (previously `50.0%`)

The tests failed three times before the fix and all pass afterward.

## Verification

- focused tests: 3 passed
- perfstats tests: 87 passed, no warnings
- full suite: 1507 passed, 16 third-party seaborn/Matplotlib warnings
- Sphinx warnings-as-errors build: passed
- public API check: 409 current names
- dependency check: passed
- independent probability calculation: passed
- Ruff and changed-line lint: passed
- Pyright: 0 errors
- `git diff --check`: passed

## Scope

- one production module, one focused test module, and `CHANGELOG.md`
- no public signature, default, export, or dependency changes
- other descriptive-table and all-missing reduction findings remain separate future PRs
