### PR TITLE
Support annualized reduced descriptive tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Made annualized `AVG_WITH_POSITIVE_PROB` and `SKEW_KURTOSIS` descriptive tables return their
+  reduced schemas instead of raising while removing the volatility column.
+
 ## [5.15.0] - 2026-08-24
 
 ### Fixed

--- a/src/qis/perfstats/desc_table.py
+++ b/src/qis/perfstats/desc_table.py
@@ -83,7 +83,8 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
         desc_table_type: which set of statistics to report; positive-probability modes use each
             column's non-missing observation count as the denominator
         var_format: format applied to the statistics
-        annualize_vol: report volatility per annum rather than per period
+        annualize_vol: report volatility per annum rather than per period; reduced modes omit
+            the volatility column selected by this convention
         is_add_tstat: add the t-statistic of the mean
         norm_variable_display_type: format applied to the t-statistic
 
@@ -110,11 +111,13 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
     if annualize_vol:
         an_factor = infer_annualisation_factor_from_df(data=df)
         vol = std * np.sqrt(an_factor)
-        descriptive_table[PerfStat.STD_AN.to_str()] = [var_format.format(x) for x in vol]
+        volatility_column = PerfStat.STD_AN.value.name
     else:
         an_factor = 1.0
         vol = std
-        descriptive_table[PerfStat.STD.to_str()] = [var_format.format(x) for x in std]
+        volatility_column = PerfStat.STD.value.name
+    # Keep the selected label so reduced modes remove the column they actually created.
+    descriptive_table[volatility_column] = [var_format.format(x) for x in vol]
 
     if is_add_tstat:
         an_mean = an_factor * mean
@@ -133,8 +136,9 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
         pass
 
     elif desc_table_type == desc_table_type.AVG_WITH_POSITIVE_PROB:
-        descriptive_table = descriptive_table.drop(PerfStat.AVG.to_str(), axis=1)
-        descriptive_table = descriptive_table.drop(PerfStat.STD.to_str(), axis=1)
+        # Remove the setup columns before reporting the reduced positive-only schema.
+        descriptive_table = descriptive_table.drop(
+            [PerfStat.AVG.value.name, volatility_column], axis=1)
 
         prob = _compute_positive_probability(data=data_np)
         descriptive_table[PerfStat.POSITIVE.to_str(short=True, short_n=True)] = ['{:.1%}'.format(x) for x in prob]
@@ -154,8 +158,9 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
         descriptive_table[PerfStat.NORMTEST.to_str(short=True, short_n=True)] = ['{:.2f}'.format(x) for x in ps]
 
     elif desc_table_type == desc_table_type.SKEW_KURTOSIS:
-        descriptive_table = descriptive_table.drop(PerfStat.AVG.to_str(), axis=1)
-        descriptive_table = descriptive_table.drop(PerfStat.STD.to_str(), axis=1)
+        # Remove the setup columns before reporting the reduced moment-only schema.
+        descriptive_table = descriptive_table.drop(
+            [PerfStat.AVG.value.name, volatility_column], axis=1)
         descriptive_table[PerfStat.SKEWNESS.to_str(short=True, short_n=True)] = [norm_variable_display_type.format(x) for x in skew(data_np, axis=0, nan_policy=nan_policy)]
         descriptive_table[PerfStat.KURTOSIS.to_str(short=True, short_n=True)] = [norm_variable_display_type.format(x) for x in kurtosis(data_np, axis=0, nan_policy=nan_policy)]
     elif desc_table_type == desc_table_type.WITH_SCORE:

--- a/src/qis/perfstats/tests/desc_table_annualized_modes_test.py
+++ b/src/qis/perfstats/tests/desc_table_annualized_modes_test.py
@@ -1,0 +1,244 @@
+"""Regression tests for annualized reduced descriptive-table modes.
+
+``compute_desc_table`` initially creates an average and either a periodic ``Std`` column or an
+annualized ``Std An`` column. ``AVG_WITH_POSITIVE_PROB`` and ``SKEW_KURTOSIS`` then remove those
+setup columns before reporting their reduced schemas. The selected volatility convention must
+therefore change which label is removed, not whether these otherwise valid modes can be used.
+
+The deterministic monthly fixture has directly countable signs and symmetric arithmetic
+progressions. Its positive shares, skewness, and excess kurtosis are calculated independently in
+the expected tables below. The tests cover annualized regressions, unchanged periodic controls,
+Series/DataFrame consistency, display formatting, labels, warnings, and caller ownership.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import pandas as pd
+import pytest
+
+# qis
+import qis.perfstats.desc_table as desc_table_module
+from qis.perfstats.desc_table import DescTableType
+
+
+class _DescTableModuleProtocol(Protocol):
+    """Typed test-side interface for the public function exercised below."""
+
+    def compute_desc_table(
+            self,
+            *,
+            df: pd.DataFrame | pd.Series,
+            desc_table_type: DescTableType,
+            annualize_vol: bool,
+            norm_variable_display_type: str = '{:.1f}') -> pd.DataFrame:
+        """Return a formatted descriptive-statistics table."""
+        raise NotImplementedError
+
+
+_DESC_TABLE_MODULE = cast(_DescTableModuleProtocol, desc_table_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures
+# =============================================================================
+
+_DATES = pd.date_range('2024-01-31', periods=5, freq='ME')
+
+_KURTOSIS_COLUMN = 'Kurt'
+_NORM_FORMAT = '{:.3f}'
+_POSITIVE_ASSET = 'Positive Asset'
+_POSITIVE_COLUMN = 'Positive'
+_SKEW_COLUMN = 'Skew'
+_SYMMETRIC_ASSET = 'Symmetric Asset'
+
+
+def _monthly_returns() -> pd.DataFrame:
+    """Create two five-observation arithmetic progressions.
+
+    ``Symmetric Asset`` has two positive observations among five, while ``Positive Asset`` has
+    five. Both columns are symmetric around their means, so their skewness is zero. Their second
+    and fourth central moments give excess kurtosis ``1.7 - 3.0 = -1.3``.
+
+    Returns:
+        Monthly return panel in the expected display order.
+    """
+    return pd.DataFrame(
+        {
+            _SYMMETRIC_ASSET: (-0.50, -0.25, 0.00, 0.25, 0.50),
+            _POSITIVE_ASSET: (0.25, 0.50, 0.75, 1.00, 1.25),
+        },
+        index=_DATES,
+    )
+
+
+def _expected_positive_table() -> pd.DataFrame:
+    """Return the direct positive-count ratios as display strings.
+
+    Returns:
+        One-column table containing ``2 / 5`` and ``5 / 5``.
+    """
+    return pd.DataFrame(
+        {_POSITIVE_COLUMN: ('40.0%', '100.0%')},
+        index=[_SYMMETRIC_ASSET, _POSITIVE_ASSET],
+    )
+
+
+def _expected_skew_kurtosis_table() -> pd.DataFrame:
+    """Return the independently calculated centered-moment statistics.
+
+    Returns:
+        Two-column table with zero skewness and ``-1.3`` excess kurtosis.
+    """
+    return pd.DataFrame(
+        {
+            _SKEW_COLUMN: ('0.000', '0.000'),
+            _KURTOSIS_COLUMN: ('-1.300', '-1.300'),
+        },
+        index=[_SYMMETRIC_ASSET, _POSITIVE_ASSET],
+    )
+
+
+def _compute_without_warnings(
+        data: pd.DataFrame | pd.Series,
+        desc_table_type: DescTableType,
+        annualize_vol: bool) -> pd.DataFrame:
+    """Call the public function while treating every emitted warning as a failure.
+
+    Args:
+        data: Finite monthly Series or DataFrame supplied to the public function.
+        desc_table_type: Reduced descriptive-table mode under test.
+        annualize_vol: Whether the setup volatility uses the annualized label.
+
+    Returns:
+        Formatted descriptive-statistics table.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        return _DESC_TABLE_MODULE.compute_desc_table(
+            df=data,
+            desc_table_type=desc_table_type,
+            annualize_vol=annualize_vol,
+            norm_variable_display_type=_NORM_FORMAT,
+        )
+
+
+# =============================================================================
+# Annualized reduced-mode regressions
+# =============================================================================
+
+def test_compute_desc_table_annualized_positive_probability_omits_volatility() -> None:
+    """Drop ``Std An`` and return only independently counted positive shares.
+
+    Five monthly dates imply annualization factor 12, so the setup schema contains ``Std An``
+    rather than ``Std``. The reduced output must remove that selected label and retain only the
+    direct ``2 / 5`` and ``5 / 5`` positive probabilities without mutating the input frame.
+    """
+    returns = _monthly_returns()
+    original_returns = returns.copy(deep=True)
+
+    actual = _compute_without_warnings(
+        data=returns,
+        desc_table_type=DescTableType.AVG_WITH_POSITIVE_PROB,
+        annualize_vol=True,
+    )
+
+    pd.testing.assert_frame_equal(actual, _expected_positive_table())
+    pd.testing.assert_frame_equal(returns, original_returns)
+
+
+def test_compute_desc_table_annualized_skew_kurtosis_omits_volatility() -> None:
+    """Drop ``Std An`` and return the independently calculated centered moments.
+
+    Both arithmetic progressions have zero third central moment. Their fourth standardized
+    moment is 1.7, giving Fisher excess kurtosis ``-1.3``. The custom three-decimal format, asset
+    order, and statistic order must survive annualization without modifying the input frame.
+    """
+    returns = _monthly_returns()
+    original_returns = returns.copy(deep=True)
+
+    actual = _compute_without_warnings(
+        data=returns,
+        desc_table_type=DescTableType.SKEW_KURTOSIS,
+        annualize_vol=True,
+    )
+
+    pd.testing.assert_frame_equal(actual, _expected_skew_kurtosis_table())
+    pd.testing.assert_frame_equal(returns, original_returns)
+
+
+# =============================================================================
+# Existing periodic-mode controls
+# =============================================================================
+
+@pytest.mark.parametrize(
+    ('desc_table_type', 'expected'),
+    (
+        (DescTableType.AVG_WITH_POSITIVE_PROB, _expected_positive_table()),
+        (DescTableType.SKEW_KURTOSIS, _expected_skew_kurtosis_table()),
+    ),
+)
+def test_compute_desc_table_periodic_reduced_modes_remain_unchanged(
+        desc_table_type: DescTableType,
+        expected: pd.DataFrame) -> None:
+    """Preserve the established reduced tables when volatility is not annualized.
+
+    Args:
+        desc_table_type: Reduced descriptive-table mode under test.
+        expected: Independently calculated complete display table for that mode.
+    """
+    returns = _monthly_returns()
+    original_returns = returns.copy(deep=True)
+
+    actual = _compute_without_warnings(
+        data=returns,
+        desc_table_type=desc_table_type,
+        annualize_vol=False,
+    )
+
+    pd.testing.assert_frame_equal(actual, expected)
+    pd.testing.assert_frame_equal(returns, original_returns)
+
+
+# =============================================================================
+# Series/DataFrame consistency
+# =============================================================================
+
+@pytest.mark.parametrize(
+    ('desc_table_type', 'expected'),
+    (
+        (DescTableType.AVG_WITH_POSITIVE_PROB, _expected_positive_table()),
+        (DescTableType.SKEW_KURTOSIS, _expected_skew_kurtosis_table()),
+    ),
+)
+def test_compute_desc_table_annualized_reduced_modes_preserve_named_series_contract(
+        desc_table_type: DescTableType,
+        expected: pd.DataFrame) -> None:
+    """Return the same one-row annualized table for equivalent pandas shapes.
+
+    Args:
+        desc_table_type: Reduced descriptive-table mode under test.
+        expected: Independently calculated complete display table for that mode.
+    """
+    returns = _monthly_returns()[_SYMMETRIC_ASSET]
+    returns_frame = returns.to_frame()
+    original_returns = returns.copy(deep=True)
+    original_frame = returns_frame.copy(deep=True)
+
+    series_result = _compute_without_warnings(
+        data=returns,
+        desc_table_type=desc_table_type,
+        annualize_vol=True,
+    )
+    frame_result = _compute_without_warnings(
+        data=returns_frame,
+        desc_table_type=desc_table_type,
+        annualize_vol=True,
+    )
+
+    expected_series_table = expected.loc[[_SYMMETRIC_ASSET]]
+    pd.testing.assert_frame_equal(series_result, expected_series_table)
+    pd.testing.assert_frame_equal(frame_result, expected_series_table)
+    pd.testing.assert_frame_equal(series_result, frame_result)
+    pd.testing.assert_series_equal(returns, original_returns)
+    pd.testing.assert_frame_equal(returns_frame, original_frame)


