### PR TITLE
Handle all-missing descriptive statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Made annualized `AVG_WITH_POSITIVE_PROB` and `SKEW_KURTOSIS` descriptive tables return their
   reduced schemas instead of raising while removing the volatility column.
+- Made `compute_desc_table()` support nullable `Float64` / `pd.NA` inputs and return formatted
+  missing statistics for all-missing dated columns without reduction warnings or score-mode errors.
 
 ## [5.15.0] - 2026-08-24
 

--- a/src/qis/perfstats/desc_table.py
+++ b/src/qis/perfstats/desc_table.py
@@ -16,7 +16,7 @@ statistics are ``perf_stats.py``.
 # packages
 import numpy as np
 import pandas as pd
-from typing import Union
+from typing import Callable, Union
 from scipy.stats import skew, kurtosis, percentileofscore, normaltest
 from enum import Enum
 
@@ -59,6 +59,50 @@ def _compute_positive_probability(data: np.ndarray) -> np.ndarray:
     )
 
 
+def _reduce_observed(
+        data: np.ndarray,
+        reduction: Callable[[np.ndarray], np.ndarray]) -> np.ndarray:
+    """Apply a reduction without passing all-missing dated columns to it.
+
+    Args:
+        data: Two-dimensional numerical observations arranged by row and column.
+        reduction: Column-wise reduction returning one value per supplied column.
+
+    Returns:
+        Reduction values in input-column order, with NaN for columns without observations.
+    """
+    # Empty panels need a separate accept-or-reject contract; preserve their existing behavior.
+    if data.shape[0] == 0:
+        return reduction(data)
+
+    observed_columns = np.any(np.logical_not(np.isnan(data)), axis=0)
+    values = np.full(data.shape[1], np.nan, dtype=float)
+    if np.any(observed_columns):
+        values[observed_columns] = reduction(data[:, observed_columns])
+    return values
+
+
+def _add_moment_columns(
+        descriptive_table: pd.DataFrame,
+        data: np.ndarray,
+        value_format: str) -> None:
+    """Add formatted skewness and kurtosis for each observed input column.
+
+    Args:
+        descriptive_table: Output table to which the two moment columns are added.
+        data: Two-dimensional numerical observations arranged by row and column.
+        value_format: Display format applied to each moment.
+    """
+    skews = _reduce_observed(
+        data, lambda values: skew(values, axis=0, nan_policy='omit'))
+    kurts = _reduce_observed(
+        data, lambda values: kurtosis(values, axis=0, nan_policy='omit'))
+    descriptive_table[PerfStat.SKEWNESS.value.short] = [
+        value_format.format(x) for x in skews]
+    descriptive_table[PerfStat.KURTOSIS.value.short_n] = [
+        value_format.format(x) for x in kurts]
+
+
 def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
                        desc_table_type: DescTableType = DescTableType.SHORT,
                        var_format: str = '{:.2f}',
@@ -73,7 +117,10 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
     Transposes the panel: the input is time by ticker, the output is ticker by statistic.
     Values are returned as formatted strings, not numbers, because this feeds the table
     renderer directly — use the underlying statistic functions if the numbers are wanted.
-    Columns may contain nans; statistics are computed on the available observations.
+    Columns may contain nans or ``pd.NA`` in nullable numeric dtypes; both are treated as missing,
+    and statistics are computed on the available observations.
+    Dated columns without observations remain in the table with formatted missing statistics
+    and do not emit reduction warnings.
     Positive probabilities divide positive returns by non-missing observations in each column;
     zero returns are observed and non-positive.
 
@@ -102,9 +149,11 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
     else:
         raise TypeError(f"unsupported data type = {type(df)}")
 
-    data_np = df.to_numpy()
-    mean = np.nanmean(data_np, axis=0)
-    std = np.nanstd(data_np, ddof=1, axis=0)
+    # Normalize nullable pandas values so numerical reducers receive np.nan rather than pd.NA.
+    data_np = df.to_numpy(dtype=float, na_value=np.nan)
+    # Skip all-missing dated columns so undefined base statistics remain NaN without warnings.
+    mean = _reduce_observed(data_np, lambda values: np.nanmean(values, axis=0))
+    std = _reduce_observed(data_np, lambda values: np.nanstd(values, ddof=1, axis=0))
 
     descriptive_table[PerfStat.AVG.to_str()] = [var_format.format(x) for x in mean]
 
@@ -148,50 +197,64 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
         descriptive_table[PerfStat.POSITIVE.to_str(short=True, short_n=True)] = ['{:.1%}'.format(x) for x in prob]
 
     elif desc_table_type == desc_table_type.WITH_KURTOSIS:
-        descriptive_table[PerfStat.SKEWNESS.to_str(short=True, short_n=True)] = [norm_variable_display_type.format(x) for x in skew(data_np, axis=0, nan_policy=nan_policy)]
-        descriptive_table[PerfStat.KURTOSIS.to_str(short=True, short_n=True)] = [norm_variable_display_type.format(x) for x in kurtosis(data_np, axis=0, nan_policy=nan_policy)]
+        # Evaluate moments only for observed columns so SciPy does not warn for empty samples.
+        _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
 
     elif desc_table_type == desc_table_type.WITH_NORMAL_PVAL:
-        descriptive_table[PerfStat.SKEWNESS.to_str(short=True, short_n=True)] = [norm_variable_display_type.format(x) for x in skew(data_np, axis=0, nan_policy=nan_policy)]
-        descriptive_table[PerfStat.KURTOSIS.to_str(short=True, short_n=True)] = [norm_variable_display_type.format(x) for x in kurtosis(data_np, axis=0, nan_policy=nan_policy)]
-        k2, ps = normaltest(a=data_np, axis=0, nan_policy='omit')
-        descriptive_table[PerfStat.NORMTEST.to_str(short=True, short_n=True)] = ['{:.2f}'.format(x) for x in ps]
+        # Apply moments and normality only where a sample exists, retaining NaN elsewhere.
+        _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
+        ps = _reduce_observed(
+            data_np, lambda values: normaltest(
+                a=values, axis=0, nan_policy=nan_policy)[1])
+        descriptive_table[PerfStat.NORMTEST.value.short_n] = [
+            '{:.2f}'.format(x) for x in ps]
 
     elif desc_table_type == desc_table_type.SKEW_KURTOSIS:
-        # Remove the setup columns before reporting the reduced moment-only schema.
+        # Remove setup columns and leave unobserved moments undefined in the reduced schema.
         descriptive_table = descriptive_table.drop(
             [PerfStat.AVG.value.name, volatility_column], axis=1)
-        descriptive_table[PerfStat.SKEWNESS.to_str(short=True, short_n=True)] = [norm_variable_display_type.format(x) for x in skew(data_np, axis=0, nan_policy=nan_policy)]
-        descriptive_table[PerfStat.KURTOSIS.to_str(short=True, short_n=True)] = [norm_variable_display_type.format(x) for x in kurtosis(data_np, axis=0, nan_policy=nan_policy)]
+        _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
     elif desc_table_type == desc_table_type.WITH_SCORE:
         column_data = [df[column].dropna() for column in df.columns]
-        percentiles = [percentileofscore(a=x, score=x.iloc[-1], kind='rank') for x in column_data]
-        descriptive_table[PerfStat.LAST.to_str()] = [var_format.format(x.iloc[-1]) for x in column_data]
+        # A dated but unobserved history has neither a last value nor a percentile rank.
+        if df.index.empty:
+            last_values = [x.iloc[-1] for x in column_data]
+        else:
+            last_values = [x.iloc[-1] if not x.empty else np.nan for x in column_data]
+        percentiles = [
+            percentileofscore(a=x, score=last_value, kind='rank') if not x.empty else np.nan
+            for x, last_value in zip(column_data, last_values)
+        ]
+        descriptive_table[PerfStat.LAST.value.name] = [var_format.format(x) for x in last_values]
         descriptive_table[PerfStat.RANK.to_str()] = ['{:.0%}'.format(0.01*x) for x in percentiles]
 
     elif desc_table_type == desc_table_type.EXTENSIVE:
-        descriptive_table[PerfStat.SKEWNESS.to_str(short=True, short_n=True)] \
-            = [norm_variable_display_type.format(x) for x in skew(df.values, axis=0, nan_policy=nan_policy)]
-        descriptive_table[PerfStat.KURTOSIS.to_str(short=True, short_n=True)] \
-            = [norm_variable_display_type.format(x) for x in kurtosis(df.values, axis=0, nan_policy=nan_policy)]
+        # Apply each extended reduction only to columns containing observations.
+        _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
+        minimums = _reduce_observed(data_np, lambda values: np.nanmin(values, axis=0))
+        lower_quantiles = _reduce_observed(
+            data_np, lambda values: np.nanquantile(values, q=0.16, axis=0))
+        medians = _reduce_observed(data_np, lambda values: np.nanmedian(values, axis=0))
+        upper_quantiles = _reduce_observed(
+            data_np, lambda values: np.nanquantile(values, q=0.84, axis=0))
+        maximums = _reduce_observed(data_np, lambda values: np.nanmax(values, axis=0))
         descriptive_table[PerfStat.MIN.to_str()] \
-            = [var_format.format(x) for x in np.nanmin(df.values, axis=0)]
+            = [var_format.format(x) for x in minimums]
         descriptive_table[PerfStat.QUANT_M_1STD.to_str(short=True)]\
-            = [var_format.format(x) for x in np.nanquantile(df.values, q=0.16, axis=0)]
+            = [var_format.format(x) for x in lower_quantiles]
         descriptive_table[PerfStat.MEDIAN.to_str(short=True)] \
