### PR TITLE
Honor backfill frequency-grid fill policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Aligned time-varying financing rates by date in `lever_returns()` and
   `delever_returns()`, preserving pandas shape and labels and exact zero-leverage identity.
+- Made `bfill_timeseries()` honor return fill policies on expanded frequency grids and support
+  one- and two-observation histories without requiring frequency inference.
 
 ## [5.13.0] - 2026-08-23
 

--- a/src/qis/perfstats/tests/timeseries_bfill_frequency_test.py
+++ b/src/qis/perfstats/tests/timeseries_bfill_frequency_test.py
@@ -319,3 +319,47 @@ def test_bfill_timeseries_forward_fills_price_levels_on_expanded_grid() -> None:
         is_prices=True,
         check_exact=False,
     )
+
+
+def test_bfill_timeseries_carries_off_grid_price_into_requested_grid() -> None:
+    """Carry a weekend price into the first business date of the requested grid.
+
+    Saturday January 6 is outside a business-day index but is the latest available level for
+    Monday January 8. Frequency conversion must therefore use that 100 price rather than create
+    a leading missing value. The Tuesday and Wednesday provider levels remain anchored.
+    """
+    older = pd.Series(
+        [100.0, 110.0],
+        index=pd.DatetimeIndex(["2024-01-06", "2024-01-09"]),
+        name="Older provider",
+    )
+    newer = pd.Series(
+        [110.0, 121.0],
+        index=pd.DatetimeIndex(["2024-01-09", "2024-01-10"]),
+        name=_ASSET_NAME,
+    )
+    original_older = older.copy(deep=True)
+    original_newer = newer.copy(deep=True)
+    expected = pd.Series(
+        [100.0, 110.0, 121.0],
+        index=pd.bdate_range("2024-01-08", "2024-01-10"),
+        name=_ASSET_NAME,
+    )
+
+    actual = bfill_timeseries(
+        df_newer=newer,
+        df_older=older,
+        freq="B",
+        is_prices=True,
+    )
+
+    assert isinstance(actual, pd.Series)
+    pd.testing.assert_series_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    pd.testing.assert_series_equal(older, original_older, check_exact=True)
+    pd.testing.assert_series_equal(newer, original_newer, check_exact=True)

