### PR TITLE
Validate leverage-transform parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   retaining their original order.
 - Made optional `compute_desc_table()` t-statistics undefined for zero-volatility samples instead
   of returning infinity with a divide-by-zero warning.
+- Rejected invalid leverage ratios and annualization factors in `lever_returns()` and
+  `delever_returns()` with consistent descriptive errors before applying either transform.
 
 ## [5.17.0] - 2026-08-25
 

--- a/src/qis/perfstats/returns.py
+++ b/src/qis/perfstats/returns.py
@@ -32,6 +32,8 @@ statistics such as Sharpe are assembled in ``qis/perfstats/perf_stats.py``.
 """
 # packages
 import warnings
+from math import isfinite
+from numbers import Integral, Real
 import numpy as np
 import pandas as pd
 from typing import Union, Dict, Optional
@@ -1091,6 +1093,35 @@ def get_excess_returns_nav(prices: Union[pd.DataFrame, pd.Series],
 # is already present, so no additional imports are needed.
 
 
+def _validate_leverage_parameters(leverage: object,
+                                  periods_per_year: object) -> None:
+    """Validate the shared scalar domain of the public leverage transforms.
+
+    Args:
+        leverage: Candidate debt-to-equity ratio.
+        periods_per_year: Candidate annualization factor or ``None``.
+
+    Raises:
+        ValueError: If leverage is not a finite nonnegative real scalar, or if
+            periods_per_year is neither ``None`` nor a positive integer.
+    """
+    if (isinstance(leverage, (bool, np.bool_))
+            or not isinstance(leverage, Real)
+            or not isfinite(leverage)
+            or leverage < 0.0):
+        raise ValueError(
+            f"leverage must be a finite non-negative real number, got {leverage!r}"
+        )
+
+    if (periods_per_year is not None
+            and (isinstance(periods_per_year, (bool, np.bool_))
+                 or not isinstance(periods_per_year, Integral)
+                 or periods_per_year <= 0)):
+        raise ValueError(
+            f"periods_per_year must be a positive integer or None, got {periods_per_year!r}"
+        )
+
+
 def delever_returns(returns: Union[pd.Series, pd.DataFrame],
                     leverage: float,
                     financing_rate: Union[float, pd.Series] = 0.0,
@@ -1111,20 +1142,25 @@ def delever_returns(returns: Union[pd.Series, pd.DataFrame],
 
     Args:
         returns: Period returns of the levered portfolio (Series or DataFrame).
-        leverage: Leverage ratio L (debt / equity). For a 1.5x levered fund pass 0.5;
-            for a 3x ETF pass 2.0; for the typical BDC at 1.0x debt-to-equity pass 1.0.
+        leverage: Finite, nonnegative leverage ratio L (debt / equity). Booleans are invalid.
+            For a 1.5x levered fund pass 0.5; for a 3x ETF pass 2.0; for the typical BDC at
+            1.0x debt-to-equity pass 1.0.
         financing_rate: Annualised financing rate. Pass a float for constant cost
             (e.g. risk-free rate as a crude proxy), or a Series indexed by date for
             time-varying financing (recommended for accuracy). Series observations are
             aligned to return dates and forward-filled from prior observations only.
             Default 0.0 ignores financing — only correct if the portfolio earns the
             financing rate on its borrowed capital, which is rarely the case.
-        periods_per_year: Annualisation factor used to convert the financing rate
-            to per-period. If None, inferred from the index frequency.
+        periods_per_year: Strictly positive integer annualisation factor used to convert the
+            financing rate to per-period. If None, inferred from the index frequency.
 
     Returns:
         De-levered returns matching the input shape and pandas labels. Zero leverage
         returns an independent copy, even when financing data is unavailable.
+
+    Raises:
+        ValueError: If leverage is not a finite nonnegative real scalar, or if an explicit
+            periods_per_year is not a positive integer.
 
     Note:
         This assumes constant leverage and a single-tier financing structure. Real
@@ -1138,6 +1174,9 @@ def delever_returns(returns: Union[pd.Series, pd.DataFrame],
         >>> ocsl_unlev = delever_returns(ocsl_returns, leverage=1.07,
         ...                              financing_rate=0.061)
     """
+    # Validate explicit inputs before zero leverage can bypass an invalid annualization factor.
+    _validate_leverage_parameters(leverage=leverage, periods_per_year=periods_per_year)
+
     # Preserve an exact identity before unavailable financing can propagate NaNs.
     if leverage == 0.0:
         return returns.copy()
