### PR TITLE
fix: define empty backfill-provider behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the Sphinx site; the frequency convention note previously rendered them as literal text.
 - Trimmed model-layer NAVs to their common valid range before resampling, so a layer that ends
   early no longer contributes forward-filled zero returns to the common sample.
+- Defined empty-provider behavior for `bfill_timeseries()`, processing the available provider
+  under the newer schema and rejecting newer DataFrames that cannot define any output columns.
 - Preserved finite newer and single-observation older price anchors when
   `bfill_timeseries()` reconstructs joined price histories.
 - Supported pandas nullable floating price panels in `to_returns()` without changing return

--- a/src/qis/perfstats/tests/timeseries_bfill_empty_provider_test.py
+++ b/src/qis/perfstats/tests/timeseries_bfill_empty_provider_test.py
@@ -1,0 +1,420 @@
+"""Regression coverage for empty providers in time-series backfills.
+
+``bfill_timeseries`` defines its public shape and labels from the newer provider while using the
+older provider only to extend available history. A provider with no observations should therefore
+behave like an unavailable history rather than exposing incidental pandas indexing errors. A
+zero-column newer DataFrame is different: it cannot define the documented output schema and must
+be rejected explicitly.
+
+The deterministic cases below exercise returns and prices through Series and DataFrame inputs,
+NumPy-backed and nullable floating dtypes, every return fill policy, and one mixed panel containing
+finite and all-missing states simultaneously. Literal expectations preserve the available provider
+without calling another QIS backfill, return, or NAV path. The tests also pin frequency metadata,
+labels, column order, warning behavior, and caller ownership.
+"""
+
+import warnings
+from typing import Literal, cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.perfstats.timeseries_bfill import bfill_timeseries
+
+
+# =============================================================================
+# Shared deterministic fixtures and comparison helpers
+# =============================================================================
+
+_OLDER_DATES = pd.DatetimeIndex(("2024-01-01", "2024-01-02"), freq="B")
+_NEWER_DATES = pd.DatetimeIndex(("2024-01-03", "2024-01-05"))
+_EXPECTED_NEWER_DATES = pd.DatetimeIndex(
+    ("2024-01-03", "2024-01-04", "2024-01-05"),
+    freq="B",
+)
+
+_ABSENT = "Absent"
+_ASSET = "Asset"
+_FINITE = "Finite"
+_RAGGED = "Ragged"
+
+_TOLERANCE = 1.0e-12
+
+_FloatDtype = Literal["float64", "Float64"]
+
+
+def _astype_frame(frame: pd.DataFrame, dtype: _FloatDtype) -> pd.DataFrame:
+    """Apply one explicitly supported floating representation to a frame.
+
+    Args:
+        frame: NumPy-backed deterministic fixture.
+        dtype: NumPy-backed or pandas nullable floating dtype.
+
+    Returns:
+        Converted DataFrame with the requested physical column dtypes.
+    """
+    if dtype == "Float64":
+        return frame.astype(pd.Float64Dtype())
+    return frame.astype(np.float64)
+
+
+def _astype_series(series: pd.Series, dtype: _FloatDtype) -> pd.Series:
+    """Apply one explicitly supported floating representation to a Series.
+
+    Args:
+        series: NumPy-backed deterministic fixture.
+        dtype: NumPy-backed or pandas nullable floating dtype.
+
+    Returns:
+        Converted Series with the requested dtype.
+    """
+    if dtype == "Float64":
+        return series.astype(pd.Float64Dtype())
+    return series.astype(np.float64)
+
+
+def _call_warning_free(
+    newer: pd.Series | pd.DataFrame,
+    older: pd.Series | pd.DataFrame,
+    *,
+    is_prices: bool,
+    fill_method: str | None = None,
+) -> pd.Series | pd.DataFrame:
+    """Call the public join while asserting warning and ownership contracts.
+
+    Args:
+        newer: Newer caller-owned provider.
+        older: Older caller-owned provider.
+        is_prices: Whether the providers contain prices rather than returns.
+        fill_method: Missing-return policy supplied to the public function.
+
+    Returns:
+        Public backfill result.
+    """
+    original_newer = newer.copy()
+    original_older = older.copy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = bfill_timeseries(
+            df_newer=newer,
+            df_older=older,
+            freq="B",
+            fill_method=fill_method,
+            is_prices=is_prices,
+        )
+
+    if isinstance(newer, pd.Series):
+        assert isinstance(older, pd.Series)
+        pd.testing.assert_series_equal(newer, original_newer, check_exact=True)
+        pd.testing.assert_series_equal(older, original_older, check_exact=True)
+    else:
+        assert isinstance(older, pd.DataFrame)
+        pd.testing.assert_frame_equal(newer, original_newer, check_exact=True)
+        pd.testing.assert_frame_equal(older, original_older, check_exact=True)
+    return actual
+
+
+def _assert_frame_close(actual: pd.Series | pd.DataFrame, expected: pd.DataFrame) -> None:
+    """Assert complete DataFrame values, schema, dtypes, and frequency.
+
+    Args:
+        actual: Result carrying the public Series-or-DataFrame annotation.
+        expected: Independently constructed DataFrame reference.
+    """
+    assert isinstance(actual, pd.DataFrame)
+    pd.testing.assert_frame_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    actual_index = cast(pd.DatetimeIndex, actual.index)
+    assert actual_index.freqstr == "B"
+
+
+def _assert_series_close(actual: pd.Series | pd.DataFrame, expected: pd.Series) -> None:
+    """Assert complete Series values, name, dtype, and frequency.
+
+    Args:
+        actual: Result carrying the public Series-or-DataFrame annotation.
+        expected: Independently constructed Series reference.
+    """
+    assert isinstance(actual, pd.Series)
+    pd.testing.assert_series_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+    actual_index = cast(pd.DatetimeIndex, actual.index)
+    assert actual_index.freqstr == "B"
+
+
+# =============================================================================
+# Empty older-provider pass-through
+# =============================================================================
+
+
+@pytest.mark.parametrize("is_prices", (False, True), ids=("returns", "prices"))
+@pytest.mark.parametrize("dtype", ("float64", "Float64"))
+def test_bfill_timeseries_preserves_mixed_newer_panel_with_empty_older_provider(
+    dtype: _FloatDtype,
+    is_prices: bool,
+) -> None:
+    """Preserve finite and all-missing newer columns when older has no rows.
+
+    For returns, Thursday has no supplied observation and remains missing under the default
+    policy. For prices, the independently expected Thursday level carries Wednesday's 100 forward.
+    The all-missing neighbor remains missing in both modes.
+
+    Args:
+        dtype: Floating representation applied to providers and expectation.
+        is_prices: Whether the finite values are levels or returns.
+    """
+    finite = (100.0, 200.0) if is_prices else (0.10, 0.20)
+    expected_finite = (100.0, 100.0, 200.0) if is_prices else (0.10, np.nan, 0.20)
+    newer = _astype_frame(
+        pd.DataFrame({_FINITE: finite, _ABSENT: (np.nan, np.nan)}, index=_NEWER_DATES),
+        dtype,
+    )
+    older = _astype_frame(
+        pd.DataFrame(columns=newer.columns, index=pd.DatetimeIndex([])),
+        dtype,
+    )
+    expected = _astype_frame(
+        pd.DataFrame(
+            {_FINITE: expected_finite, _ABSENT: (np.nan, np.nan, np.nan)},
+            index=_EXPECTED_NEWER_DATES,
+        ),
+        dtype,
+    )
+
+    actual = _call_warning_free(newer, older, is_prices=is_prices)
+
+    _assert_frame_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("fill_method", "expected_values"),
+    (
+        pytest.param(None, (0.10, np.nan, 0.20), id="preserve-missing"),
+        pytest.param("to_zero", (0.10, 0.00, 0.20), id="fill-zero"),
+        pytest.param("ffill", (0.10, 0.10, 0.20), id="forward-fill"),
+    ),
+)
+@pytest.mark.parametrize("dtype", ("float64", "Float64"))
+def test_bfill_timeseries_applies_return_fill_policy_with_empty_older_series(
+    dtype: _FloatDtype,
+    fill_method: str | None,
+    expected_values: tuple[float, float, float],
+) -> None:
+    """Apply each documented return-gap policy when only newer data are available.
+
+    Args:
+        dtype: Floating representation applied to providers and expectation.
+        fill_method: Public missing-return policy under test.
+        expected_values: Literal Wednesday-through-Friday returns.
+    """
+    newer = _astype_series(pd.Series((0.10, 0.20), index=_NEWER_DATES, name=_ASSET), dtype)
+    older = _astype_series(
+        pd.Series([], index=pd.DatetimeIndex([]), dtype=np.float64, name="Older name"),
+        dtype,
+    )
+    expected = _astype_series(
+        pd.Series(expected_values, index=_EXPECTED_NEWER_DATES, name=_ASSET),
+        dtype,
+    )
+
+    actual = _call_warning_free(
+        newer,
+        older,
+        is_prices=False,
+        fill_method=fill_method,
+    )
+
+    _assert_series_close(actual, expected)
+
+
+# =============================================================================
+# Empty newer-provider fallback
+# =============================================================================
+
+
+@pytest.mark.parametrize("is_prices", (False, True), ids=("returns", "prices"))
+@pytest.mark.parametrize("dtype", ("float64", "Float64"))
+def test_bfill_timeseries_uses_older_mixed_panel_when_newer_has_no_rows(
+    dtype: _FloatDtype,
+    is_prices: bool,
+) -> None:
+    """Use compatible older histories under the empty newer provider's schema.
+
+    The newer schema deliberately reverses the older columns and adds an absent column. Finite and
+    ragged older values remain literal, while the newer-only column is missing on both older dates.
+
+    Args:
+        dtype: Floating representation applied to providers and expectation.
+        is_prices: Whether the finite values are levels or returns.
+    """
+    finite = (100.0, 110.0) if is_prices else (0.01, 0.02)
+    ragged = (np.nan, 50.0) if is_prices else (np.nan, 0.03)
+    older = _astype_frame(
+        pd.DataFrame({_FINITE: finite, _RAGGED: ragged}, index=_OLDER_DATES),
+        dtype,
+    )
+    newer = _astype_frame(
+        pd.DataFrame(columns=(_RAGGED, _FINITE, _ABSENT), index=pd.DatetimeIndex([])),
+        dtype,
+    )
+    expected = _astype_frame(
+        pd.DataFrame(
+            {
+                _RAGGED: ragged,
+                _FINITE: finite,
+                _ABSENT: (np.nan, np.nan),
+            },
+            index=_OLDER_DATES,
+        ),
+        dtype,
+    )
+
+    actual = _call_warning_free(newer, older, is_prices=is_prices)
+
+    _assert_frame_close(actual, expected)
+
+
+@pytest.mark.parametrize("is_prices", (False, True), ids=("returns", "prices"))
+@pytest.mark.parametrize("dtype", ("float64", "Float64"))
+def test_bfill_timeseries_uses_newer_series_name_with_empty_newer_provider(
+    dtype: _FloatDtype,
+    is_prices: bool,
+) -> None:
+    """Preserve older values while taking the public Series label from newer.
+
+    Args:
+        dtype: Floating representation applied to providers and expectation.
+        is_prices: Whether the finite values are levels or returns.
+    """
+    values = (100.0, 110.0) if is_prices else (0.01, 0.02)
+    older = _astype_series(pd.Series(values, index=_OLDER_DATES, name="Older name"), dtype)
+    newer = _astype_series(
+        pd.Series([], index=pd.DatetimeIndex([]), dtype=np.float64, name=_ASSET),
+        dtype,
+    )
+    expected = _astype_series(pd.Series(values, index=_OLDER_DATES, name=_ASSET), dtype)
+
+    actual = _call_warning_free(newer, older, is_prices=is_prices)
+
+    _assert_series_close(actual, expected)
+
+
+# =============================================================================
+# Both-empty and schema-less DataFrame boundaries
+# =============================================================================
+
+
+@pytest.mark.parametrize("is_prices", (False, True), ids=("returns", "prices"))
+@pytest.mark.parametrize("dtype", ("float64", "Float64"))
+@pytest.mark.parametrize("input_kind", ("series", "frame"))
+def test_bfill_timeseries_returns_newer_empty_schema_when_both_providers_have_no_rows(
+    input_kind: Literal["series", "frame"],
+    dtype: _FloatDtype,
+    is_prices: bool,
+) -> None:
+    """Return an owned empty object carrying the newer provider's declared schema.
+
+    Args:
+        input_kind: Public pandas shape under test.
+        dtype: Floating representation applied to providers and expectation.
+        is_prices: Whether the empty providers nominally contain levels or returns.
+    """
+    empty_index = pd.DatetimeIndex([])
+    expected_index = pd.DatetimeIndex([], dtype=empty_index.dtype, freq="B")
+    if input_kind == "series":
+        newer = _astype_series(
+            pd.Series([], index=empty_index, dtype=np.float64, name=_ASSET), dtype
+        )
+        older = _astype_series(
+            pd.Series([], index=empty_index, dtype=np.float64, name="Older name"),
+            dtype,
+        )
+        expected = _astype_series(
+            pd.Series([], index=expected_index, dtype=np.float64, name=_ASSET),
+            dtype,
+        )
+        actual = _call_warning_free(newer, older, is_prices=is_prices)
+        _assert_series_close(actual, expected)
+    else:
+        newer = _astype_frame(
+            pd.DataFrame(columns=(_RAGGED, _FINITE), index=empty_index),
+            dtype,
+        )
+        older = _astype_frame(
+            pd.DataFrame(columns=(_FINITE, _RAGGED), index=empty_index),
+            dtype,
+        )
+        expected = _astype_frame(
+            pd.DataFrame(columns=(_RAGGED, _FINITE), index=expected_index),
+            dtype,
+        )
+        actual = _call_warning_free(newer, older, is_prices=is_prices)
+        _assert_frame_close(actual, expected)
+
+
+@pytest.mark.parametrize("is_prices", (False, True), ids=("returns", "prices"))
+@pytest.mark.parametrize("dtype", ("float64", "Float64"))
+def test_bfill_timeseries_ignores_zero_column_older_dataframe(
+    dtype: _FloatDtype,
+    is_prices: bool,
+) -> None:
+    """Exclude dates from an older DataFrame that supplies no output column.
+
+    Args:
+        dtype: Floating representation applied to newer and expected panels.
+        is_prices: Whether the finite values are levels or returns.
+    """
+    finite = (100.0, 200.0) if is_prices else (0.10, 0.20)
+    expected_finite = (100.0, 100.0, 200.0) if is_prices else (0.10, np.nan, 0.20)
+    newer = _astype_frame(
+        pd.DataFrame({_FINITE: finite, _ABSENT: (np.nan, np.nan)}, index=_NEWER_DATES),
+        dtype,
+    )
+    older = pd.DataFrame(index=_OLDER_DATES)
+    expected = _astype_frame(
+        pd.DataFrame(
+            {_FINITE: expected_finite, _ABSENT: (np.nan, np.nan, np.nan)},
+            index=_EXPECTED_NEWER_DATES,
+        ),
+        dtype,
+    )
+
+    actual = _call_warning_free(newer, older, is_prices=is_prices)
+
+    _assert_frame_close(actual, expected)
+
+
+@pytest.mark.parametrize("is_prices", (False, True), ids=("returns", "prices"))
+def test_bfill_timeseries_rejects_zero_column_newer_dataframe(is_prices: bool) -> None:
+    """Reject a newer DataFrame that cannot define the documented output schema.
+
+    Args:
+        is_prices: Whether the older provider contains levels or returns.
+    """
+    newer = pd.DataFrame(index=_NEWER_DATES)
+    older = pd.DataFrame({_FINITE: (100.0, 110.0)}, index=_OLDER_DATES)
+    original_newer = newer.copy()
+    original_older = older.copy()
+
+    with pytest.raises(ValueError, match="df_newer must contain at least one column"):
+        bfill_timeseries(
+            df_newer=newer,
+            df_older=older,
+            freq="B",
+            is_prices=is_prices,
+        )
+
+    pd.testing.assert_frame_equal(newer, original_newer, check_exact=True)
+    pd.testing.assert_frame_equal(older, original_older, check_exact=True)