-            = [var_format.format(x) for x in np.nanmedian(df.values, axis=0)]
+            = [var_format.format(x) for x in medians]
         descriptive_table[PerfStat.QUANT_P1_STD.to_str(short=True)] \
-            = [var_format.format(x) for x in np.nanquantile(df.values, q=0.84, axis=0)]
+            = [var_format.format(x) for x in upper_quantiles]
         descriptive_table[PerfStat.MAX.to_str()] \
-            = [var_format.format(x) for x in np.nanmax(df.values, axis=0)]
+            = [var_format.format(x) for x in maximums]
 
     elif desc_table_type == desc_table_type.WITH_MEDIAN:
+        # Leave unobserved medians and moments as NaN without invoking warning-producing reducers.
+        medians = _reduce_observed(data_np, lambda values: np.nanmedian(values, axis=0))
         descriptive_table[PerfStat.MEDIAN.to_str(short=True)] \
-            = [var_format.format(x) for x in np.nanmedian(df.values, axis=0)]
-        descriptive_table[PerfStat.SKEWNESS.to_str(short=True, short_n=True)] \
-            = [norm_variable_display_type.format(x) for x in skew(df.values, axis=0, nan_policy=nan_policy)]
-        descriptive_table[PerfStat.KURTOSIS.to_str(short=True, short_n=True)] \
-            = [norm_variable_display_type.format(x) for x in kurtosis(df.values, axis=0, nan_policy=nan_policy)]
+            = [var_format.format(x) for x in medians]
+        _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
 
     else:
         raise TypeError(f"desc_table_type={desc_table_type} is not implemented")

--- a/src/qis/perfstats/tests/desc_table_all_missing_test.py
+++ b/src/qis/perfstats/tests/desc_table_all_missing_test.py
@@ -5,12 +5,12 @@ dates but no observed values still belongs in that table: each undefined statist
 established formatted missing representation without emitting reduction warnings or preventing
 other assets from being reported.
 
-The shared eight-date panel pairs an all-missing asset with a symmetric finite control. Eight
-observations satisfy the normality test's minimum sample size, isolating warnings caused by the
-missing column. The finite expectations below come from direct counts and centered moments; the
-normality p-value is an unchanged accepted-output control. Tests cover every implemented table
-mode, exact schemas and strings, named Series/DataFrame consistency, formatting, optional
-t-statistics, nullable ``Float64`` compatibility, and caller ownership.
+The base eight-date panel pairs an all-missing asset with a symmetric finite control. Normality
+cases use a separate symmetric 20-date panel so every supported SciPy version remains above its
+small-sample warning boundary. The finite expectations below come from direct counts and centered
+moments; the normality p-value is an unchanged accepted-output control. Tests cover every
+implemented table mode, exact schemas and strings, named Series/DataFrame consistency, formatting,
+optional t-statistics, nullable ``Float64`` compatibility, and caller ownership.
 """
 
 import warnings
@@ -53,6 +53,8 @@ _DATES = pd.date_range('2024-01-31', periods=8, freq='ME')
 _ALL_MISSING_ASSET = 'All Missing Asset'
 _FINITE_ASSET = 'Finite Asset'
 _FINITE_VALUES = (-4.0, -3.0, -2.0, -1.0, 1.0, 2.0, 3.0, 4.0)
+_NORMALITY_FINITE_VALUES = tuple(float(value) for value in range(-10, 0)) + tuple(
+    float(value) for value in range(1, 11))
 _SECOND_FINITE_ASSET = 'Second Finite Asset'
 
 _IMPLEMENTED_MODES = tuple(
@@ -83,10 +85,10 @@ _EXPECTED_COLUMNS: dict[DescTableType, tuple[tuple[str, str, str], ...]] = {
     ),
     DescTableType.WITH_NORMAL_PVAL: (
         ('Avg', '0.00', 'nan'),
-        ('Std', '2.93', 'nan'),
+        ('Std', '6.37', 'nan'),
         ('Skew', '0.0', 'nan'),
-        ('Kurt', '-1.4', 'nan'),
-        ('P-val', '0.28', 'nan'),
+        ('Kurt', '-1.3', 'nan'),
+        ('P-val', '0.08', 'nan'),
     ),
     DescTableType.WITH_SCORE: (
         ('Avg', '0.00', 'nan'),
@@ -119,27 +121,54 @@ _EXPECTED_COLUMNS: dict[DescTableType, tuple[tuple[str, str, str], ...]] = {
 }
 
 
-def _mixed_returns() -> pd.DataFrame:
-    """Create one finite and one all-missing asset over the same dates.
+def _finite_values(desc_table_type: DescTableType) -> tuple[float, ...]:
+    """Select a finite fixture that is warning-free for the requested mode.
 
-    The finite values sum to zero, have squared deviations totaling 60, and contain four
-    positives among eight observations. Their sample standard deviation is therefore
-    ``sqrt(60 / 7)``, while symmetry makes skewness zero. Their second and fourth central
-    moments are 7.5 and 88.5, giving excess kurtosis ``88.5 / 7.5**2 - 3``.
+    The 20 normality observations have squared deviations totaling 770, so their sample standard
+    deviation is ``sqrt(770 / 19)``. Their second and fourth central moments are 38.5 and 2533.3,
+    giving Fisher excess kurtosis ``2533.3 / 38.5**2 - 3 = -1.290909...``.
+
+    Args:
+        desc_table_type: Descriptive-table mode under test.
 
     Returns:
-        Eight-row return panel in the expected reporting order.
+        Symmetric finite observations used by that mode.
     """