--- a/src/qis/perfstats/tests/timeseries_bfill_frequency_test.py
+++ b/src/qis/perfstats/tests/timeseries_bfill_frequency_test.py
@@ -1,0 +1,321 @@
+"""Regression tests for ``bfill_timeseries`` frequency-grid semantics.
+
+Return gaps have different meanings under the three supported fill policies. ``None`` preserves
+missing returns, ``to_zero`` treats a missing return as no change after that asset begins, and
+``ffill`` explicitly repeats the last observed return. Price levels retain their established
+forward-fill convention because an unreported level remains at its last observation.
+
+The fixtures use literal expected grids rather than a QIS resampling helper. They also cover the
+one- and two-observation boundaries where pandas cannot infer a frequency, ragged DataFrame
+starts, Series/DataFrame consistency, labels, column order, and caller ownership.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.perfstats.timeseries_bfill import bfill_timeseries
+
+
+# =============================================================================
+# Shared deterministic timeline and comparison helper
+# =============================================================================
+
+_DAILY_DATES = pd.date_range("2024-01-01", periods=7, freq="D")
+_ASSET_NAME = "Asset A"
+_TOLERANCE = 1.0e-12
+
+
+def _assert_series_and_frame_results(
+        older: pd.Series,
+        newer: pd.Series,
+        expected: pd.Series,
+        fill_method: str | None = None,
+        is_prices: bool = False,
+        check_exact: bool = True,
+) -> None:
+    """Exercise equivalent Series and one-column DataFrame inputs.
+
+    Args:
+        older: Older provider history.
+        newer: Newer provider history whose name defines the output label.
+        expected: Independently constructed expected result.
+        fill_method: Missing-return policy passed to ``bfill_timeseries``.
+        is_prices: Whether inputs and expected values are price levels.
+        check_exact: Whether pandas comparisons require bitwise-equal values.
+    """
+    original_older = older.copy(deep=True)
+    original_newer = newer.copy(deep=True)
+    newer_frame = newer.to_frame()
+    older_frame = older.to_frame()
+    older_frame.columns = newer_frame.columns.copy()
+    original_older_frame = older_frame.copy(deep=True)
+    original_newer_frame = newer_frame.copy(deep=True)
+
+    series_result = bfill_timeseries(
+        df_newer=newer,
+        df_older=older,
+        freq="D",
+        fill_method=fill_method,
+        is_prices=is_prices,
+    )
+    frame_result = bfill_timeseries(
+        df_newer=newer_frame,
+        df_older=older_frame,
+        freq="D",
+        fill_method=fill_method,
+        is_prices=is_prices,
+    )
+
+    assert isinstance(series_result, pd.Series)
+    assert isinstance(frame_result, pd.DataFrame)
+    pd.testing.assert_series_equal(
+        series_result,
+        expected,
+        check_exact=check_exact,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    pd.testing.assert_frame_equal(
+        frame_result,
+        expected.to_frame(),
+        check_exact=check_exact,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    pd.testing.assert_series_equal(older, original_older, check_exact=True)
+    pd.testing.assert_series_equal(newer, original_newer, check_exact=True)
+    pd.testing.assert_frame_equal(older_frame, original_older_frame, check_exact=True)
+    pd.testing.assert_frame_equal(newer_frame, original_newer_frame, check_exact=True)
+
+
+# =============================================================================
+# Short-history frequency boundaries
+# =============================================================================
+
+@pytest.mark.parametrize("fill_method", [None, "to_zero", "ffill"])
+def test_bfill_timeseries_preserves_single_return_observation(
+        fill_method: str | None,
+) -> None:
+    """Return one observation without requiring an inferable frequency."""
+    older = pd.Series([0.10], index=_DAILY_DATES[[0]], name="Older provider")
+    newer = pd.Series([0.20], index=_DAILY_DATES[[0]], name=_ASSET_NAME)
+    expected = pd.Series([0.20], index=_DAILY_DATES[:1], name=_ASSET_NAME)
+
+    _assert_series_and_frame_results(
+        older=older,
+        newer=newer,
+        expected=expected,
+        fill_method=fill_method,
+    )
+
+
+@pytest.mark.parametrize(
+    ("fill_method", "inserted_return"),
+    [
+        (None, np.nan),
+        ("to_zero", 0.00),
+        ("ffill", 0.10),
+    ],
+)
+def test_bfill_timeseries_applies_fill_policy_to_two_observation_return_grid(
+        fill_method: str | None,
+        inserted_return: float,
+) -> None:
+    """Expand two observations without calling pandas frequency inference.
+
+    January 2 is absent from the supplied histories. Its independently expected return is
+    missing, zero, or the January 1 return according to the selected valid fill policy.
+    """
+    older = pd.Series([0.10], index=_DAILY_DATES[[0]], name="Older provider")
+    newer = pd.Series([0.20], index=_DAILY_DATES[[2]], name=_ASSET_NAME)
+    expected = pd.Series(
+        [0.10, inserted_return, 0.20],
+        index=_DAILY_DATES[:3],
+        name=_ASSET_NAME,
+    )
+
+    _assert_series_and_frame_results(
+        older=older,
+        newer=newer,
+        expected=expected,
+        fill_method=fill_method,
+    )
+
+
+# =============================================================================
+# Return-grid fill policies
+# =============================================================================
+
+@pytest.mark.parametrize(
+    ("fill_method", "expected_values"),
+    [
+        (None, (0.10, np.nan, 0.20, np.nan, 0.30)),
+        ("to_zero", (0.10, 0.00, 0.20, 0.00, 0.30)),
+        ("ffill", (0.10, 0.10, 0.20, 0.20, 0.30)),
+    ],
+)
+def test_bfill_timeseries_applies_fill_policy_to_gapped_return_grid(
+        fill_method: str | None,
+        expected_values: tuple[float, ...],
+) -> None:
+    """Give each valid fill policy distinct values on dates inserted into the grid."""
+    older = pd.Series(
+        [0.10, 0.20],
+        index=_DAILY_DATES[[0, 2]],
+        name="Older provider",
+    )
+    newer = pd.Series([0.30], index=_DAILY_DATES[[4]], name=_ASSET_NAME)
+    expected = pd.Series(
+        expected_values,
+        index=_DAILY_DATES[:5],
+        name=_ASSET_NAME,
+    )
+
+    _assert_series_and_frame_results(
+        older=older,
+        newer=newer,
+        expected=expected,
+        fill_method=fill_method,
+    )
+
+
+def test_bfill_timeseries_none_preserves_existing_and_inserted_missing_returns() -> None:
+    """Keep both a supplied return gap and a newly inserted grid date missing."""
+    older = pd.Series(
+        [0.10, np.nan, 0.20],
+        index=_DAILY_DATES[:3],
+        name="Older provider",
+    )
+    newer = pd.Series([0.30], index=_DAILY_DATES[[4]], name=_ASSET_NAME)
+    expected = pd.Series(
+        [0.10, np.nan, 0.20, np.nan, 0.30],
+        index=_DAILY_DATES[:5],
+        name=_ASSET_NAME,
+    )
+
+    _assert_series_and_frame_results(
+        older=older,
+        newer=newer,
+        expected=expected,
+        fill_method=None,
+    )
+
+
+def test_bfill_timeseries_to_zero_preserves_dataframe_ragged_starts() -> None:
+    """Fill inserted returns only after each DataFrame column begins.
+
+    Asset B has no history before January 3, so January 1-2 remain missing. Thereafter the
+    inserted January 4 return is zero. Asset A begins on January 1 and receives zeros on both
+    inserted dates. Reversed newer columns also pin the output-order contract.
+    """
+    older = pd.DataFrame(
+        {
+            "Asset A": [0.10, 0.20],
+            "Asset B": [np.nan, 0.40],
+        },
+        index=_DAILY_DATES[[0, 2]],
+    )
+    newer = pd.DataFrame(
+        {
+            "Asset B": [0.50],
+            "Asset A": [0.30],
+        },
+        index=_DAILY_DATES[[4]],
+    )
+    original_older = older.copy(deep=True)
+    original_newer = newer.copy(deep=True)
+    expected = pd.DataFrame(
+        {
+            "Asset B": [np.nan, np.nan, 0.40, 0.00, 0.50],
+            "Asset A": [0.10, 0.00, 0.20, 0.00, 0.30],
+        },
+        index=_DAILY_DATES[:5],
+    )
+
+    actual = bfill_timeseries(
+        df_newer=newer,
+        df_older=older,
+        freq="D",
+        fill_method="to_zero",
+    )
+
+    assert isinstance(actual, pd.DataFrame)
+    pd.testing.assert_frame_equal(actual, expected, check_exact=True)
+    pd.testing.assert_frame_equal(older, original_older, check_exact=True)
+    pd.testing.assert_frame_equal(newer, original_newer, check_exact=True)
+
+
+def test_bfill_timeseries_to_zero_preserves_all_missing_column() -> None:
+    """Leave a column missing when it has no observation from either provider.
+
+    The ``to_zero`` policy begins only after a column's first observed return. Asset B therefore
+    remains missing across the expanded grid rather than acquiring a zero on its final date.
+    """
+    older = pd.DataFrame(
+        {
+            "Asset A": [0.10, 0.20],
+            "Asset B": [np.nan, np.nan],
+        },
+        index=_DAILY_DATES[[0, 2]],
+    )
+    newer = pd.DataFrame(
+        {
+            "Asset A": [0.30],
+            "Asset B": [np.nan],
+        },
+        index=_DAILY_DATES[[4]],
+    )
+    expected = pd.DataFrame(
+        {
+            "Asset A": [0.10, 0.00, 0.20, 0.00, 0.30],
+            "Asset B": [np.nan, np.nan, np.nan, np.nan, np.nan],
+        },
+        index=_DAILY_DATES[:5],
+    )
+
+    actual = bfill_timeseries(
+        df_newer=newer,
+        df_older=older,
+        freq="D",
+        fill_method="to_zero",
+    )
+
+    assert isinstance(actual, pd.DataFrame)
+    pd.testing.assert_frame_equal(actual, expected, check_exact=True)
+
+
+# =============================================================================
+# Existing price-level convention
+# =============================================================================
+
+def test_bfill_timeseries_forward_fills_price_levels_on_expanded_grid() -> None:
+    """Preserve price levels between observations when expanding their date grid.
+
+    The supplied prices rise by 10% at every observation. Missing calendar dates retain the
+    preceding level, while the newer provider's overlapping January 5 level and January 7 level
+    remain anchored at 121 and 133.1.
+    """
+    older = pd.Series(
+        [100.0, 110.0, 121.0],
+        index=_DAILY_DATES[[0, 2, 4]],
+        name="Older provider",
+    )
+    newer = pd.Series(
+        [121.0, 133.1],
+        index=_DAILY_DATES[[4, 6]],
+        name=_ASSET_NAME,
+    )
+    expected = pd.Series(
+        [100.0, 100.0, 110.0, 110.0, 121.0, 121.0, 133.1],
+        index=_DAILY_DATES,
+        name=_ASSET_NAME,
+    )
+
+    _assert_series_and_frame_results(
+        older=older,
+        newer=newer,
+        expected=expected,
+        is_prices=True,
+        check_exact=False,
+    )

--- a/src/qis/perfstats/timeseries_bfill.py
+++ b/src/qis/perfstats/timeseries_bfill.py
@@ -214,10 +214,11 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
     # Short splices have no inferable frequency but can still be expanded safely.
     inferred_freq = pd.infer_freq(bfill_datas.index) if len(bfill_datas.index) >= 3 else None
     if inferred_freq != freq:
-        bfill_datas = bfill_datas.asfreq(freq)
         if is_prices:
-            # Preserve price levels on dates introduced by the expanded grid.
-            bfill_datas = bfill_datas.ffill()
+            # Carry the latest source price even when its date is outside the target grid.
+            bfill_datas = bfill_datas.asfreq(freq, method='ffill').ffill()
+        else:
+            bfill_datas = bfill_datas.asfreq(freq)
 
     if fill_method is not None and is_prices is False:
         # Apply return policies after expansion so inserted dates follow the selected convention.

--- a/src/qis/perfstats/timeseries_bfill.py
+++ b/src/qis/perfstats/timeseries_bfill.py
@@ -122,12 +122,28 @@ def interpolate_infrequent_returns(infrequent_returns: Union[pd.Series, pd.DataF
 def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent data
                      df_older: Union[pd.DataFrame, pd.Series],  # older price is preserved to the end
                      freq: str = 'B',
-                     fill_method: Optional[str] = None,  # for return use to_zero, else ffill
+                     fill_method: Optional[str] = None,  # None, 'to_zero', or 'ffill' for returns
                      is_prices: bool = False
                      ) -> Union[pd.DataFrame, pd.Series]:
-    """
-    append column-wise older df data to df new data
-    nb output columns are always data_newer columns
+    """Extend newer time series backward with older provider histories.
+
+    Args:
+        df_newer: Newer Series or DataFrame whose labels and columns define the output.
+        df_older: Older object of the same pandas type, used before each newer history begins.
+        freq: Frequency of the returned date grid.
+        fill_method: Return-gap policy. ``None`` preserves missing returns, ``'to_zero'`` fills
+            missing returns with zero after each column begins, and ``'ffill'`` carries its last
+            observed return forward. For price inputs, the policy is applied in return space.
+        is_prices: Whether the supplied data are price levels. Expanded price grids carry the
+            last observed level forward.
+
+    Returns:
+        Backfilled data on the requested grid, matching the newer input's pandas type, labels,
+        and column order.
+
+    Raises:
+        NotImplementedError: If the newer and older inputs are not both Series or both
+            DataFrames.
     """
     is_series_out = False
     if isinstance(df_newer, pd.Series) and isinstance(df_older, pd.Series):
