### PR TITLE
Preserve missing benchmark sign regimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved missing benchmark observations in positive/negative regime classification instead of
+  assigning them to the positive regime.
+
 ## [5.14.0] - 2026-08-24
 
 ### Added

--- a/src/qis/perfstats/regime_classifier.py
+++ b/src/qis/perfstats/regime_classifier.py
@@ -614,11 +614,18 @@ class BenchmarkReturnsPositiveNegativeRegime(RegimeClassifier):
         regime_ids = self.get_regime_ids()
 
         # A missing benchmark return has no sign and must not enter either frequency bucket.
+        observed = benchmark_returns.notna()
         regime_classification = pd.Series(
-            np.where(benchmark_returns < 0, regime_ids[0], regime_ids[1]),
+            np.nan,
             index=benchmark_returns.index,
-            name=self.REGIME_COLUMN
-        ).mask(benchmark_returns.isna())
+            name=self.REGIME_COLUMN,
+            dtype=object,
+        )
+        regime_classification.loc[observed] = np.where(
+            benchmark_returns.loc[observed] < 0,
+            regime_ids[0],
+            regime_ids[1],
+        )
 
         sampled_returns_with_regime_id[self.REGIME_COLUMN] = regime_classification
 

--- a/src/qis/perfstats/regime_classifier.py
+++ b/src/qis/perfstats/regime_classifier.py
@@ -550,7 +550,7 @@ class BenchmarkReturnsPositiveNegativeRegime(RegimeClassifier):
     """Regime classifier based on positive vs negative benchmark returns.
 
     Classifies periods into two simple regimes based on benchmark return sign,
-    useful for up/down market analysis.
+    useful for up/down market analysis. Missing benchmark returns remain unclassified.
     """
 
     def __init__(self,
@@ -587,7 +587,8 @@ class BenchmarkReturnsPositiveNegativeRegime(RegimeClassifier):
             include_end_date: Include last period
 
         Returns:
-            DataFrame with returns and regime classification
+            DataFrame with returns and regime classification. Missing benchmark returns have a
+            missing regime ID.
 
         Raises:
             ValueError: If insufficient data for classification
@@ -609,14 +610,15 @@ class BenchmarkReturnsPositiveNegativeRegime(RegimeClassifier):
                 f"Decrease regime frequency"
             )
 
-        benchmark_returns = sampled_returns_with_regime_id[benchmark]
+        benchmark_returns = cast(pd.Series, sampled_returns_with_regime_id[benchmark])
         regime_ids = self.get_regime_ids()
 
+        # A missing benchmark return has no sign and must not enter either frequency bucket.
         regime_classification = pd.Series(
             np.where(benchmark_returns < 0, regime_ids[0], regime_ids[1]),
             index=benchmark_returns.index,
             name=self.REGIME_COLUMN
-        )
+        ).mask(benchmark_returns.isna())
 
         sampled_returns_with_regime_id[self.REGIME_COLUMN] = regime_classification
 

--- a/src/qis/perfstats/tests/regime_sign_missing_test.py
+++ b/src/qis/perfstats/tests/regime_sign_missing_test.py
@@ -259,3 +259,30 @@ def test_positive_negative_regime_preserves_series_shape_name_and_input() -> Non
     pd.testing.assert_frame_equal(series_result, frame_result)
     pd.testing.assert_series_equal(benchmark, original_benchmark, check_exact=True)
     pd.testing.assert_frame_equal(benchmark_frame, original_frame, check_exact=True)
+
+
+def test_positive_negative_regime_supports_nullable_benchmark_missing_values() -> None:
+    """Classify observed nullable returns without evaluating ``pd.NA`` as a boolean."""
+    benchmark = pd.Series(
+        _BENCHMARK_PRICES,
+        index=_DATES,
+        name=_BENCHMARK_NAME,
+        dtype="Float64",
+    )
+    original_benchmark = benchmark.copy(deep=True)
+    expected_regimes = pd.Series(
+        (np.nan, np.nan, "Negative", np.nan, np.nan, "Positive", "Positive"),
+        index=_DATES,
+        name=_REGIME_COLUMN,
+        dtype=object,
+    )
+
+    actual = _classifier().compute_sampled_returns_with_regime_id(
+        prices=benchmark,
+        benchmark=_BENCHMARK_NAME,
+        include_start_date=True,
+        include_end_date=True,
+    )
+
+    pd.testing.assert_series_equal(actual[_REGIME_COLUMN], expected_regimes)
+    pd.testing.assert_series_equal(benchmark, original_benchmark, check_exact=True)