### PR DESCRIPTION
## Summary

- Track whether `compute_desc_table()` creates the periodic `Std` or annualized `Std An` column.
- Make `AVG_WITH_POSITIVE_PROB` and `SKEW_KURTOSIS` remove that selected setup column.
- Add deterministic regression coverage for both reduced modes and pandas input shapes.

## Behavior

Annualized reduced tables now return their intended schemas instead of raising while attempting
to remove the periodic volatility label. Ordinary reduced modes, the other annualized modes,
values, formatting, labels, column order, warnings, and caller ownership remain unchanged.

## Regression evidence

Before the fix, the four annualized DataFrame/Series cases raised
`KeyError: "['Std'] not found in axis"`; the two ordinary controls passed. The direct expectations
are positive shares of `2 / 5 = 40%` and `5 / 5 = 100%`, with zero skewness and `-1.3` Fisher
excess kurtosis for both symmetric arithmetic progressions. All six focused cases pass after the
fix, and the adjacent positive-probability regressions also pass.

## Verification

- focused and adjacent descriptive-table tests: 9 passed
- perfstats: 140 passed
- full suite: 1574 passed with 16 accepted third-party Seaborn/Matplotlib warnings
- changed-line Ruff: 0 violations
- new test and production Pyright: 0 errors
- public API synchronization, dependency check, and `git diff --check`: passed
- strict Sphinx: no related warning; nonzero only for six inherited stale OHLC generated pages

## Scope

This changes only volatility-label selection in `compute_desc_table()`, its public argument
documentation, the focused regression module, and the `Unreleased` changelog. It does not change
public signatures, exports, annualization inference, descriptive-statistic calculations, or
missing-data policy. General nullable `Float64`/`pd.NA` conversion remains a separate 
checkpoint that will be handled in the next PR.