@@ -179,7 +195,8 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
         if bfill_data.index.is_unique is False:  # check if index is unique
             bfill_data = bfill_data.iloc[bfill_data.index.duplicated(keep='last') == False]
 
-        if fill_method is not None:
+        # Price gaps must be resolved in return space before levels are reconstructed.
+        if fill_method is not None and is_prices:
             start = dfo.get_nonnan_index(bfill_data)
             if fill_method == 'to_zero':
                 bfill_data[start:] = bfill_data[start:].fillna(value=0.0)
@@ -194,8 +211,25 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
                                          init_period=None,
                                          terminal_value=terminal_value)
 
-    if pd.infer_freq(bfill_datas.index) != freq:
-        bfill_datas = bfill_datas.asfreq(freq, method='ffill').ffill()
+    # Short splices have no inferable frequency but can still be expanded safely.
+    inferred_freq = pd.infer_freq(bfill_datas.index) if len(bfill_datas.index) >= 3 else None
+    if inferred_freq != freq:
+        bfill_datas = bfill_datas.asfreq(freq)
+        if is_prices:
+            # Preserve price levels on dates introduced by the expanded grid.
+            bfill_datas = bfill_datas.ffill()
+
+    if fill_method is not None and is_prices is False:
+        # Apply return policies after expansion so inserted dates follow the selected convention.
+        for column in bfill_datas:
+            # An all-missing column has no observation from which its fill policy can begin.
+            if not bfill_datas[column].notna().any():
+                continue
+            start = dfo.get_nonnan_index(bfill_datas[column])
+            if fill_method == 'to_zero':
+                bfill_datas.loc[start:, column] = bfill_datas.loc[start:, column].fillna(0.0)
+            else:
+                bfill_datas.loc[start:, column] = bfill_datas.loc[start:, column].ffill()
 
     if is_series_out:
         bfill_datas = bfill_datas.iloc[:, 0]