--- a/src/qis/perfstats/tests/regime_sign_missing_test.py
+++ b/src/qis/perfstats/tests/regime_sign_missing_test.py
@@ -1,0 +1,261 @@
+"""Regression tests for missing benchmark returns in sign-based regimes.
+
+``BenchmarkReturnsPositiveNegativeRegime`` partitions dates by the sign of the benchmark return:
+finite negative returns are ``Negative``, while zero and finite positive returns are ``Positive``.
+A missing return has no sign and therefore must retain a missing regime ID rather than entering
+either bucket.
+
+The deterministic daily fixture contains leading and interior missing benchmark prices. Direct
+adjacent-price arithmetic produces four missing returns, one negative return, one positive return,
+and one zero return. Expected values are constructed without another QIS return or classification
+path, and the tests also pin shared regime frequencies, Series/DataFrame consistency, labels,
+column order, and caller ownership.
+"""
+
+from typing import Protocol, cast
+
+import numpy as np
+import pandas as pd
+
+from qis.perfstats.regime_classifier import (
+    BenchmarkReturnsPositiveNegativeRegime,
+    compute_mean_freq_regimes,
+)
+
+
+# =============================================================================
+# Shared deterministic fixture and independent reference
+# =============================================================================
+
+_DATES = pd.date_range("2024-01-01", periods=7, freq="D")
+
+_ASSET_NAME = "Strategy"
+_BENCHMARK_NAME = "Reference Index"
+_REGIME_COLUMN = "regime"
+
+_ASSET_PRICES = (50.0, 51.0, 52.0, 53.0, 54.0, 55.0, 56.0)
+_BENCHMARK_PRICES = (np.nan, 100.0, 90.0, np.nan, 99.0, 108.9, 108.9)
+
+_TOLERANCE = 1.0e-12
+
+
+class _SignClassifierProtocol(Protocol):
+    """Typed test-side interface for the public classifier method."""
+
+    def compute_sampled_returns_with_regime_id(
+            self,
+            *,
+            prices: pd.DataFrame | pd.Series,
+            benchmark: str,
+            include_start_date: bool,
+            include_end_date: bool,
+    ) -> pd.DataFrame:
+        """Return classified daily returns for the supplied prices."""
+        raise NotImplementedError
+
+
+def _price_panel() -> pd.DataFrame:
+    """Create the daily two-column price panel used by the regression.
+
+    Returns:
+        Price panel with a complete asset and a benchmark containing leading and interior gaps.
+    """
+    return pd.DataFrame(
+        {
+            _ASSET_NAME: _ASSET_PRICES,
+            _BENCHMARK_NAME: _BENCHMARK_PRICES,
+        },
+        index=_DATES,
+    )
+
+
+def _expected_classified_returns() -> pd.DataFrame:
+    """Construct expected returns and regimes directly from adjacent prices.
+
+    The interior missing benchmark price makes both adjacent return intervals undefined. The
+    remaining finite benchmark returns are ``90 / 100 - 1 = -10%``,
+    ``108.9 / 99 - 1 = 10%``, and ``108.9 / 108.9 - 1 = 0%``.
+
+    Returns:
+        Independently calculated return panel with the expected sign-regime column.
+    """
+    return pd.DataFrame(
+        {
+            _ASSET_NAME: (
+                np.nan,
+                51.0 / 50.0 - 1.0,
+                52.0 / 51.0 - 1.0,
+                53.0 / 52.0 - 1.0,
+                54.0 / 53.0 - 1.0,
+                55.0 / 54.0 - 1.0,
+                56.0 / 55.0 - 1.0,
+            ),
+            _BENCHMARK_NAME: (
+                np.nan,
+                np.nan,
+                90.0 / 100.0 - 1.0,
+                np.nan,
+                np.nan,
+                108.9 / 99.0 - 1.0,
+                108.9 / 108.9 - 1.0,
+            ),
+            _REGIME_COLUMN: (
+                np.nan,
+                np.nan,
+                "Negative",
+                np.nan,
+                np.nan,
+                "Positive",
+                "Positive",
+            ),
+        },
+        index=_DATES,
+    )
+
+
+def _classifier(regime_ids_colors: dict[str, str] | None = None) -> _SignClassifierProtocol:
+    """Create the daily sign classifier behind a fully typed test interface.
+
+    Args:
+        regime_ids_colors: Optional ordered custom regime-name and color mapping.
+
+    Returns:
+        Daily positive/negative benchmark-return classifier.
+    """
+    if regime_ids_colors is None:
+        classifier = BenchmarkReturnsPositiveNegativeRegime(freq="D")
+    else:
+        classifier = BenchmarkReturnsPositiveNegativeRegime(
+            freq="D",
+            regime_ids_colors=regime_ids_colors,
+        )
+    return cast(_SignClassifierProtocol, classifier)
+
+
+# =============================================================================
+# Missing-regime classification and shared frequencies
+# =============================================================================
+
+def test_positive_negative_regime_preserves_missing_benchmark_returns() -> None:
+    """Leave missing benchmark returns unclassified and exclude them from frequencies.
+
+    Four of seven benchmark returns are missing and therefore have no sign. Of the three
+    classified dates, one is negative and two are nonnegative, so the independently counted
+    frequencies are exactly ``Negative = 1/3`` and ``Positive = 2/3``. The complete output,
+    including asset returns, labels, column order, and the caller-owned input, is asserted.
+    """
+    prices = _price_panel()
+    original_prices = prices.copy(deep=True)
+    expected = _expected_classified_returns()
+    expected_frequencies = pd.Series(
+        (1.0 / 3.0, 2.0 / 3.0),
+        index=pd.Index(("Negative", "Positive"), name=_REGIME_COLUMN),
+    )
+
+    actual = _classifier().compute_sampled_returns_with_regime_id(
+        prices=prices,
+        benchmark=_BENCHMARK_NAME,
+        include_start_date=True,
+        include_end_date=True,
+    )
+    _, actual_frequencies = compute_mean_freq_regimes(actual)
+
+    pd.testing.assert_frame_equal(
+        actual,
+        expected,
+        check_dtype=False,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    pd.testing.assert_series_equal(
+        actual_frequencies,
+        expected_frequencies,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    pd.testing.assert_frame_equal(prices, original_prices, check_exact=True)
+
+
+def test_positive_negative_regime_preserves_custom_names_and_missing_mask() -> None:
+    """Apply custom sign labels without assigning missing returns to either regime.
+
+    Custom IDs must replace the finite default labels in their supplied order while the four
+    independently identified missing benchmark returns remain unclassified. The complete return
+    panel and caller-owned prices are asserted so custom metadata cannot alter numerical values.
+    """
+    prices = _price_panel()
+    original_prices = prices.copy(deep=True)
+    expected = _expected_classified_returns()
+    expected[_REGIME_COLUMN] = (
+        np.nan,
+        np.nan,
+        "Down",
+        np.nan,
+        np.nan,
+        "Up",
+        "Up",
+    )
+
+    actual = _classifier(
+        regime_ids_colors={"Down": "salmon", "Up": "darkgreen"},
+    ).compute_sampled_returns_with_regime_id(
+        prices=prices,
+        benchmark=_BENCHMARK_NAME,
+        include_start_date=True,
+        include_end_date=True,
+    )
+
+    pd.testing.assert_frame_equal(
+        actual,
+        expected,
+        check_dtype=False,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    pd.testing.assert_frame_equal(prices, original_prices, check_exact=True)
+
+
+# =============================================================================
+# Series and DataFrame consistency
+# =============================================================================
+
+def test_positive_negative_regime_preserves_series_shape_name_and_input() -> None:
+    """Match one-column DataFrame behavior for a named benchmark Series.
+
+    The Series path must return the benchmark and regime columns on the original daily index,
+    preserve every missing regime from the independent reference, and leave both equivalent
+    caller inputs unchanged.
+    """
+    benchmark = _price_panel()[_BENCHMARK_NAME]
+    benchmark_frame = benchmark.to_frame()
+    original_benchmark = benchmark.copy(deep=True)
+    original_frame = benchmark_frame.copy(deep=True)
+    expected = _expected_classified_returns().loc[:, [_BENCHMARK_NAME, _REGIME_COLUMN]]
+
+    series_result = _classifier().compute_sampled_returns_with_regime_id(
+        prices=benchmark,
+        benchmark=_BENCHMARK_NAME,
+        include_start_date=True,
+        include_end_date=True,
+    )
+    frame_result = _classifier().compute_sampled_returns_with_regime_id(
+        prices=benchmark_frame,
+        benchmark=_BENCHMARK_NAME,
+        include_start_date=True,
+        include_end_date=True,
+    )
+
+    pd.testing.assert_frame_equal(
+        series_result,
+        expected,
+        check_dtype=False,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    pd.testing.assert_frame_equal(series_result, frame_result)
+    pd.testing.assert_series_equal(benchmark, original_benchmark, check_exact=True)
+    pd.testing.assert_frame_equal(benchmark_frame, original_frame, check_exact=True)


### PR DESCRIPTION

## Summary

Preserve missing benchmark observations in positive/negative regime classification instead of assigning them to the positive regime.

This change:

- leaves missing benchmark returns unclassified;
- excludes those dates from sign-regime frequency denominators;
- preserves custom regime names and caller-owned inputs; and
- documents the correction under `CHANGELOG.md` → `Unreleased`.

## Behavior

Finite negative benchmark returns remain `Negative`. Zero and finite positive returns remain `Positive`. A missing benchmark return now receives a missing regime ID because it has no sign.

Custom ordered mappings behave consistently. For example, `Down` and `Up` replace the default finite labels while missing returns remain unclassified.

No public signature, return calculation, sampling convention, or finite sign boundary changes.

## Regression evidence

The deterministic daily benchmark prices are:

`[NaN, 100.0, 90.0, NaN, 99.0, 108.9, 108.9]`

Direct adjacent-price arithmetic gives:

- benchmark returns: `[NaN, NaN, -10%, NaN, NaN, +10%, 0%]`
- expected regimes: `[NaN, NaN, Negative, NaN, NaN, Positive, Positive]`

Before the fix, all four missing returns were classified as `Positive`. The focused regressions produced two failures, and regime frequencies were incorrectly calculated as:

- `Negative = 1/7`
- `Positive = 6/7`

Excluding unclassified dates gives the independently counted expectations:

- `Negative = 1/3`
- `Positive = 2/3`

The custom-name regression was also proven against the original defect: it failed on four of seven missing-mask positions and passed after restoring the fix.

Coverage includes:

- leading and interior missing benchmark prices;
- negative, zero, and positive boundaries;
- exact returns and regime placement;
- shared regime frequencies;
- Series/DataFrame consistency;
- custom `Down`/`Up` labels;
- complete-asset/missing-benchmark mixed panels;
- index and column preservation; and
- caller-owned input preservation.

## Verification

- Focused PR 19 regressions: 3 passed
- PR 18, PR 19, and adjacent regime regressions: 15 passed
- Perfstats suite: 133 passed
- Full suite: passed; 1,566 tests collected
- Full-suite warnings: 16 accepted third-party Seaborn/Matplotlib warnings
- Changed-line Ruff: 0 violations
- New test Pyright: 0 errors
- Changed production block: no Pyright diagnostics
- Public API synchronization: passed; 406 names current
- Dependency check: passed
- `git diff --check`: passed
- Changed documentation: rendered without related warnings

The strict documentation build remains nonzero for the same 11 unrelated baseline/environment warnings.

## Scope

The PR changes only:

- `CHANGELOG.md`
- `src/qis/perfstats/regime_classifier.py`
- `src/qis/perfstats/tests/regime_sign_missing_test.py`

It does not change return conversion, make the regime output categorical for unobserved sign categories, or add mapping-cardinality validation.