@@ -1181,20 +1220,28 @@ def lever_returns(returns: Union[pd.Series, pd.DataFrame],
 
     Args:
         returns: Period returns of the unlevered asset (Series or DataFrame).
-        leverage: Leverage ratio L (debt / equity).
+        leverage: Finite, nonnegative leverage ratio L (debt / equity). Booleans are invalid.
         financing_rate: Annualised financing rate (float or Series). Series observations
             are aligned to return dates and forward-filled from prior observations only.
-        periods_per_year: Annualisation factor. If None, inferred from index.
+        periods_per_year: Strictly positive integer annualisation factor. If None, inferred
+            from the index.
 
     Returns:
         Levered returns matching the input shape and pandas labels. Zero leverage
         returns an independent copy, even when financing data is unavailable.
+
+    Raises:
+        ValueError: If leverage is not a finite nonnegative real scalar, or if an explicit
+            periods_per_year is not a positive integer.
 
     Example:
         >>> # Show what GCF would look like at 1x leverage with BDC-like financing
         >>> gcf_levered = lever_returns(gcf_returns, leverage=1.0,
         ...                             financing_rate=0.061)
     """
+    # Validate explicit inputs before zero leverage can bypass an invalid annualization factor.
+    _validate_leverage_parameters(leverage=leverage, periods_per_year=periods_per_year)
+
     # Preserve an exact identity before unavailable financing can propagate NaNs.
     if leverage == 0.0:
         return returns.copy()

--- a/src/qis/perfstats/tests/returns_leverage_validation_test.py
+++ b/src/qis/perfstats/tests/returns_leverage_validation_test.py
@@ -1,0 +1,364 @@
+"""Regression tests for leverage-transform parameter validation.
+
+``lever_returns`` and ``delever_returns`` share two scalar parameters that define their numerical
+domain. Leverage is documented as a debt-to-equity ratio and therefore must be finite and
+nonnegative. An explicitly supplied ``periods_per_year`` must be a strictly positive integer;
+``None`` continues to request frequency inference.
+
+The deterministic monthly panel below keeps every valid result independently calculable. With
+12% annual financing and 12 periods per year, financing is 1% per period. At leverage 0.5, the
+forward equation is ``1.5 * return - 0.5%`` and the inverse equation is
+``(levered return + 0.5%) / 1.5``. Tests cover Series/DataFrame parity, Python and NumPy integer
+factors, invalid type and range boundaries, validation before the zero-leverage shortcut,
+warnings, labels, and caller ownership.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.perfstats.returns import delever_returns, lever_returns
+
+
+# =============================================================================
+# Shared deterministic fixtures and typed transform interface
+# =============================================================================
+
+_DATES = pd.date_range("2024-01-31", periods=2, freq="ME")
+
+_ANNUAL_FINANCING_RATE = 0.12
+_LEVERAGE = 0.5
+_PERIODS_PER_YEAR = 12
+_TOLERANCE = 1.0e-12
+
+_LEVERAGE_ERROR = r"leverage must be a finite non-negative real number, got"
+_PERIODS_ERROR = r"periods_per_year must be a positive integer or None, got"
+
+
+class _LeverageTransform(Protocol):
+    """Test-side interface that permits deliberately invalid runtime arguments."""
+
+    def __call__(
+            self,
+            *,
+            returns: pd.Series | pd.DataFrame,
+            leverage: object,
+            financing_rate: float | pd.Series,
+            periods_per_year: object | None,
+    ) -> pd.Series | pd.DataFrame:
+        """Apply a leverage transform for validation testing."""
+        raise NotImplementedError
+
+
+_TRANSFORMS: tuple[tuple[str, _LeverageTransform], ...] = (
+    ("lever", cast(_LeverageTransform, lever_returns)),
+    ("delever", cast(_LeverageTransform, delever_returns)),
+)
+
+
+def _assert_pandas_equal(
+        actual: pd.Series | pd.DataFrame,
+        expected: pd.Series | pd.DataFrame,
+) -> None:
+    """Assert exact equality after narrowing both pandas objects to the same shape.
+
+    Args:
+        actual: Series or DataFrame produced or retained by a test.
+        expected: Independently copied object with the expected matching shape.
+    """
+    if isinstance(actual, pd.Series):
+        assert isinstance(expected, pd.Series)
+        pd.testing.assert_series_equal(actual, expected, check_exact=True)
+    else:
+        assert isinstance(actual, pd.DataFrame)
+        assert isinstance(expected, pd.DataFrame)
+        pd.testing.assert_frame_equal(actual, expected, check_exact=True)
+
+
+def _expected_levered_frame() -> pd.DataFrame:
+    """Return the leverage-0.5 result calculated directly from the public equation.
+
+    Returns:
+        Two-asset monthly levered returns with literal independently calculated values.
+    """
+    return pd.DataFrame(
+        {
+            "Asset A": (0.025, -0.020),
+            "Asset B": (0.055, -0.005),
+        },
+        index=_DATES,
+    )
+
+
+def _returns_frame() -> pd.DataFrame:
+    """Create the valid two-asset monthly return panel.
+
+    Returns:
+        Monthly return DataFrame used by every validation boundary.
+    """
+    return pd.DataFrame(
+        {
+            "Asset A": (0.02, -0.01),
+            "Asset B": (0.04, 0.00),
+        },
+        index=_DATES,
+    )
+
+
+def _return_variants() -> tuple[pd.Series, pd.DataFrame]:
+    """Create equivalent named-Series and mixed-panel inputs.
+
+    Returns:
+        Fresh one-asset Series and two-asset DataFrame inputs.
+    """
+    frame = _returns_frame()
+    series = frame["Asset A"].copy()
+    assert isinstance(series, pd.Series)
+    return series, frame
+
+
+# =============================================================================
+# Valid boundaries and independently calculated controls
+# =============================================================================
+
+def test_lever_returns_preserves_valid_series_and_dataframe_equation() -> None:
+    """Match the independently calculated forward equation without mutating inputs."""
+    returns = _returns_frame()
+    returns_series = returns["Asset A"].copy()
+    original_returns = returns.copy(deep=True)
+    original_series = returns_series.copy(deep=True)
+    expected = _expected_levered_frame()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual_frame = lever_returns(
+            returns=returns,
+            leverage=_LEVERAGE,
+            financing_rate=_ANNUAL_FINANCING_RATE,
+            periods_per_year=_PERIODS_PER_YEAR,
+        )
+        actual_series = lever_returns(
+            returns=returns_series,
+            leverage=_LEVERAGE,
+            financing_rate=_ANNUAL_FINANCING_RATE,
+            periods_per_year=_PERIODS_PER_YEAR,
+        )
+
+    assert isinstance(actual_frame, pd.DataFrame)
+    assert isinstance(actual_series, pd.Series)
+    pd.testing.assert_frame_equal(actual_frame, expected, atol=_TOLERANCE)
+    pd.testing.assert_series_equal(actual_series, expected["Asset A"], atol=_TOLERANCE)
+    pd.testing.assert_frame_equal(returns, original_returns, check_exact=True)
+    pd.testing.assert_series_equal(returns_series, original_series, check_exact=True)
+
+
+def test_delever_returns_preserves_valid_series_and_dataframe_equation() -> None:
+    """Invert literal levered values without using the forward function as an oracle."""
+    levered = _expected_levered_frame()
+    levered_series = levered["Asset A"].copy()
+    original_levered = levered.copy(deep=True)
+    original_series = levered_series.copy(deep=True)
+    expected = _returns_frame()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual_frame = delever_returns(
+            returns=levered,
+            leverage=_LEVERAGE,
+            financing_rate=_ANNUAL_FINANCING_RATE,
+            periods_per_year=_PERIODS_PER_YEAR,
+        )
+        actual_series = delever_returns(
+            returns=levered_series,
+            leverage=_LEVERAGE,
+            financing_rate=_ANNUAL_FINANCING_RATE,
+            periods_per_year=_PERIODS_PER_YEAR,
+        )
+
+    assert isinstance(actual_frame, pd.DataFrame)
+    assert isinstance(actual_series, pd.Series)
+    pd.testing.assert_frame_equal(actual_frame, expected, atol=_TOLERANCE)
+    pd.testing.assert_series_equal(actual_series, expected["Asset A"], atol=_TOLERANCE)
+    pd.testing.assert_frame_equal(levered, original_levered, check_exact=True)
+    pd.testing.assert_series_equal(levered_series, original_series, check_exact=True)
+
+
+@pytest.mark.parametrize(("transform_name", "transform"), _TRANSFORMS, ids=("lever", "delever"))
+def test_leverage_transforms_accept_numpy_scalar_parameters(
+        transform_name: str,
+        transform: _LeverageTransform,
+) -> None:
+    """Accept NumPy real leverage and integer periods with the same result as Python scalars."""
+    returns = _returns_frame()
+    original_returns = returns.copy(deep=True)
+
+    expected = transform(
+        returns=returns,
+        leverage=_LEVERAGE,
+        financing_rate=_ANNUAL_FINANCING_RATE,
+        periods_per_year=_PERIODS_PER_YEAR,
+    )
+    actual = transform(
+        returns=returns,
+        leverage=np.float64(_LEVERAGE),
+        financing_rate=_ANNUAL_FINANCING_RATE,
+        periods_per_year=np.int64(_PERIODS_PER_YEAR),
+    )
+
+    assert transform_name in {"lever", "delever"}
+    assert isinstance(actual, pd.DataFrame)
+    assert isinstance(expected, pd.DataFrame)
+    pd.testing.assert_frame_equal(actual, expected, check_exact=True)
+    pd.testing.assert_frame_equal(returns, original_returns, check_exact=True)
+
+
+@pytest.mark.parametrize(("transform_name", "transform"), _TRANSFORMS, ids=("lever", "delever"))
+def test_leverage_transforms_preserve_monthly_annualization_inference(
+        transform_name: str,
+        transform: _LeverageTransform,
+) -> None:
+    """Match an explicit monthly factor when a sufficient index requests frequency inference."""
+    frame = pd.DataFrame(
+        {
+            "Asset A": (0.02, -0.01, 0.03, 0.00),
+            "Asset B": (0.04, 0.00, -0.02, 0.01),
+        },
+        index=pd.date_range("2024-01-31", periods=4, freq="ME"),
+    )
+    series = frame["Asset A"].copy()
+    assert isinstance(series, pd.Series)
+
+    for returns in (series, frame):
+        original_returns = returns.copy(deep=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            expected = transform(
+                returns=returns,
+                leverage=_LEVERAGE,
+                financing_rate=_ANNUAL_FINANCING_RATE,
+                periods_per_year=_PERIODS_PER_YEAR,
+            )
+            actual = transform(
+                returns=returns,
+                leverage=_LEVERAGE,
+                financing_rate=_ANNUAL_FINANCING_RATE,
+                periods_per_year=None,
+            )
+
+        assert transform_name in {"lever", "delever"}
+        if isinstance(returns, pd.Series):
+            assert isinstance(actual, pd.Series)
+            assert isinstance(expected, pd.Series)
+            pd.testing.assert_series_equal(actual, expected, check_exact=True)
+        else:
+            assert isinstance(actual, pd.DataFrame)
+            assert isinstance(expected, pd.DataFrame)
+            pd.testing.assert_frame_equal(actual, expected, check_exact=True)
+        _assert_pandas_equal(returns, original_returns)
+
+
+# =============================================================================
+# Invalid leverage boundaries
+# =============================================================================
+
+@pytest.mark.parametrize(("transform_name", "transform"), _TRANSFORMS, ids=("lever", "delever"))
+@pytest.mark.parametrize(
+    "invalid_leverage",
+    (-1.0, -0.5, np.nan, np.inf, True, 1.0 + 0.0j, "1.0"),
+    ids=("singular-minus-one", "negative", "nan", "infinity", "boolean", "complex", "string"),
+)
+def test_leverage_transforms_reject_invalid_leverage(
+        transform_name: str,
+        transform: _LeverageTransform,
+        invalid_leverage: object,
+) -> None:
+    """Reject every invalid leverage class consistently for Series and DataFrame inputs."""
+    for returns in _return_variants():
+        original_returns = returns.copy(deep=True)
+        with pytest.raises(ValueError, match=_LEVERAGE_ERROR):
+            transform(
+                returns=returns,
+                leverage=invalid_leverage,
+                financing_rate=_ANNUAL_FINANCING_RATE,
+                periods_per_year=_PERIODS_PER_YEAR,
+            )
+
+        assert transform_name in {"lever", "delever"}
+        _assert_pandas_equal(returns, original_returns)
+
+
+# =============================================================================
+# Invalid annualization boundaries and validation order
+# =============================================================================
+
+@pytest.mark.parametrize(("transform_name", "transform"), _TRANSFORMS, ids=("lever", "delever"))
+@pytest.mark.parametrize(
+    "invalid_periods_per_year",
+    (0, -1, 12.0, 12.5, True, np.nan, np.inf, "12"),
+    ids=(
+        "zero", "negative", "integral-float", "fractional",
+        "boolean", "nan", "infinity", "string",
+    ),
+)
+def test_leverage_transforms_reject_invalid_periods_per_year(
+        transform_name: str,
+        transform: _LeverageTransform,
+        invalid_periods_per_year: object,
+) -> None:
+    """Reject non-integer or non-positive annualization consistently without mutating inputs."""
+    for returns in _return_variants():
+        original_returns = returns.copy(deep=True)
+        with pytest.raises(ValueError, match=_PERIODS_ERROR):
+            transform(
+                returns=returns,
+                leverage=_LEVERAGE,
+                financing_rate=_ANNUAL_FINANCING_RATE,
+                periods_per_year=invalid_periods_per_year,
+            )
+
+        assert transform_name in {"lever", "delever"}
+        _assert_pandas_equal(returns, original_returns)
+
+
+@pytest.mark.parametrize(("transform_name", "transform"), _TRANSFORMS, ids=("lever", "delever"))
+def test_leverage_transforms_validate_periods_before_zero_leverage_identity(
+        transform_name: str,
+        transform: _LeverageTransform,
+) -> None:
+    """Reject an explicitly invalid factor even when zero leverage makes arithmetic unnecessary."""
+    returns = _returns_frame()
+    original_returns = returns.copy(deep=True)
+
+    with pytest.raises(ValueError, match=_PERIODS_ERROR):
+        transform(
+            returns=returns,
+            leverage=0.0,
+            financing_rate=np.nan,
+            periods_per_year=0,
+        )
+
+    assert transform_name in {"lever", "delever"}
+    pd.testing.assert_frame_equal(returns, original_returns, check_exact=True)
+
+
+@pytest.mark.parametrize(("transform_name", "transform"), _TRANSFORMS, ids=("lever", "delever"))
+def test_leverage_transforms_keep_zero_identity_with_inferred_periods(
+        transform_name: str,
+        transform: _LeverageTransform,
+) -> None:
+    """Preserve the independent zero-leverage copy when annualization is intentionally omitted."""
+    for returns in _return_variants():
+        original_returns = returns.copy(deep=True)
+        actual = transform(
+            returns=returns,
+            leverage=0.0,
+            financing_rate=np.nan,
+            periods_per_year=None,
+        )
+
+        assert transform_name in {"lever", "delever"}
+        assert actual is not returns
+        _assert_pandas_equal(actual, original_returns)


### PR DESCRIPTION
## Summary

- validate the shared scalar parameters of `lever_returns()` and `delever_returns()`;
- require leverage to be a finite, nonnegative real scalar;
- require an explicit `periods_per_year` to be a strictly positive integer;
- perform validation before the zero-leverage identity shortcut;
- document the accepted domains and consistent `ValueError` contract.

## Behavioral change

This intentionally changes behavior for inputs outside the documented domain.

Both transforms now reject:

- negative, non-finite, Boolean, complex, and nonnumeric leverage values;
- zero, negative, floating-point, non-finite, Boolean, and nonnumeric explicit annualization factors.

This includes integral floats such as `periods_per_year=12.0`; callers must pass the integer `12`.

Previously, invalid inputs could be silently accepted, produce infinite or non-finite output, raise incidental operation-specific exceptions, or bypass validation when leverage was zero. They now raise consistent descriptive `ValueError` exceptions.

Valid calculations, public signatures, return conventions, funding alignment, annualization inference, Series/DataFrame shape and labels, and caller ownership remain unchanged.

## Regression coverage

The deterministic tests cover:

- independently calculated forward and inverse leverage equations;
- Series and DataFrame parity;
- Python and NumPy scalar parameters;
- explicit and inferred monthly annualization;
- every approved invalid type and range boundary;
- validation before the zero-leverage shortcut;
- zero-leverage independent-copy behavior;
- warnings and caller ownership.

With 12% annual financing, 12 periods per year, and leverage 0.5, the independently calculated levered panel is:

- Asset A — `[2.5%, -2.0%]`
- Asset B — `[5.5%, -0.5%]`

The literal inverse equation restores the original returns exactly.

## Verification

- focused PR 13/PR 24 leverage regressions — 47 passed
- perfstats suite — 227 passed
- full suite — 1667 passed, 16 warnings
- Ruff — passed
- Pyright — 0 errors on the new test
- public API synchronization — passed
- dependency check — passed
- `git diff --check` — passed

The remaining warnings are existing third-party Seaborn/Matplotlib deprecation warnings.
