### PR TITLE
Normalize performance-fee date boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `delever_returns()` with consistent descriptive errors before applying either transform.
 - Made leverage funding alignment independent of financing-Series storage order and rejected
   ambiguous duplicate funding dates for nonzero leverage with a descriptive error.
+- Processed unique performance-fee return dates chronologically, rejected duplicate dates, and
+  crystallized fees on the latest available observation on or before calendar period ends.
 
 ## [5.17.0] - 2026-08-25
 

--- a/src/qis/perfstats/returns.py
+++ b/src/qis/perfstats/returns.py
@@ -618,22 +618,37 @@ def compute_net_return_ex_perf_man_fees(gross_return: pd.Series,
     """Compute net returns after management and performance fees.
 
     Args:
-        gross_return: Gross return time series
+        gross_return: Gross return time series. Unique dates are interpreted chronologically
+            regardless of physical row order.
         man_fee: Annual management fee (e.g., 0.01 for 1%)
         perf_fee: Performance fee rate on profits above HWM (e.g., 0.2 for 20%)
-        perf_fee_frequency: Frequency for performance fee crystallization (e.g., 'YE')
+        perf_fee_frequency: Frequency for performance fee crystallization (e.g., 'YE'). Calendar
+            boundaries use the latest available observation on or before the period end.
 
     Returns:
-        Net return time series after fees
+        Net return time series after fees in increasing date order.
+
+    Raises:
+        ValueError: If gross_return contains duplicate dates.
     """
+    # Fee state is path-dependent, so physical row order cannot define its chronology.
+    if not gross_return.index.is_unique:
+        raise ValueError("gross_return index must not contain duplicate dates")
+    gross_return = gross_return.sort_index()
+
     # Generate performance fee crystallization dates
     perf_fee_cristalization_schedule = da.generate_dates_schedule(
         time_period=da.TimePeriod(gross_return.index[0], gross_return.index[-1]),
         freq=perf_fee_frequency)
 
-    perf_cris_dates = np.isin(element=gross_return.index,
-                              test_elements=perf_fee_cristalization_schedule,
-                              assume_unique=True)
+    # Map off-grid calendar ends backward so later returns never enter the prior fee period.
+    perf_cris_positions = np.asarray(
+        gross_return.index.searchsorted(perf_fee_cristalization_schedule, side='right'),
+        dtype=int,
+    ) - 1
+    perf_cris_positions = perf_cris_positions[perf_cris_positions >= 0]
+    perf_cris_dates = np.zeros(len(gross_return.index), dtype=bool)
+    perf_cris_dates[perf_cris_positions] = True
 
     # Initialize tracking DataFrame
     nav_data = pd.DataFrame(data=0.0,

--- a/src/qis/perfstats/tests/returns_fee_boundaries_test.py
+++ b/src/qis/perfstats/tests/returns_fee_boundaries_test.py
@@ -1,16 +1,22 @@
 """Assurance tests for management and performance fee return adjustments.
 
-These deterministic tests document established behavior in
-``compute_net_return_ex_perf_man_fees`` rather than correcting a production defect. The initial
-observation establishes NAV at 100 and therefore has a conventional zero net return. Subsequent
-management fees use actual elapsed calendar days divided by 365, while performance fees apply
-only to gains above the previously crystallized high-water mark.
+These deterministic tests document and protect the fee boundaries in
+``compute_net_return_ex_perf_man_fees``. The initial observation establishes NAV at 100 and
+therefore has a conventional zero net return. Subsequent management fees use actual elapsed
+calendar days divided by 365, while performance fees apply only to gains above the previously
+crystallized high-water mark. Calendar crystallization boundaries use the latest observation on
+or before the boundary so ordinary weekend and holiday period ends are not skipped. Unique return
+dates are processed chronologically regardless of physical row order, while duplicate dates are
+rejected because path-dependent fee state would otherwise be ambiguous.
 
 Expected values are calculated directly from the fee equations and supplied as literals. No QIS
 NAV or return-conversion function is used to construct an expected result.
 """
 
+import warnings
+
 import pandas as pd
+import pytest
 
 from qis.perfstats.returns import compute_net_return_ex_perf_man_fees
 
@@ -21,6 +27,7 @@ from qis.perfstats.returns import compute_net_return_ex_perf_man_fees
 
 _MONTH_END_DATES = pd.date_range("2024-01-31", periods=4, freq="ME")
 _FUND_NAME = "Fund"
+_DUPLICATE_DATE_ERROR = r"gross_return index must not contain duplicate dates"
 _TOLERANCE = 1.0e-12
 
 
@@ -46,6 +53,80 @@ def _assert_result_and_input_ownership(
     )
     pd.testing.assert_series_equal(supplied, original, check_exact=True)
     assert actual is not supplied
+
+
+# =============================================================================
+# Return-index chronology and uniqueness
+# =============================================================================
+
+@pytest.mark.parametrize(
+    "order",
+    ((0, 1, 2, 3), (3, 2, 1, 0), (0, 2, 1, 3)),
+    ids=("sorted", "reversed", "interior-shuffled"),
+)
+def test_compute_net_return_ex_perf_man_fees_normalizes_unique_return_dates(
+        order: tuple[int, ...],
+) -> None:
+    """Apply fee state chronologically regardless of physical Series row order.
+
+    The December 31 year-end is off-grid and therefore maps to December 30. A 36.5%
+    management fee produces exact daily accrual of 0.1%, while a 20% performance fee
+    crystallizes the first gain. The literal result protects the interaction among
+    chronological ordering, actual/365 accrual, and the on-or-before boundary rule.
+
+    Args:
+        order: Physical row permutation applied to the same date-to-return mapping.
+    """
+    dates = pd.DatetimeIndex(
+        ["2022-12-29", "2022-12-30", "2023-01-03", "2023-01-10"],
+        name="Date",
+    )
+    values = (0.00, 0.10, 0.10, -0.05)
+    gross_returns = pd.Series(
+        [values[position] for position in order],
+        index=dates[list(order)],
+        name=_FUND_NAME,
+    )
+    original = gross_returns.copy()
+    expected = pd.Series(
+        [0.00, 0.07920, 0.07680, -0.046413075780089153],
+        index=dates,
+        name=_FUND_NAME,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = compute_net_return_ex_perf_man_fees(
+            gross_return=gross_returns,
+            man_fee=0.365,
+            perf_fee=0.20,
+            perf_fee_frequency="YE",
+        )
+
+    _assert_result_and_input_ownership(actual, expected, gross_returns, original)
+
+
+def test_compute_net_return_ex_perf_man_fees_rejects_duplicate_return_dates() -> None:
+    """Reject ambiguous repeated observations before calculating path-dependent fee state."""
+    gross_returns = pd.Series(
+        [0.00, 0.10, 0.20],
+        index=pd.DatetimeIndex(
+            ["2024-01-01", "2024-01-02", "2024-01-02"],
+            name="Date",
+        ),
+        name=_FUND_NAME,
+    )
+    original = gross_returns.copy()
+
+    with pytest.raises(ValueError, match=_DUPLICATE_DATE_ERROR):
+        compute_net_return_ex_perf_man_fees(
+            gross_return=gross_returns,
+            man_fee=0.0,
+            perf_fee=0.20,
+            perf_fee_frequency="YE",
+        )
+
+    pd.testing.assert_series_equal(gross_returns, original, check_exact=True)
 
 
 # =============================================================================
@@ -144,6 +225,88 @@ def test_compute_net_return_ex_perf_man_fees_crystallizes_only_profits_above_hwm
         man_fee=0.0,
         perf_fee=0.20,
         perf_fee_frequency="ME",
+    )
+
+    _assert_result_and_input_ownership(actual, expected, gross_returns, original)
+
+
+@pytest.mark.parametrize(
+    ("dates", "frequency"),
+    [
+        (["2022-12-29", "2022-12-30", "2023-01-03"], "YE"),
+        (["2024-05-29", "2024-05-30", "2024-06-03"], "ME"),
+        (["2024-12-30", "2024-12-31", "2025-01-02"], "YE"),
+    ],
+    ids=["weekend-year-end", "holiday-month-end", "exact-year-end"],
+)
+def test_compute_net_return_ex_perf_man_fees_uses_latest_period_end_observation(
+        dates: list[str],
+        frequency: str,
+) -> None:
+    """Crystallize on the latest observation at or before each calendar boundary.
+
+    The weekend and synthetic-holiday cases omit their calendar period-end observations, while
+    the exact control includes December 31. In every case the 10% pre-boundary gain takes GAV to
+    110, crystallizes a fee of 2, and carries NAV/GAV/HWM of 108 forward. The following 10% gain
+    then produces GAV 118.8, fee 2.16, and NAV 116.64: an exact 8% net return from 108.
+
+    Args:
+        dates: Sorted observation dates surrounding the crystallization boundary.
+        frequency: Calendar frequency used to generate that boundary.
+    """
+    gross_returns = pd.Series(
+        [0.00, 0.10, 0.10],
+        index=pd.DatetimeIndex(dates),
+        name=_FUND_NAME,
+    )
+    original = gross_returns.copy(deep=True)
+    # Literal expectations come from the GAV/NAV/HWM calculation above, not a QIS helper.
+    expected = pd.Series(
+        [0.00, 0.08, 0.08],
+        index=pd.DatetimeIndex(dates),
+        name=_FUND_NAME,
+    )
+
+    actual = compute_net_return_ex_perf_man_fees(
+        gross_return=gross_returns,
+        man_fee=0.0,
+        perf_fee=0.20,
+        perf_fee_frequency=frequency,
+    )
+
+    _assert_result_and_input_ownership(actual, expected, gross_returns, original)
+
+
+def test_compute_net_return_ex_perf_man_fees_maps_multiple_off_grid_year_ends() -> None:
+    """Crystallize independently at consecutive off-grid calendar year ends.
+
+    December 31 falls on a weekend in both 2022 and 2023, so the corresponding December 30 and
+    December 29 observations must close their respective fee periods. The first crystallization
+    carries NAV/GAV/HWM 108 into 2023. The second carries 126.144 into 2024, making the returns
+    immediately after both boundaries exactly 8% rather than retaining an uncrystallized fee
+    liability from the prior period.
+    """
+    dates = pd.DatetimeIndex(
+        ["2022-12-29", "2022-12-30", "2023-01-03", "2023-12-29", "2024-01-02"]
+    )
+    gross_returns = pd.Series(
+        [0.00, 0.10, 0.10, 0.10, 0.10],
+        index=dates,
+        name=_FUND_NAME,
+    )
+    original = gross_returns.copy(deep=True)
+    # The 2023 year-end return is 126.144 / 116.64 - 1; the next period restarts at 8%.
+    expected = pd.Series(
+        [0.00, 0.08, 0.08, 0.08148148148148149, 0.08],
+        index=dates,
+        name=_FUND_NAME,
+    )
+
+    actual = compute_net_return_ex_perf_man_fees(
+        gross_return=gross_returns,
+        man_fee=0.0,
+        perf_fee=0.20,
+        perf_fee_frequency="YE",
     )
 
     _assert_result_and_input_ownership(actual, expected, gross_returns, original)


### PR DESCRIPTION
## Summary

- crystallize performance fees on the latest available observation on or before each calendar
  period end;
- process unique return dates chronologically and reject ambiguous duplicate dates; and
- add deterministic regression coverage for fee timing, date order, labels, and caller ownership.

## Motivation

`compute_net_return_ex_perf_man_fees()` previously matched crystallization schedules to return
dates exactly. Ordinary weekend or holiday period ends were therefore skipped, carrying pre-fee
GAV and the prior high-water mark into the next fee period. For a year-end boundary after a Friday
observation, the subsequent example return was 8.148148148% rather than the independently expected
8%.

The calculation was also dependent on physical Series row order. Sorted, reversed, and shuffled
versions of the same date-to-return mapping produced different fee paths, while duplicate dates
were processed despite making path-dependent fee state ambiguous.

## Behavior and compatibility

Calendar boundaries now map backward to the latest available observation, so no post-boundary
return enters the prior fee period. Unique inputs are sorted chronologically on a local Series,
and duplicate dates raise a descriptive `ValueError`. Results are returned in increasing date
order without mutating the caller's Series.

Sorted inputs with exact crystallization dates retain their established results. The public
signature, exports, actual/365 management-fee convention, performance-fee equation, and initial
zero-return convention are unchanged.

## Regression coverage

The deterministic offline tests use literal, independently calculated expectations and cover:

- weekend and synthetic-holiday period ends;
- exact-boundary and multiple-period controls;
- subsequent-period GAV, NAV, fee, and high-water-mark effects;
- zero and nonzero actual/365 management fees;
- sorted, reversed, and interior-shuffled return dates;
- descriptive duplicate-date rejection; and
- Series labels, warnings, result order, and caller-owned input preservation.

## Verification

- focused interacting regressions: 83 passed;
- complete `perfstats` suite: 256 passed;
- full repository suite: 1,697 passed with 16 accepted third-party warnings;
- Google-docstring convention: 343 passed;
- new-test Ruff and Pyright: passed;
- no new production Ruff or Pyright findings;
- public API synchronization and dependency checks: passed; and
- `git diff --check`: passed.