--- a/src/qis/perfstats/timeseries_bfill.py
+++ b/src/qis/perfstats/timeseries_bfill.py
@@ -158,9 +158,11 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
 
     Args:
         df_newer: Newer Series or DataFrame whose labels and columns define the output. Its rows
-            are interpreted in increasing date order without modifying the caller's object.
+            are interpreted in increasing date order without modifying the caller's object. A
+            zero-row object retains its declared schema; a zero-column DataFrame is invalid.
         df_older: Older object of the same pandas type, used before each newer history begins. Its
-            rows are also interpreted in increasing date order without modifying the caller.
+            rows are also interpreted in increasing date order without modifying the caller. A
+            zero-row object or zero-column DataFrame is treated as an unavailable provider.
         freq: Frequency of the returned date grid.
         fill_method: Return-gap policy. ``None`` preserves missing returns, ``'to_zero'`` fills
             missing returns with zero after each column begins, and ``'ffill'`` carries its last
@@ -171,10 +173,14 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
 
     Returns:
         Chronologically ordered backfilled data on the requested grid with matching frequency
-        metadata, preserving the newer input's pandas type, labels, and column order.
+        metadata, preserving the newer input's pandas type, labels, and column order. If one
+        provider has no observations, the available provider supplies the result under the newer
+        schema and existing frequency and fill policies; if both have no observations, an owned
+        empty object with that schema is returned.
 
     Raises:
-        ValueError: If ``fill_method`` is not ``None``, ``'to_zero'``, or ``'ffill'``.
+        ValueError: If the newer DataFrame has no columns, or if ``fill_method`` is not ``None``,
+            ``'to_zero'``, or ``'ffill'``.
         NotImplementedError: If the newer and older inputs are not both Series or both
             DataFrames.
     """
@@ -201,6 +207,28 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
         df_newer = df_newer.sort_index()
     if not df_older.index.is_monotonic_increasing:
         df_older = df_older.sort_index()
+
+    if df_newer.shape[1] == 0:
+        raise ValueError("df_newer must contain at least one column")
+
+    newer_has_no_rows = len(df_newer.index) == 0
+    older_has_no_data = len(df_older.index) == 0 or df_older.shape[1] == 0
+    if newer_has_no_rows and older_has_no_data:
+        # With no observations, the newer declaration is the complete output contract.
+        empty_result = df_newer.asfreq(freq)
+        if is_series_out:
+            empty_series = cast(pd.Series, empty_result.iloc[:, 0])
+            return empty_series
+        return empty_result
+    if older_has_no_data:
+        # Reuse the established single-provider path without letting empty dates affect the grid.
+        df_older = df_newer
+    elif newer_has_no_rows:
+        # The newer schema still controls labels, order, and dtypes when only older data exist.
+        df_newer = df_newer.reindex(index=df_older.index)
+        df_newer.update(df_older)
+        df_older = df_newer
+
     # Price reconstruction must retain dates even when their calculated return is missing.
     provider_index = df_newer.index.union(df_older.index).sort_values()
     


### PR DESCRIPTION
## What changed

Define deterministic empty-provider behavior for `bfill_timeseries()` while preserving the newer provider's schema and the established frequency and fill policies.

Empty older providers and zero-row newer providers previously produced inconsistent incidental exceptions or mode-dependent results, while a zero-column newer DataFrame could not define an output schema.

## Behavior

A nonempty newer provider with an empty older provider uses the newer history; a zero-row newer provider with a declared schema uses compatible older history under that schema; two zero-row providers return an owned empty result with the newer schema; and a zero-column newer DataFrame raises a descriptive `ValueError`. The public signature, defaults, exports, and established nonempty-provider behavior are unchanged.

## Regression evidence

Before the production fix, the finalized deterministic matrix produced `22 failed, 10 passed`. Literal expectations calculated independently of the implementation cover Series/DataFrame parity, returns/prices, ordinary and nullable floating dtypes, all return fill methods, a mixed finite/all-missing panel, warnings, schema, result ownership, and caller ownership. After the fix, the focused matrix passes all `32` cases.

## Verification

- Changed-line Ruff: zero violations.
- Changed-line Pyright: zero diagnostics (20 inherited or indirect diagnostics excluded).
- Focused regression: `32 passed`.
- Complete `src/qis/perfstats/tests/` suite: `361 passed`.
- Sphinx warning-as-error build: passed.
- Full `src/qis/` suite: `1836 passed`, with 16 known third-party seaborn/Matplotlib warnings.
- Public-API synchronization: current at 406 names.
- Dependency and committed-diff checks: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/timeseries_bfill.py`, and `src/qis/perfstats/tests/timeseries_bfill_empty_provider_test.py`.

Out of scope: The separate sole-provider off-grid frequency policy remains PR 52. This PR does not change public signatures, defaults, exports, dependencies, or unrelated utilities.

## Checklist

- [ ] Tests cover the changed public behavior or defect.
- [ ] Point-in-time code uses no observations later than the decision time.
- [ ] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [ ] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [ ] The changed-lines ruff gate and production docstring gate pass.
- [ ] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [ ] New runtime dependencies or public-signature changes are called out explicitly.