### PR DESCRIPTION
## Summary

Correct `bfill_timeseries()` frequency expansion so return gaps follow the selected fill policy,
and allow one- and two-observation histories without requiring pandas frequency inference.
Add deterministic, offline Series and DataFrame regressions, update the public docstring, and
record the numerical correction under `CHANGELOG.md` → `Unreleased`.

## Behavior

This changes numerical behavior on expanded return grids:

- `fill_method=None` preserves existing and inserted missing returns;
- `fill_method='to_zero'` fills missing returns with zero only after each column starts;
- `fill_method='ffill'` carries the last observed return only after each column starts; and
- one- and two-observation results no longer raise through `pd.infer_freq()`.

Ragged leading histories and entirely all-missing columns remain missing. The established
forward-filled price-level convention is unchanged, as are Series/DataFrame labels, column order,
and caller-input ownership. No signature, default, export, or dependency changes.

## Regression evidence

Against unchanged accepted production code, the initial focused set had 10 failures and 2 passing
controls: one- and two-observation histories raised `ValueError`, while `None` and `to_zero`
incorrectly repeated nonzero returns. The added all-missing traceability assertion also failed
because its final missing value became zero.

For observations on January 1, 3, and 5, the corrected results match independently constructed
expectations:

- `None`: `[10%, NaN, 20%, NaN, 30%]`
- `to_zero`: `[10%, 0%, 20%, 0%, 30%]`
- `ffill`: `[10%, 10%, 20%, 20%, 30%]`

## Verification

- existing and new backfill tests: 16 passed
- perfstats: 112 passed
- full suite: 1528 passed, 16 third-party Seaborn/Matplotlib warnings
- independent return-grid and ragged-start calculations: passed
- changed-line Ruff: 0 violations
- new test Pyright: 0 errors
- public API synchronization: passed; 406 names current
- dependency and whitespace checks: passed

The Sphinx `-W` build completed with 11 unrelated accepted-main warnings: five unavailable online
intersphinx inventories plus three stale removed-OHLC imports and their three generated pages.
None referenced this change.

## Scope

- three files: one production function, one deterministic test module, and `CHANGELOG.md`
- invalid `fill_method` validation remains the separate PR 27 investigation
- unsorted input handling and absent older price columns remain separate PRs 16 and 17
