### PR TITLE
fix: preserve backfill price anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Preserved finite newer and single-observation older price anchors when
+  `bfill_timeseries()` reconstructs joined price histories.
 - Supported pandas nullable floating price panels in `to_returns()` without changing return
   conventions or accepted NumPy-backed results.
 

--- a/src/qis/perfstats/tests/returns_nullable_prices_test.py
+++ b/src/qis/perfstats/tests/returns_nullable_prices_test.py
@@ -6,9 +6,8 @@ use literal references for every return mode and first-observation option. A mix
 two finite assets, ragged and all-missing histories, and terminal non-positive observations in one
 call so pandas' physical multi-column representation cannot hide behind one-column coverage.
 
-The downstream backfill control intentionally retains the accepted missing first-price result
-owned by PR 30. This module changes nullable conversion only; it must not establish a different
-price-initialization, frequency, or fill convention.
+The downstream backfill control also verifies that nullable conversion retains an independently
+supplied first-price anchor without changing frequency or fill conventions.
 """
 
 import warnings
@@ -367,11 +366,10 @@ def test_to_returns_retains_nullable_series_and_one_column_behavior() -> None:
 
 
 def test_bfill_timeseries_supports_nullable_mixed_price_panel() -> None:
-    """Enable nullable conversion without changing accepted backfill values.
+    """Retain nullable conversion and the coincident ragged price anchor.
 
-    The ragged Tuesday price remains missing in this PR's expected result because its lost initial
-    anchor is the separate PR 30 defect. Fallback, shared, and absent columns pin the accepted
-    mixed-state, off-grid, schema, warning, and ownership behavior around this conversion fix.
+    Fallback, shared, and absent columns pin the mixed-state, off-grid, schema, warning, and
+    ownership behavior around the Tuesday ragged anchor.
     """
     older = _as_nullable(
         pd.DataFrame(
@@ -400,7 +398,7 @@ def test_bfill_timeseries_supports_nullable_mixed_price_panel() -> None:
         pd.DataFrame(
             {
                 "Absent": (np.nan, np.nan, np.nan),
-                _RAGGED: (np.nan, np.nan, 231.0),
+                _RAGGED: (np.nan, 210.0, 231.0),
                 "Fallback": (50.0, 55.0, 55.0),
                 "Shared": (100.0, 110.0, 121.0),
             },

--- a/src/qis/perfstats/tests/timeseries_bfill_frequency_metadata_test.py
+++ b/src/qis/perfstats/tests/timeseries_bfill_frequency_metadata_test.py
@@ -309,9 +309,9 @@ def test_bfill_timeseries_preserves_mixed_off_grid_prices_and_frequency(
     """Retain every accepted price state while pinning business-day metadata.
 
     Saturday's shared and fallback prices carry into Monday, fallback remains 55 on Wednesday,
-    and the absent asset remains missing. The accepted implementation currently leaves ragged
-    missing through Tuesday before reaching 231 on Wednesday; PR 30 owns that separate price-
-    initialization defect. These literal values ensure metadata work changes no numerical state.
+    and the absent asset remains missing. The coincident ragged price anchors Tuesday at 210
+    before reaching 231 on Wednesday. These literal values ensure metadata work retains every
+    price state while assigning the requested frequency.
 
     Args:
         older_positions: Positional permutation applied to the older price provider.
@@ -339,7 +339,7 @@ def test_bfill_timeseries_preserves_mixed_off_grid_prices_and_frequency(
     expected = pd.DataFrame(
         {
             _ABSENT_ASSET: (np.nan, np.nan, np.nan),
-            _RAGGED_ASSET: (np.nan, np.nan, 231.0),
+            _RAGGED_ASSET: (np.nan, 210.0, 231.0),
             _FALLBACK_ASSET: (50.0, 55.0, 55.0),
             _SHARED_ASSET: (100.0, 110.0, 121.0),
         },

--- a/src/qis/perfstats/tests/timeseries_bfill_price_initialization_test.py
+++ b/src/qis/perfstats/tests/timeseries_bfill_price_initialization_test.py
@@ -1,0 +1,357 @@
+"""Regression coverage for price anchors in time-series backfills.
+
+``bfill_timeseries(is_prices=True)`` joins providers in return space and then reconstructs price
+levels. A first observed price has no preceding observation from which to calculate a return, but
+it is still a supplied level and must not disappear merely because its provider has no usable
+earlier return. These tests calculate the required levels directly rather than through QIS return
+or NAV helpers.
+
+The mixed panel exercises every material column state simultaneously under NumPy-backed and
+pandas nullable floating dtypes. Separate Series/DataFrame controls cover physical one-row
+providers, because another column's dates can otherwise hide that boundary. The regressions also
+assert warning behavior, frequency metadata, labels, caller ownership, and chronological
+equivalence where each property is material.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.perfstats.timeseries_bfill import bfill_timeseries
+
+
+# =============================================================================
+# Shared deterministic fixtures and comparison helpers
+# =============================================================================
+
+_ABSENT = "Absent"
+_FALLBACK = "Fallback"
+_FINITE_ONLY = "Finite only"
+_RAGGED = "Ragged"
+_SHARED = "Shared"
+_SINGLE_NEWER = "Single newer"
+_SINGLE_OLDER = "Single older"
+
+_MIXED_EXPECTED_DATES = pd.bdate_range("2024-01-08", "2024-01-10")
+_MIXED_NEWER_DATES = pd.DatetimeIndex(("2024-01-09", "2024-01-10"))
+_MIXED_OLDER_DATES = pd.DatetimeIndex(("2024-01-06", "2024-01-09"))
+
+_TOLERANCE = 1.0e-12
+
+
+def _assert_frame_close(actual: pd.Series | pd.DataFrame, expected: pd.DataFrame) -> None:
+    """Assert DataFrame values, missingness, labels, dtypes, and frequency.
+
+    Args:
+        actual: Public result carrying a Series-or-DataFrame return annotation.
+        expected: Independently constructed result in the requested dtype.
+    """
+    assert isinstance(actual, pd.DataFrame)
+    pd.testing.assert_frame_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    assert isinstance(actual.index, pd.DatetimeIndex)
+    assert actual.index.freqstr == "B"
+
+
+def _assert_series_close(actual: pd.Series | pd.DataFrame, expected: pd.Series) -> None:
+    """Assert Series values, missingness, labels, dtype, and frequency.
+
+    Args:
+        actual: Public result carrying a Series-or-DataFrame return annotation.
+        expected: Independently constructed result in the requested dtype.
+    """
+    assert isinstance(actual, pd.Series)
+    pd.testing.assert_series_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    assert isinstance(actual.index, pd.DatetimeIndex)
+    assert actual.index.freqstr == "B"
+
+
+def _convert_dtype(
+    frame: pd.DataFrame,
+    dtype: np.dtype[np.float64] | pd.Float64Dtype,
+) -> pd.DataFrame:
+    """Convert every physical column to one supported floating representation.
+
+    Args:
+        frame: NumPy-backed deterministic fixture.
+        dtype: NumPy or pandas nullable floating dtype.
+
+    Returns:
+        New DataFrame whose physical columns share the requested dtype.
+    """
+    return frame.astype(dtype)
+
+
+def _make_expected_mixed_panel() -> pd.DataFrame:
+    """Create literal expected prices for every simultaneous column state.
+
+    Returns:
+        Business-day panel preserving each supplied provider anchor.
+    """
+    return pd.DataFrame(
+        {
+            _ABSENT: (np.nan, np.nan, np.nan),
+            _FINITE_ONLY: (np.nan, 200.0, 220.0),
+            _RAGGED: (np.nan, 210.0, 231.0),
+            _SINGLE_NEWER: (np.nan, np.nan, 300.0),
+            _SINGLE_OLDER: (np.nan, 75.0, 75.0),
+            _FALLBACK: (50.0, 55.0, 55.0),
+            _SHARED: (100.0, 110.0, 121.0),
+        },
+        index=_MIXED_EXPECTED_DATES,
+    )
+
+
+def _make_mixed_providers() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Create providers containing every material price-anchor boundary.
+
+    Returns:
+        Older and newer NumPy-backed price panels.
+    """
+    older = pd.DataFrame(
+        {
+            _RAGGED: (np.nan, 210.0),
+            _SINGLE_OLDER: (np.nan, 75.0),
+            _FALLBACK: (50.0, 55.0),
+            _SHARED: (100.0, 110.0),
+        },
+        index=_MIXED_OLDER_DATES,
+    )
+    newer = pd.DataFrame(
+        {
+            _ABSENT: (np.nan, np.nan),
+            _FINITE_ONLY: (200.0, 220.0),
+            _RAGGED: (210.0, 231.0),
+            _SINGLE_NEWER: (np.nan, 300.0),
+            _SINGLE_OLDER: (np.nan, np.nan),
+            _FALLBACK: (np.nan, np.nan),
+            _SHARED: (110.0, 121.0),
+        },
+        index=_MIXED_NEWER_DATES,
+    )
+    return older, newer
+
+
+# =============================================================================
+# Simultaneous DataFrame price-anchor boundaries
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        pytest.param(np.dtype(np.float64), id="float64"),
+        pytest.param(pd.Float64Dtype(), id="nullable-float64"),
+    ),
+)
+@pytest.mark.parametrize("reverse_rows", (False, True), ids=("sorted", "reversed"))
+def test_bfill_timeseries_preserves_every_mixed_price_anchor(
+    dtype: np.dtype[np.float64] | pd.Float64Dtype,
+    reverse_rows: bool,
+) -> None:
+    """Preserve all materially different anchors in one physical panel.
+
+    ``Finite only`` and ``Single newer`` have no older counterpart. ``Ragged`` begins on the
+    same Tuesday in both providers but has no calculable older return. ``Single older`` has one
+    observed older level and an all-missing newer history. ``Fallback`` and ``Shared`` are healthy
+    controls, while ``Absent`` must remain entirely missing.
+
+    Args:
+        dtype: Floating representation applied to both providers and the literal expectation.
+        reverse_rows: Whether to reverse physical provider row order before the public call.
+    """
+    older, newer = _make_mixed_providers()
+    older = _convert_dtype(older, dtype)
+    newer = _convert_dtype(newer, dtype)
+    if reverse_rows:
+        older = older.iloc[::-1]
+        newer = newer.iloc[::-1]
+    original_older = older.copy(deep=True)
+    original_newer = newer.copy(deep=True)
+    expected = _convert_dtype(_make_expected_mixed_panel(), dtype)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = bfill_timeseries(
+            df_newer=newer,
+            df_older=older,
+            freq="B",
+            is_prices=True,
+        )
+
+    _assert_frame_close(actual, expected)
+    pd.testing.assert_frame_equal(older, original_older, check_exact=True)
+    pd.testing.assert_frame_equal(newer, original_newer, check_exact=True)
+
+
+# =============================================================================
+# Series/DataFrame shape and physical-row boundaries
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        pytest.param(np.dtype(np.float64), id="float64"),
+        pytest.param(pd.Float64Dtype(), id="nullable-float64"),
+    ),
+)
+def test_bfill_timeseries_preserves_finite_newer_series_start(
+    dtype: np.dtype[np.float64] | pd.Float64Dtype,
+) -> None:
+    """Retain the first finite newer price through equivalent Series and DataFrame calls.
+
+    Args:
+        dtype: Floating representation applied to providers and literal expectations.
+    """
+    older = pd.Series(
+        (np.nan, np.nan),
+        index=pd.bdate_range("2024-01-08", periods=2),
+        name="Asset",
+    ).astype(dtype)
+    newer = pd.Series(
+        (200.0, 210.0, 220.5),
+        index=pd.bdate_range("2024-01-10", periods=3),
+        name="Asset",
+    ).astype(dtype)
+    expected = pd.Series(
+        (np.nan, np.nan, 200.0, 210.0, 220.5),
+        index=pd.bdate_range("2024-01-08", periods=5),
+        name="Asset",
+    ).astype(dtype)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        series_actual = bfill_timeseries(
+            df_newer=newer,
+            df_older=older,
+            freq="B",
+            is_prices=True,
+        )
+        frame_actual = bfill_timeseries(
+            df_newer=newer.to_frame(),
+            df_older=older.to_frame(),
+            freq="B",
+            is_prices=True,
+        )
+
+    _assert_series_close(series_actual, expected)
+    _assert_frame_close(frame_actual, expected.to_frame())
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        pytest.param(np.dtype(np.float64), id="float64"),
+        pytest.param(pd.Float64Dtype(), id="nullable-float64"),
+    ),
+)
+def test_bfill_timeseries_preserves_one_row_older_provider(
+    dtype: np.dtype[np.float64] | pd.Float64Dtype,
+) -> None:
+    """Use a physical one-row older provider as a valid price anchor.
+
+    The fallback has no newer price, so its supplied 50 must carry across the requested grid. The
+    shared path scales the lone older 100 to the first newer 110 and then compounds to 121. Running
+    the fallback alone through Series also proves that another column's dates are unnecessary.
+
+    Args:
+        dtype: Floating representation applied to providers and literal expectations.
+    """
+    older = _convert_dtype(
+        pd.DataFrame({_FALLBACK: (50.0,), _SHARED: (100.0,)}, index=[pd.Timestamp("2024-01-01")]),
+        dtype,
+    )
+    newer = _convert_dtype(
+        pd.DataFrame(
+            {_FALLBACK: (np.nan, np.nan), _SHARED: (110.0, 121.0)},
+            index=pd.bdate_range("2024-01-02", periods=2),
+        ),
+        dtype,
+    )
+    expected = _convert_dtype(
+        pd.DataFrame(
+            {_FALLBACK: (50.0, 50.0, 50.0), _SHARED: (110.0, 110.0, 121.0)},
+            index=pd.bdate_range("2024-01-01", periods=3),
+        ),
+        dtype,
+    )
+    expected_fallback = pd.Series(
+        (50.0, 50.0, 50.0),
+        index=expected.index,
+        name=_FALLBACK,
+    ).astype(dtype)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        frame_actual = bfill_timeseries(
+            df_newer=newer,
+            df_older=older,
+            freq="B",
+            is_prices=True,
+        )
+        series_actual = bfill_timeseries(
+            df_newer=newer[_FALLBACK],
+            df_older=older[_FALLBACK],
+            freq="B",
+            is_prices=True,
+        )
+
+    _assert_frame_close(frame_actual, expected)
+    _assert_series_close(series_actual, expected_fallback)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        pytest.param(np.dtype(np.float64), id="float64"),
+        pytest.param(pd.Float64Dtype(), id="nullable-float64"),
+    ),
+)
+def test_bfill_timeseries_carries_one_off_grid_older_price(
+    dtype: np.dtype[np.float64] | pd.Float64Dtype,
+) -> None:
+    """Carry one Saturday older price onto the complete business-day grid.
+
+    Args:
+        dtype: Floating representation applied to providers and literal expectations.
+    """
+    older = pd.Series(
+        (75.0,),
+        index=pd.DatetimeIndex(("2024-01-06",)),
+        name="Asset",
+    ).astype(dtype)
+    newer = pd.Series(
+        (np.nan, np.nan),
+        index=pd.DatetimeIndex(("2024-01-09", "2024-01-10")),
+        name="Asset",
+    ).astype(dtype)
+    expected = pd.Series(
+        (75.0, 75.0, 75.0),
+        index=pd.bdate_range("2024-01-08", "2024-01-10"),
+        name="Asset",
+    ).astype(dtype)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = bfill_timeseries(
+            df_newer=newer,
+            df_older=older,
+            freq="B",
+            is_prices=True,
+        )
+
+    _assert_series_close(actual, expected)

--- a/src/qis/perfstats/timeseries_bfill.py
+++ b/src/qis/perfstats/timeseries_bfill.py
@@ -119,6 +119,31 @@ def interpolate_infrequent_returns(infrequent_returns: Union[pd.Series, pd.DataF
     return infrequent_return_backfill
 
 
+def _add_price_return_anchors(price_returns: pd.DataFrame,
+                              prices: pd.DataFrame,
+                              prior_returns: Optional[pd.DataFrame] = None
+                              ) -> None:
+    """Retain first observed provider prices as zero-return NAV anchors.
+
+    Args:
+        price_returns: Fresh return frame to update in place.
+        prices: Provider prices whose first finite level may require an anchor.
+        prior_returns: Earlier-provider returns that can already anchor a newer history.
+    """
+    for column, price_series in prices.items():
+        if price_series.isna().all():
+            continue
+        first_price_date = cast(pd.Timestamp, dfo.get_nonnan_index(price_series))
+        has_prior_anchor = False
+        if prior_returns is not None and column in prior_returns.columns:
+            prior_return_series = prior_returns[column]
+            prior_observations = prior_return_series.loc[:first_price_date]
+            has_prior_anchor = bool(prior_observations.notna().any())
+        if not has_prior_anchor:
+            # A zero return preserves the supplied level without inventing price movement.
+            price_returns.loc[first_price_date, column] = 0.0
+
+
 def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent data
                      df_older: Union[pd.DataFrame, pd.Series],  # older price is preserved to the end
                      freq: str = 'B',
@@ -127,8 +152,9 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
                      ) -> Union[pd.DataFrame, pd.Series]:
     """Extend newer time series backward with older provider histories.
 
-    For price DataFrames, a newer all-missing column without an older counterpart remains
-    entirely missing.
+    For price inputs, a provider's first observed level supplies a zero-return NAV anchor when no
+    usable earlier return exists. A newer all-missing DataFrame column without an older
+    counterpart remains entirely missing.
 
     Args:
         df_newer: Newer Series or DataFrame whose labels and columns define the output. Its rows
@@ -139,8 +165,9 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
         fill_method: Return-gap policy. ``None`` preserves missing returns, ``'to_zero'`` fills
             missing returns with zero after each column begins, and ``'ffill'`` carries its last
             observed return forward. For price inputs, the policy is applied in return space.
-        is_prices: Whether the supplied data are price levels. Expanded price grids carry the
-            last observed level forward.
+        is_prices: Whether the supplied data are price levels. First observed provider prices are
+            retained when no earlier return can anchor them, and expanded grids carry the last
+            observed level forward.
 
     Returns:
         Chronologically ordered backfilled data on the requested grid with matching frequency
@@ -174,6 +201,8 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
         df_newer = df_newer.sort_index()
     if not df_older.index.is_monotonic_increasing:
         df_older = df_older.sort_index()
+    # Price reconstruction must retain dates even when their calculated return is missing.
+    provider_index = df_newer.index.union(df_older.index).sort_values()
     
     price_fallback_columns = []
     if is_prices:
@@ -197,8 +226,13 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
             terminal_value_old = dfo.get_last_nonnan_values(aligned_older)
             terminal_value = np.where(np.isnan(terminal_value), terminal_value_old, terminal_value)
 
-        df_newer = ret.to_returns(df_newer)
-        df_older = ret.to_returns(df_older, is_first_zero=True)  # the time series will start from first day of df_older
+        df_newer = cast(pd.DataFrame, ret.to_returns(newer_prices))
+        df_older = cast(pd.DataFrame, ret.to_returns(older_prices))
+        # Anchor older prices first so only genuinely unanchored newer histories are initialized.
+        _add_price_return_anchors(price_returns=df_older, prices=older_prices)
+        _add_price_return_anchors(price_returns=df_newer,
+                                  prices=newer_prices,
+                                  prior_returns=df_older)
     else:
         terminal_value = None
 
@@ -237,9 +271,13 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
     bfill_datas = pd.concat(bfill_datas, axis=1, sort=True).sort_index()
 
     if is_prices:
+        # Preserve price dates whose missing returns still delimit a valid provider history.
+        bfill_datas = bfill_datas.reindex(provider_index)
         bfill_datas = ret.returns_to_nav(returns=bfill_datas,
                                          init_period=None,
                                          terminal_value=terminal_value)
+        # Restore trailing provider dates removed by between-NaN NAV cleanup before fallback fill.
+        bfill_datas = bfill_datas.reindex(provider_index)
         # Carry available older-only histories independently of grid-resampling side effects.
         for column in price_fallback_columns:
             bfill_datas[column] = bfill_datas[column].ffill()


### PR DESCRIPTION
## What changed

Preserve supplied first price observations during price backfill when a column has no usable earlier return, without changing healthy shared-prefix scaling.

Accepted main loses the first finite price for finite newer-only, ragged coincident-start, single-observation newer-only, and physical one-row older histories because price-to-return conversion leaves no anchor from which to reconstruct NAV.

## Behavior

`bfill_timeseries(is_prices=True)` now preserves supplied price anchors when no usable prior return exists. The correction changes affected numerical output but does not change the public signature, defaults, exports, dependencies, or return convention; all-missing columns remain missing and established shared-prefix scaling remains unchanged.

## Regression evidence

- **Fail before:** the deterministic price-initialization module reported `10 failed`, covering ordinary `float64` and nullable `Float64` mixed panels, Series/DataFrame parity, one-row older providers, and off-grid anchors.
- **Independent expectation:** literal expected prices preserve the supplied levels for finite newer-only `[NaN, 200, 220]`, ragged coincident-start `[NaN, 210, 231]`, single newer `[NaN, NaN, 300]`, and single older `[NaN, 75, 75]` states while retaining absent, fallback, and healthy shared controls unchanged.
- **Pass after:** all `35` focused price-anchor and interaction regressions pass for ordinary and nullable dtypes, including values, missing placement, labels, order, frequency, warnings, Series/DataFrame parity, off-grid dates, and caller ownership.

## Verification

- Focused price-anchor and interaction modules: `35 passed`.
- Complete perfstats suite: `327 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `1784 passed, 16 warnings`; all warnings are known third-party seaborn/Matplotlib deprecations.
- Changed-line Ruff and Pyright: no PR-attributable findings; strict Pylance-aligned review also found no PR-attributable diagnostic.
- Public-API synchronization: passed with `408` names.
- Dependency, formatting, and whitespace checks: passed for clean commit `4dec320`.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/timeseries_bfill.py`, `src/qis/perfstats/tests/timeseries_bfill_price_initialization_test.py`, `src/qis/perfstats/tests/timeseries_bfill_frequency_metadata_test.py`, and `src/qis/perfstats/tests/returns_nullable_prices_test.py`.

Out of scope: Empty-provider policy, non-positive-price validity, general backfill fill and frequency policies, append behavior, public signatures, exports, dependencies, and unrelated formatting.

## Checklist

- [ ] Tests cover the changed public behavior or defect.
- [ ] Point-in-time code uses no observations later than the decision time.
- [ ] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [ ] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [ ] The changed-lines ruff gate and production docstring gate pass.
- [ ] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [ ] New runtime dependencies or public-signature changes are called out explicitly.