### PR TITLE
docs: fix two typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ with sns.axes_style("darkgrid"):
 ust_3m_rate = yf.download('^IRX', start="2003-12-31", end=None, ignore_tz=True, auto_adjust=True)['Close'].dropna() / 100.0
 # set parameters for computing performance stats including returns vols and regressions
 perf_params = qis.PerfParams(freq='ME', freq_reg='QE', rates_data=ust_3m_rate)
-# perf_columns is list to display different perfomance metrics from enumeration PerfStat
+# perf_columns is list to display different performance metrics from enumeration PerfStat
 fig = qis.plot_ra_perf_table(prices=prices,
                              perf_columns=[PerfStat.TOTAL_RETURN, PerfStat.PA_RETURN, PerfStat.PA_EXCESS_RETURN,
                                            PerfStat.VOL, PerfStat.SHARPE_RF0,
@@ -235,7 +235,7 @@ fig, _ = qis.plot_ra_perf_table_benchmark(prices=prices,
 ### 2. Multi assets factsheet <a name="multiassets"></a>
 This report is adopted for reporting the risk-adjusted performance 
 of several assets with the goal
-of cross-sectional comparision
+of cross-sectional comparison
 
 Run [`examples/factsheets/multi_assets.py`](examples/factsheets/multi_assets.py).
 


### PR DESCRIPTION
Two typo fixes in `README.md`:

- line 203 — `# perf_columns is list to display different perfomance metrics…` → "performance" (a comment inside an example snippet)
- line 238 — "of cross-sectional comparision" → "comparison"

---

Separately, while checking the docs I noticed a set of links under `docs/` that point at files not present in the repository — flagging rather than fixing, since the right resolution (add the files vs. drop the links) is your call:

- `docs/_included/factsheets.md`, `docs/_included/reporting_frequencies.md`, `docs/_included/frequency_convention_note.md`, `docs/_included/sharpe_conventions.md` — referenced from `factsheets_and_reporting.md`, `gallery.md`, `fx_hedging_and_market_data.md`, `performance_analytics_and_sharpe.md`, `portfolio_backtesting.md`, `private_asset_unsmoothing.md`, `incomplete_and_mixed_frequency_data.md`, and `tracking_error_and_risk.md`. There is no `docs/_included/` directory on `main`.
- `docs/api/index.rst` — referenced as "API reference" from `quickstart.md:74` and `software_design.md:58`. There is no `docs/api/` directory.

Happy to open a follow-up PR for those if you tell me which way you'd like them resolved.