+    if desc_table_type is DescTableType.WITH_NORMAL_PVAL:
+        return _NORMALITY_FINITE_VALUES
+    return _FINITE_VALUES
+
+
+def _mixed_returns(desc_table_type: DescTableType) -> pd.DataFrame:
+    """Create one finite and one all-missing asset over the same dates.
+
+    The base finite values sum to zero, have squared deviations totaling 60, and contain four
+    positives among eight observations. Their sample standard deviation is therefore
+    ``sqrt(60 / 7)``, while symmetry makes skewness zero. Their second and fourth central
+    moments are 7.5 and 88.5, giving excess kurtosis ``88.5 / 7.5**2 - 3``. The normality mode
+    substitutes the 20-point fixture documented by ``_finite_values``.
+
+    Args:
+        desc_table_type: Descriptive-table mode that determines the finite fixture length.
+
+    Returns:
+        Return panel in the expected reporting order and mode-specific sample length.
+    """
+    finite_values = _finite_values(desc_table_type)
+    dates = pd.date_range('2024-01-31', periods=len(finite_values), freq='ME')
     return pd.DataFrame(
         {
-            _FINITE_ASSET: _FINITE_VALUES,
-            _ALL_MISSING_ASSET: (np.nan,) * len(_DATES),
+            _FINITE_ASSET: finite_values,
+            _ALL_MISSING_ASSET: (np.nan,) * len(dates),
         },
-        index=_DATES,
+        index=dates,
     )
 
 
-def _nullable_returns(*, include_all_missing: bool) -> pd.DataFrame:
+def _nullable_returns(
+        desc_table_type: DescTableType,
+        *,
+        include_all_missing: bool) -> pd.DataFrame:
     """Create a multi-column nullable panel with optional all-missing history.
 
     Two independently stored finite columns exercise the extension-array conversion across a
@@ -147,18 +176,21 @@ def _nullable_returns(*, include_all_missing: bool) -> pd.DataFrame:
     same fixture covers both finite-only and mixed finite/all-missing nullable boundaries.
 
     Args:
+        desc_table_type: Descriptive-table mode that determines the finite fixture length.
         include_all_missing: Whether to append the all-missing nullable column.
 
     Returns:
-        Eight-row return panel whose columns all use pandas nullable ``Float64`` dtype.
+        Return panel whose columns use pandas nullable ``Float64`` and the mode-specific length.
     """
+    finite_values = _finite_values(desc_table_type)
+    dates = pd.date_range('2024-01-31', periods=len(finite_values), freq='ME')
     values: dict[str, tuple[float, ...]] = {
-        _FINITE_ASSET: _FINITE_VALUES,
-        _SECOND_FINITE_ASSET: _FINITE_VALUES,
+        _FINITE_ASSET: finite_values,
+        _SECOND_FINITE_ASSET: finite_values,
     }
     if include_all_missing:
-        values[_ALL_MISSING_ASSET] = (np.nan,) * len(_DATES)
-    return pd.DataFrame(values, index=_DATES).astype('Float64')
+        values[_ALL_MISSING_ASSET] = (np.nan,) * len(dates)
+    return pd.DataFrame(values, index=dates).astype('Float64')
 
 
 def _expected_table(desc_table_type: DescTableType) -> pd.DataFrame:
@@ -254,7 +286,7 @@ def test_compute_desc_table_all_missing_column_returns_undefined_statistics(
     Args:
         desc_table_type: Implemented descriptive-table mode under test.
     """
-    returns = _mixed_returns()
+    returns = _mixed_returns(desc_table_type)
     original_returns = returns.copy(deep=True)
 
     actual = _compute_without_warnings(returns, desc_table_type)
@@ -283,7 +315,8 @@ def test_compute_desc_table_nullable_float64_returns_exact_statistics(
         desc_table_type: Implemented descriptive-table mode under test.
         include_all_missing: Whether the nullable panel contains the all-missing asset.
     """
-    returns = _nullable_returns(include_all_missing=include_all_missing)
+    returns = _nullable_returns(
+        desc_table_type, include_all_missing=include_all_missing)
     original_returns = returns.copy(deep=True)
     assert returns.dtypes.astype(str).tolist() == ['Float64'] * len(returns.columns)
 
@@ -308,7 +341,7 @@ def test_compute_desc_table_nullable_float64_supports_annualized_reduced_modes(
     Args:
         desc_table_type: Reduced descriptive-table mode under test.
     """
-    returns = _nullable_returns(include_all_missing=True)
+    returns = _nullable_returns(desc_table_type, include_all_missing=True)
     original_returns = returns.copy(deep=True)
 
     actual = _compute_without_warnings(
@@ -373,7 +406,7 @@ def test_compute_desc_table_all_missing_named_series_matches_dataframe(
     Args:
         desc_table_type: Implemented descriptive-table mode under test.
     """
-    returns = _mixed_returns()[_ALL_MISSING_ASSET]
+    returns = _mixed_returns(desc_table_type)[_ALL_MISSING_ASSET]
     returns_frame = returns.to_frame()
     original_returns = returns.copy(deep=True)
     original_frame = returns_frame.copy(deep=True)

--- a/src/qis/perfstats/tests/desc_table_all_missing_test.py
+++ b/src/qis/perfstats/tests/desc_table_all_missing_test.py
@@ -1,0 +1,389 @@
+"""Regression coverage for all-missing descriptive-statistics columns.
+
+``compute_desc_table`` reports display-ready statistics for every input column. An asset with
+dates but no observed values still belongs in that table: each undefined statistic should use the
+established formatted missing representation without emitting reduction warnings or preventing
+other assets from being reported.
+
+The shared eight-date panel pairs an all-missing asset with a symmetric finite control. Eight
+observations satisfy the normality test's minimum sample size, isolating warnings caused by the
+missing column. The finite expectations below come from direct counts and centered moments; the
+normality p-value is an unchanged accepted-output control. Tests cover every implemented table
+mode, exact schemas and strings, named Series/DataFrame consistency, formatting, optional
+t-statistics, nullable ``Float64`` compatibility, and caller ownership.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# qis
+import qis.perfstats.desc_table as desc_table_module
+from qis.perfstats.desc_table import DescTableType
+
+
+class _DescTableModuleProtocol(Protocol):
+    """Typed test-side interface for the public function exercised below."""
+
+    def compute_desc_table(
+            self,
+            *,
+            df: pd.DataFrame | pd.Series,
+            desc_table_type: DescTableType,
+            var_format: str = '{:.2f}',
+            annualize_vol: bool = False,
+            is_add_tstat: bool = False,
+            norm_variable_display_type: str = '{:.1f}') -> pd.DataFrame:
+        """Return a formatted descriptive-statistics table."""
+        raise NotImplementedError
+
+
+_DESC_TABLE_MODULE = cast(_DescTableModuleProtocol, desc_table_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent expectations
+# =============================================================================
+
+_DATES = pd.date_range('2024-01-31', periods=8, freq='ME')
+
+_ALL_MISSING_ASSET = 'All Missing Asset'
+_FINITE_ASSET = 'Finite Asset'
+_FINITE_VALUES = (-4.0, -3.0, -2.0, -1.0, 1.0, 2.0, 3.0, 4.0)
+_SECOND_FINITE_ASSET = 'Second Finite Asset'
+
+_IMPLEMENTED_MODES = tuple(
+    mode for mode in DescTableType if mode is not DescTableType.NONE)
+_REDUCED_MODES = (
+    DescTableType.AVG_WITH_POSITIVE_PROB,
+    DescTableType.SKEW_KURTOSIS,
+)
+
+_EXPECTED_COLUMNS: dict[DescTableType, tuple[tuple[str, str, str], ...]] = {
+    DescTableType.SHORT: (
+        ('Avg', '0.00', 'nan'),
+        ('Std', '2.93', 'nan'),
+    ),
+    DescTableType.AVG_WITH_POSITIVE_PROB: (
+        ('Positive', '50.0%', 'nan%'),
+    ),
+    DescTableType.WITH_POSITIVE_PROB: (
+        ('Avg', '0.00', 'nan'),
+        ('Std', '2.93', 'nan'),
+        ('Positive', '50.0%', 'nan%'),
+    ),
+    DescTableType.WITH_KURTOSIS: (
+        ('Avg', '0.00', 'nan'),
+        ('Std', '2.93', 'nan'),
+        ('Skew', '0.0', 'nan'),
+        ('Kurt', '-1.4', 'nan'),
+    ),
+    DescTableType.WITH_NORMAL_PVAL: (
+        ('Avg', '0.00', 'nan'),
+        ('Std', '2.93', 'nan'),
+        ('Skew', '0.0', 'nan'),
+        ('Kurt', '-1.4', 'nan'),
+        ('P-val', '0.28', 'nan'),
+    ),
+    DescTableType.WITH_SCORE: (
+        ('Avg', '0.00', 'nan'),
+        ('Std', '2.93', 'nan'),
+        ('Last', '4.00', 'nan'),
+        ('Rank', '100%', 'nan%'),
+    ),
+    DescTableType.EXTENSIVE: (
+        ('Avg', '0.00', 'nan'),
+        ('Std', '2.93', 'nan'),
+        ('Skew', '0.0', 'nan'),
+        ('Kurt', '-1.4', 'nan'),
+        ('Min', '-4.00', 'nan'),
+        ('-1std', '-2.88', 'nan'),
+        ('Median', '0.00', 'nan'),
+        ('+1std', '2.88', 'nan'),
+        ('Max', '4.00', 'nan'),
+    ),
+    DescTableType.SKEW_KURTOSIS: (
+        ('Skew', '0.0', 'nan'),
+        ('Kurt', '-1.4', 'nan'),
+    ),
+    DescTableType.WITH_MEDIAN: (
+        ('Avg', '0.00', 'nan'),
+        ('Std', '2.93', 'nan'),
+        ('Median', '0.00', 'nan'),
+        ('Skew', '0.0', 'nan'),
+        ('Kurt', '-1.4', 'nan'),
+    ),
+}
+
+
+def _mixed_returns() -> pd.DataFrame:
+    """Create one finite and one all-missing asset over the same dates.
+
+    The finite values sum to zero, have squared deviations totaling 60, and contain four
+    positives among eight observations. Their sample standard deviation is therefore
+    ``sqrt(60 / 7)``, while symmetry makes skewness zero. Their second and fourth central
+    moments are 7.5 and 88.5, giving excess kurtosis ``88.5 / 7.5**2 - 3``.
+
+    Returns:
+        Eight-row return panel in the expected reporting order.
+    """
+    return pd.DataFrame(
+        {
+            _FINITE_ASSET: _FINITE_VALUES,
+            _ALL_MISSING_ASSET: (np.nan,) * len(_DATES),
+        },
+        index=_DATES,
+    )
+
+
+def _nullable_returns(*, include_all_missing: bool) -> pd.DataFrame:
+    """Create a multi-column nullable panel with optional all-missing history.
+
+    Two independently stored finite columns exercise the extension-array conversion across a
+    genuine two-dimensional panel. The optional third column adds ``pd.NA`` observations so the
+    same fixture covers both finite-only and mixed finite/all-missing nullable boundaries.
+
+    Args:
+        include_all_missing: Whether to append the all-missing nullable column.
+
+    Returns:
+        Eight-row return panel whose columns all use pandas nullable ``Float64`` dtype.
+    """
+    values: dict[str, tuple[float, ...]] = {
+        _FINITE_ASSET: _FINITE_VALUES,
+        _SECOND_FINITE_ASSET: _FINITE_VALUES,
+    }
+    if include_all_missing:
+        values[_ALL_MISSING_ASSET] = (np.nan,) * len(_DATES)
+    return pd.DataFrame(values, index=_DATES).astype('Float64')
+
+
+def _expected_table(desc_table_type: DescTableType) -> pd.DataFrame:
+    """Build the exact display table from independently specified strings.
+
+    Args:
+        desc_table_type: Implemented descriptive-table mode under test.
+
+    Returns:
+        Complete expected table for the shared finite and all-missing assets.
+    """
+    return pd.DataFrame(
+        {
+            column: (finite_value, missing_value)
+            for column, finite_value, missing_value in _EXPECTED_COLUMNS[desc_table_type]
+        },
+        index=[_FINITE_ASSET, _ALL_MISSING_ASSET],
+    )
+
+
+def _expected_nullable_table(
+        desc_table_type: DescTableType,
+        *,
+        include_all_missing: bool) -> pd.DataFrame:
+    """Build exact expected strings for the multi-column nullable fixture.
+
+    Args:
+        desc_table_type: Implemented descriptive-table mode under test.
+        include_all_missing: Whether the expected table includes the missing asset.
+
+    Returns:
+        Complete expected table for two finite assets and the optional missing asset.
+    """
+    index = [_FINITE_ASSET, _SECOND_FINITE_ASSET]
+    if include_all_missing:
+        index.append(_ALL_MISSING_ASSET)
+    return pd.DataFrame(
+        {
+            column: (finite_value, finite_value, missing_value)
+            if include_all_missing else (finite_value, finite_value)
+            for column, finite_value, missing_value in _EXPECTED_COLUMNS[desc_table_type]
+        },
+        index=index,
+    )
+
+
+def _compute_without_warnings(
+        data: pd.DataFrame | pd.Series,
+        desc_table_type: DescTableType,
+        *,
+        var_format: str = '{:.2f}',
+        annualize_vol: bool = False,
+        is_add_tstat: bool = False,
+        norm_variable_display_type: str = '{:.1f}') -> pd.DataFrame:
+    """Call the public function while treating every emitted warning as a failure.
+
+    Args:
+        data: Finite/all-missing Series or DataFrame supplied to the public function.
+        desc_table_type: Descriptive-table mode under test.
+        var_format: Display format for mean, volatility, extrema, quantiles, and last value.
+        annualize_vol: Whether volatility uses the annualized output convention.
+        is_add_tstat: Whether to include the optional t-statistic column.
+        norm_variable_display_type: Display format for moments and t-statistics.
+
+    Returns:
+        Formatted descriptive-statistics table.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        return _DESC_TABLE_MODULE.compute_desc_table(
+            df=data,
+            desc_table_type=desc_table_type,
+            var_format=var_format,
+            annualize_vol=annualize_vol,
+            is_add_tstat=is_add_tstat,
+            norm_variable_display_type=norm_variable_display_type,
+        )
+
+
+# =============================================================================
+# Warning-free all-missing behavior across every table mode
+# =============================================================================
+
+@pytest.mark.parametrize('desc_table_type', _IMPLEMENTED_MODES)
+def test_compute_desc_table_all_missing_column_returns_undefined_statistics(
+        desc_table_type: DescTableType) -> None:
+    """Return each complete mode-specific table without warnings or input mutation.
+
+    The all-missing asset has no population from which any statistic can be calculated, so every
+    reported value is the established ``nan`` string (or ``nan%`` for percentage displays). The
+    finite neighbor proves exact schemas, labels, order, values, and formatting remain unchanged.
+
+    Args:
+        desc_table_type: Implemented descriptive-table mode under test.
+    """
+    returns = _mixed_returns()
+    original_returns = returns.copy(deep=True)
+
+    actual = _compute_without_warnings(returns, desc_table_type)
+
+    pd.testing.assert_frame_equal(actual, _expected_table(desc_table_type))
+    pd.testing.assert_frame_equal(returns, original_returns)
+
+
+# =============================================================================
+# Nullable Float64 compatibility across finite and all-missing panels
+# =============================================================================
+
+@pytest.mark.parametrize('desc_table_type', _IMPLEMENTED_MODES)
+@pytest.mark.parametrize('include_all_missing', (False, True), ids=('finite', 'mixed'))
+def test_compute_desc_table_nullable_float64_returns_exact_statistics(
+        desc_table_type: DescTableType,
+        include_all_missing: bool) -> None:
+    """Support nullable finite-only and mixed panels without warnings or mutation.
+
+    The two finite columns deliberately repeat the independently specified distribution so every
+    expected display string remains directly traceable to the counts and centered moments in the
+    module docstring. The mixed case simultaneously adds the materially different all-``pd.NA``
+    state and proves it remains undefined across every implemented table mode.
+
+    Args:
+        desc_table_type: Implemented descriptive-table mode under test.
+        include_all_missing: Whether the nullable panel contains the all-missing asset.
+    """
+    returns = _nullable_returns(include_all_missing=include_all_missing)
+    original_returns = returns.copy(deep=True)
+    assert returns.dtypes.astype(str).tolist() == ['Float64'] * len(returns.columns)
+
+    actual = _compute_without_warnings(returns, desc_table_type)
+
+    expected = _expected_nullable_table(
+        desc_table_type, include_all_missing=include_all_missing)
+    pd.testing.assert_frame_equal(actual, expected)
+    pd.testing.assert_frame_equal(returns, original_returns)
+
+
+@pytest.mark.parametrize('desc_table_type', _REDUCED_MODES)
+def test_compute_desc_table_nullable_float64_supports_annualized_reduced_modes(
+        desc_table_type: DescTableType) -> None:
+    """Preserve reduced schemas when nullable volatility uses the annualized convention.
+
+    Both reduced modes discard volatility from their final schemas, so their exact expected
+    displays are convention-independent. Exercising them with ``annualize_vol=True`` nevertheless
+    proves the nullable conversion composes with the selected ``Std An`` setup column introduced
+    by the accepted annualized-mode correction.
+
+    Args:
+        desc_table_type: Reduced descriptive-table mode under test.
+    """
+    returns = _nullable_returns(include_all_missing=True)
+    original_returns = returns.copy(deep=True)
+
+    actual = _compute_without_warnings(
+        returns, desc_table_type, annualize_vol=True)
+
+    expected = _expected_nullable_table(
+        desc_table_type, include_all_missing=True)
+    pd.testing.assert_frame_equal(actual, expected)
+    pd.testing.assert_frame_equal(returns, original_returns)
+
+
+# =============================================================================
+# Optional formatting and t-statistic path
+# =============================================================================
+
+def test_compute_desc_table_all_missing_column_preserves_custom_formats_and_tstat() -> None:
+    """Format defined neighboring statistics while retaining undefined missing statistics.
+
+    The finite control ``1, ..., 8`` has mean 4.5, sample standard deviation ``sqrt(6)``, and
+    t-statistic ``4.5 / sqrt(6) = 1.837117...`` under the established non-annualized convention.
+    The all-missing asset has none of those statistics, and custom formatting must not turn its
+    missing representations into values or warnings.
+    """
+    returns = pd.DataFrame(
+        {
+            _FINITE_ASSET: tuple(float(value) for value in range(1, 9)),
+            _ALL_MISSING_ASSET: (np.nan,) * len(_DATES),
+        },
+        index=_DATES,
+    )
+    original_returns = returns.copy(deep=True)
+    expected = pd.DataFrame(
+        {
+            'Avg': ('4.500', 'nan'),
+            'Std': ('2.449', 'nan'),
+            'T-stat': ('1.837', 'nan'),
+        },
+        index=[_FINITE_ASSET, _ALL_MISSING_ASSET],
+    )
+
+    actual = _compute_without_warnings(
+        returns,
+        DescTableType.SHORT,
+        var_format='{:.3f}',
+        is_add_tstat=True,
+        norm_variable_display_type='{:.3f}',
+    )
+
+    pd.testing.assert_frame_equal(actual, expected)
+    pd.testing.assert_frame_equal(returns, original_returns)
+
+
+# =============================================================================
+# Named Series/DataFrame consistency
+# =============================================================================
+
+@pytest.mark.parametrize('desc_table_type', _IMPLEMENTED_MODES)
+def test_compute_desc_table_all_missing_named_series_matches_dataframe(
+        desc_table_type: DescTableType) -> None:
+    """Return the same one-row missing table for equivalent pandas input shapes.
+
+    Args:
+        desc_table_type: Implemented descriptive-table mode under test.
+    """
+    returns = _mixed_returns()[_ALL_MISSING_ASSET]
+    returns_frame = returns.to_frame()
+    original_returns = returns.copy(deep=True)
+    original_frame = returns_frame.copy(deep=True)
+
+    series_result = _compute_without_warnings(returns, desc_table_type)
+    frame_result = _compute_without_warnings(returns_frame, desc_table_type)
+
+    expected = _expected_table(desc_table_type).loc[[_ALL_MISSING_ASSET]]
+    pd.testing.assert_frame_equal(series_result, expected)
+    pd.testing.assert_frame_equal(frame_result, expected)
+    pd.testing.assert_frame_equal(series_result, frame_result)
+    pd.testing.assert_series_equal(returns, original_returns)
+    pd.testing.assert_frame_equal(returns_frame, original_frame)


### PR DESCRIPTION
## Summary

- Avoid passing all-missing dated columns to warning-producing NumPy and SciPy reductions.
- Return the established formatted missing values for undefined statistics, including score-mode last values and ranks.
- Normalize nullable pandas numeric data so `Float64`/`pd.NA` inputs follow the same missing-data behavior.
- Add deterministic coverage across every implemented descriptive-table mode.

## Behavior

`compute_desc_table()` now retains all-missing dated columns and reports their undefined
statistics as the existing `nan` or `nan%` display strings. These inputs no longer emit reduction
warnings, and `WITH_SCORE` no longer raises when attempting to read the last observation from an
empty history.

Nullable `Float64` inputs are converted to numerical arrays with `pd.NA` represented as `np.nan`.
Ordinary finite calculations, schemas, formatting, labels, ordering, annualization conventions,
and caller-owned inputs remain unchanged.

## Regression evidence

Before the fix:

- all nine implemented modes emitted one or more warnings for an all-missing column;
- `WITH_SCORE` raised `IndexError: single positional indexer is out-of-bounds`;
- finite-only and mixed nullable `Float64` panels raised `TypeError` in `np.isnan`.

The deterministic finite control has:

- mean: `0.00`
- sample standard deviation: `sqrt(60 / 7) = 2.93`
- positive probability: `4 / 8 = 50.0%`
- median: `0.00`
- 16th/84th quantiles: `-2.88` / `2.88`
- skewness: `0.0`
- Fisher excess kurtosis: `-1.4`
- last value and rank: `4.00` / `100%`

The all-missing control returns the corresponding `nan` or `nan%` representation.

## Verification

- focused descriptive-table regressions: 48 passed
- perfstats: 179 passed
- full suite: 1614 passed with 16 accepted third-party Seaborn/Matplotlib warnings
- changed-line Ruff: 0 violations
- production and test Pyright: 0 errors
- public API synchronization: passed
- dependency check: passed
- `git diff --check`: passed
- independent conversion check: ordinary float inputs remained unchanged, while nullable inputs matched the explicitly specified float/`np.nan` array

## Scope

This PR changes only `compute_desc_table()` and its private reduction helpers, the focused
regression module, the public behavior documentation, and the `Unreleased` changelog entry. It
does not change public signatures, exports, finite statistical calculations, formatting,
insufficient-but-nonempty sample policy, zero-row policy, or duplicate-column behavior.