### PR TITLE
fix: define descriptive-table sample boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   rejected custom regime mappings that do not contain exactly two entries.
 - Unified the historical `qis.plots.derived.desc_table` path with the canonical descriptive-table
   enum and implementation while preserving deep-import compatibility.
+- Rejected zero-row descriptive-table inputs consistently and returned warning-free missing
+  statistics for columns below each statistic's sample minimum, including normality below 20
+  observations.
 
 ## [5.19.0] - 2026-08-28
 

--- a/src/qis/perfstats/desc_table.py
+++ b/src/qis/perfstats/desc_table.py
@@ -61,24 +61,24 @@ def _compute_positive_probability(data: np.ndarray) -> np.ndarray:
 
 def _reduce_observed(
         data: np.ndarray,
-        reduction: Callable[[np.ndarray], np.ndarray]) -> np.ndarray:
-    """Apply a reduction without passing all-missing dated columns to it.
+        reduction: Callable[[np.ndarray], np.ndarray],
+        minimum_observations: int = 1) -> np.ndarray:
+    """Apply a reduction only to columns meeting its sample-size requirement.
 
     Args:
         data: Two-dimensional numerical observations arranged by row and column.
         reduction: Column-wise reduction returning one value per supplied column.
+        minimum_observations: Required number of non-missing values in each column.
 
     Returns:
-        Reduction values in input-column order, with NaN for columns without observations.
+        Reduction values in input-column order, with NaN for undersized columns.
     """
-    # Empty panels need a separate accept-or-reject contract; preserve their existing behavior.
-    if data.shape[0] == 0:
-        return reduction(data)
-
-    observed_columns = np.any(np.logical_not(np.isnan(data)), axis=0)
+    # Select columns per statistic so undersized samples never reach warning-producing reducers.
+    observation_counts = np.sum(np.logical_not(np.isnan(data)), axis=0)
+    eligible_columns = np.greater_equal(observation_counts, minimum_observations)
     values = np.full(data.shape[1], np.nan, dtype=float)
-    if np.any(observed_columns):
-        values[observed_columns] = reduction(data[:, observed_columns])
+    if np.any(eligible_columns):
+        values[eligible_columns] = reduction(data[:, eligible_columns])
     return values
 
 
@@ -93,10 +93,13 @@ def _add_moment_columns(
         data: Two-dimensional numerical observations arranged by row and column.
         value_format: Display format applied to each moment.
     """
+    # Two observations define the displayed moments; smaller samples remain explicitly missing.
     skews = _reduce_observed(
-        data, lambda values: skew(values, axis=0, nan_policy='omit'))
+        data, lambda values: skew(values, axis=0, nan_policy='omit'),
+        minimum_observations=2)
     kurts = _reduce_observed(
-        data, lambda values: kurtosis(values, axis=0, nan_policy='omit'))
+        data, lambda values: kurtosis(values, axis=0, nan_policy='omit'),
+        minimum_observations=2)
     descriptive_table[PerfStat.SKEWNESS.value.short] = [
         value_format.format(x) for x in skews]
     descriptive_table[PerfStat.KURTOSIS.value.short_n] = [
@@ -121,6 +124,9 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
     and statistics are computed on the available observations.
     Dated columns without observations remain in the table with formatted missing statistics
     and do not emit reduction warnings.
+    Statistics whose columns do not meet their minimum sample sizes also remain formatted as
+    missing: sample standard deviation, skewness, and kurtosis require two observations, while
+    the normality p-value requires 20 observations.
     Positive probabilities divide positive returns by non-missing observations in each column;
     zero returns are observed and non-positive.
 
@@ -142,6 +148,7 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
 
     Raises:
         TypeError: if ``df`` is neither pd.DataFrame nor pd.Series
+        ValueError: if ``df`` contains no observations
     """
     if isinstance(df, pd.DataFrame):
         descriptive_table = pd.DataFrame(index=df.columns)
@@ -151,11 +158,18 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
     else:
         raise TypeError(f"unsupported data type = {type(df)}")
 
+    # Reject zero rows uniformly before reducers or annualization produce incidental outcomes.
+    if df.index.empty:
+        raise ValueError("data must contain at least one observation")
+
     # Normalize nullable pandas values so numerical reducers receive np.nan rather than pd.NA.
     data_np = df.to_numpy(dtype=float, na_value=np.nan)
     # Skip all-missing dated columns so undefined base statistics remain NaN without warnings.
     mean = _reduce_observed(data_np, lambda values: np.nanmean(values, axis=0))
-    std = _reduce_observed(data_np, lambda values: np.nanstd(values, ddof=1, axis=0))
+    std = _reduce_observed(
+        data_np,
+        lambda values: np.nanstd(values, ddof=1, axis=0),
+        minimum_observations=2)
 
     descriptive_table[PerfStat.AVG.to_str()] = [var_format.format(x) for x in mean]
 
@@ -206,9 +220,11 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
     elif desc_table_type == desc_table_type.WITH_NORMAL_PVAL:
         # Apply moments and normality only where a sample exists, retaining NaN elsewhere.
         _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
+        # Require SciPy's warning-free accuracy threshold, not only its eight-value hard minimum.
         ps = _reduce_observed(
-            data_np, lambda values: normaltest(
-                a=values, axis=0, nan_policy=nan_policy)[1])
+            data_np,
+            lambda values: normaltest(a=values, axis=0, nan_policy=nan_policy)[1],
+            minimum_observations=20)
         descriptive_table[PerfStat.NORMTEST.value.short_n] = [
             '{:.2f}'.format(x) for x in ps]
 
@@ -221,10 +237,7 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
         # Iterate physical columns so repeated labels are scored independently.
         column_data = [column.dropna() for _, column in df.items()]
         # A dated but unobserved history has neither a last value nor a percentile rank.
-        if df.index.empty:
-            last_values = [x.iloc[-1] for x in column_data]
-        else:
-            last_values = [x.iloc[-1] if not x.empty else np.nan for x in column_data]
+        last_values = [x.iloc[-1] if not x.empty else np.nan for x in column_data]
         percentiles = [
             percentileofscore(a=x, score=last_value, kind='rank') if not x.empty else np.nan
             for x, last_value in zip(column_data, last_values)

--- a/src/qis/perfstats/tests/desc_table_sample_boundaries_test.py
+++ b/src/qis/perfstats/tests/desc_table_sample_boundaries_test.py
@@ -1,0 +1,421 @@
+"""Regression coverage for descriptive-table sample-size boundaries.
+
+``compute_desc_table`` combines statistics with different minimum useful sample sizes. A single
+observation defines its mean and extrema but not its sample standard deviation; two observations
+define the displayed sample moments but remain too small for a stable normality result. These
+tests require each statistic to decide eligibility independently, without warnings or loss of
+still-defined neighboring results.
+
+The central fixture places one, two, seven, eight, nineteen, twenty, and zero observations in one
+twenty-month panel. Its samples are symmetric around one and have independently calculated sums
+of squared deviations, sign counts, moments, quantiles, last values, and ranks. Both ordinary
+``float64``/``np.nan`` and nullable ``Float64``/``pd.NA`` representations must produce the exact
+same display table. Separate controls cover zero-row rejection, a valid dated zero-column panel,
+named Series/DataFrame consistency, monthly annualization, formatting, warnings, and ownership.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# qis
+import qis.perfstats.desc_table as desc_table_module
+from qis.perfstats.desc_table import DescTableType
+
+
+class _DescTableModuleProtocol(Protocol):
+    """Typed test-side interface for the public function exercised below."""
+
+    def compute_desc_table(
+        self,
+        *,
+        df: pd.DataFrame | pd.Series,
+        desc_table_type: DescTableType,
+        var_format: str = "{:.2f}",
+        annualize_vol: bool = False,
+        is_add_tstat: bool = False,
+        norm_variable_display_type: str = "{:.1f}",
+    ) -> pd.DataFrame:
+        """Return a formatted descriptive-statistics table."""
+        raise NotImplementedError
+
+
+_DESC_TABLE_MODULE = cast(_DescTableModuleProtocol, desc_table_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent expectations
+# =============================================================================
+
+_DATES = pd.date_range("2024-01-31", periods=20, freq="ME")
+
+_ONE_OBSERVATION = "One Observation"
+_TWO_OBSERVATIONS = "Two Observations"
+_SEVEN_OBSERVATIONS = "Seven Observations"
+_EIGHT_OBSERVATIONS = "Eight Observations"
+_NINETEEN_OBSERVATIONS = "Nineteen Observations"
+_TWENTY_OBSERVATIONS = "Twenty Observations"
+_ALL_MISSING = "All Missing"
+
+_ASSETS = (
+    _ONE_OBSERVATION,
+    _TWO_OBSERVATIONS,
+    _SEVEN_OBSERVATIONS,
+    _EIGHT_OBSERVATIONS,
+    _NINETEEN_OBSERVATIONS,
+    _TWENTY_OBSERVATIONS,
+    _ALL_MISSING,
+)
+
+_IMPLEMENTED_MODES = tuple(mode for mode in DescTableType if mode is not DescTableType.NONE)
+
+_EXPECTED_VALUES: dict[str, tuple[str, ...]] = {
+    "Avg": ("1.00", "1.00", "1.00", "1.00", "1.00", "1.00", "nan"),
+    "Std": ("nan", "1.41", "2.16", "2.93", "5.63", "6.37", "nan"),
+    "Positive": ("100.0%", "50.0%", "57.1%", "50.0%", "52.6%", "50.0%", "nan%"),
+    "Skew": ("nan", "0.0", "0.0", "0.0", "0.0", "0.0", "nan"),
+    "Kurt": ("nan", "-2.0", "-1.2", "-1.4", "-1.2", "-1.3", "nan"),
+    "P-val": ("nan", "nan", "nan", "nan", "nan", "0.08", "nan"),
+    "Last": ("1.00", "2.00", "4.00", "5.00", "10.00", "11.00", "nan"),
+    "Rank": ("100%", "100%", "100%", "100%", "100%", "100%", "nan%"),
+    "Min": ("1.00", "0.00", "-2.00", "-3.00", "-8.00", "-9.00", "nan"),
+    "-1std": ("1.00", "0.32", "-1.04", "-1.88", "-5.12", "-5.96", "nan"),
+    "Median": ("1.00", "1.00", "1.00", "1.00", "1.00", "1.00", "nan"),
+    "+1std": ("1.00", "1.68", "3.04", "3.88", "7.12", "7.96", "nan"),
+    "Max": ("1.00", "2.00", "4.00", "5.00", "10.00", "11.00", "nan"),
+}
+
+_EXPECTED_MODE_COLUMNS: dict[DescTableType, tuple[str, ...]] = {
+    DescTableType.SHORT: ("Avg", "Std"),
+    DescTableType.AVG_WITH_POSITIVE_PROB: ("Positive",),
+    DescTableType.WITH_POSITIVE_PROB: ("Avg", "Std", "Positive"),
+    DescTableType.WITH_KURTOSIS: ("Avg", "Std", "Skew", "Kurt"),
+    DescTableType.WITH_NORMAL_PVAL: ("Avg", "Std", "Skew", "Kurt", "P-val"),
+    DescTableType.WITH_SCORE: ("Avg", "Std", "Last", "Rank"),
+    DescTableType.EXTENSIVE: (
+        "Avg",
+        "Std",
+        "Skew",
+        "Kurt",
+        "Min",
+        "-1std",
+        "Median",
+        "+1std",
+        "Max",
+    ),
+    DescTableType.SKEW_KURTOSIS: ("Skew", "Kurt"),
+    DescTableType.WITH_MEDIAN: ("Avg", "Std", "Median", "Skew", "Kurt"),
+}
+
+
+def _place_values(values: tuple[float, ...], positions: tuple[int, ...]) -> tuple[float, ...]:
+    """Place a finite sample at selected positions in the common date range.
+
+    Args:
+        values: Chronologically ordered finite observations.
+        positions: Zero-based positions receiving those observations.
+
+    Returns:
+        Twenty-value tuple with NaN at every unselected position.
+    """
+    placed_values = [np.nan] * len(_DATES)
+    for position, value in zip(positions, values):
+        placed_values[position] = value
+    return tuple(placed_values)
+
+
+def _mixed_returns(*, nullable: bool) -> pd.DataFrame:
+    """Create the mixed sample-cardinality panel in deliberate column order.
+
+    The finite samples are symmetric around one. Their sums of squared deviations are 2, 28,
+    60, 570, and 770 for sample sizes two, seven, eight, nineteen, and twenty. Missing values
+    occur at the interior, boundaries, and tails so eligibility depends only on the observed
+    count rather than physical placement.
+
+    Args:
+        nullable: Whether every column uses pandas nullable ``Float64`` storage.
+
+    Returns:
+        Twenty-month return panel containing all relevant column states simultaneously.
+    """
+    nineteen_positions = tuple(position for position in range(len(_DATES)) if position != 9)
+    returns = pd.DataFrame(
+        {
+            _ONE_OBSERVATION: _place_values((1.0,), (9,)),
+            _TWO_OBSERVATIONS: _place_values((0.0, 2.0), (0, 19)),
+            _SEVEN_OBSERVATIONS: _place_values(
+                (-2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0), tuple(range(7))
+            ),
+            _EIGHT_OBSERVATIONS: _place_values(
+                (-3.0, -2.0, -1.0, 0.0, 2.0, 3.0, 4.0, 5.0), tuple(range(12, 20))
+            ),
+            _NINETEEN_OBSERVATIONS: _place_values(
+                tuple(float(value) for value in range(-8, 11)), nineteen_positions
+            ),
+            _TWENTY_OBSERVATIONS: tuple(float(value) for value in range(-9, 1))
+            + tuple(float(value) for value in range(2, 12)),
+            _ALL_MISSING: (np.nan,) * len(_DATES),
+        },
+        index=_DATES,
+    )
+    if nullable:
+        return returns.astype(pd.Float64Dtype())
+    return returns
+
+
+def _expected_table(desc_table_type: DescTableType) -> pd.DataFrame:
+    """Build the complete expected table from independently specified strings.
+
+    Args:
+        desc_table_type: Implemented descriptive-table mode under test.
+
+    Returns:
+        Expected schema, row order, and display strings for the mixed panel.
+    """
+    return pd.DataFrame(
+        {column: _EXPECTED_VALUES[column] for column in _EXPECTED_MODE_COLUMNS[desc_table_type]},
+        index=pd.Index(_ASSETS),
+    )
+
+
+def _compute_without_warnings(
+    data: pd.DataFrame | pd.Series,
+    desc_table_type: DescTableType,
+    *,
+    annualize_vol: bool = False,
+    is_add_tstat: bool = False,
+    var_format: str = "{:.2f}",
+    norm_variable_display_type: str = "{:.1f}",
+) -> pd.DataFrame:
+    """Call the public function while treating every emitted warning as a failure.
+
+    Args:
+        data: Series or DataFrame supplied to the public function.
+        desc_table_type: Descriptive-table mode under test.
+        annualize_vol: Whether to display annualized volatility.
+        is_add_tstat: Whether to append the existing optional t-statistic.
+        var_format: Display format for level statistics.
+        norm_variable_display_type: Display format for moments and the t-statistic.
+
+    Returns:
+        Formatted descriptive-statistics table.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        return _DESC_TABLE_MODULE.compute_desc_table(
+            df=data,
+            desc_table_type=desc_table_type,
+            var_format=var_format,
+            annualize_vol=annualize_vol,
+            is_add_tstat=is_add_tstat,
+            norm_variable_display_type=norm_variable_display_type,
+        )
+
+
+def _zero_row_input(input_shape: str) -> pd.DataFrame | pd.Series:
+    """Build a zero-row pandas object with the requested declared shape.
+
+    Args:
+        input_shape: Named Series, one-column frame, multi-column frame, or zero-column frame.
+
+    Returns:
+        Empty pandas object retaining its declared labels.
+    """
+    if input_shape == "named-series":
+        return pd.Series(index=pd.DatetimeIndex([]), dtype=float, name="Asset")
+    columns_by_shape: dict[str, list[str]] = {
+        "one-column-frame": ["Asset"],
+        "multi-column-frame": ["Asset A", "Asset B"],
+        "zero-column-frame": [],
+    }
+    return pd.DataFrame(index=pd.DatetimeIndex([]), columns=columns_by_shape[input_shape])
+
+
+# =============================================================================
+# Mixed-panel sample-cardinality regressions
+# =============================================================================
+
+
+@pytest.mark.parametrize("desc_table_type", _IMPLEMENTED_MODES)
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_compute_desc_table_applies_each_statistic_minimum_independently(
+    desc_table_type: DescTableType, nullable: bool
+) -> None:
+    """Preserve every defined statistic while leaving undersized results missing.
+
+    The mixed panel checks all relevant physical-column states in one call. In particular, a
+    one-point column retains its mean and score even though sample volatility and moments are
+    undefined; normality remains missing through nineteen points and becomes ``0.08`` at twenty.
+
+    Args:
+        desc_table_type: Implemented reporting mode under test.
+        nullable: Whether the input uses nullable ``Float64``/``pd.NA`` storage.
+    """
+    returns = _mixed_returns(nullable=nullable)
+    original_returns = returns.copy(deep=True)
+
+    actual = _compute_without_warnings(returns, desc_table_type)
+
+    pd.testing.assert_frame_equal(actual, _expected_table(desc_table_type))
+    pd.testing.assert_frame_equal(returns, original_returns)
+
+
+# =============================================================================
+# Zero-row input contract and zero-column control
+# =============================================================================
+
+
+@pytest.mark.parametrize("desc_table_type", _IMPLEMENTED_MODES)
+@pytest.mark.parametrize("annualize_vol", (False, True), ids=("periodic", "annualized"))
+def test_compute_desc_table_rejects_zero_rows_consistently_across_modes(
+    desc_table_type: DescTableType, annualize_vol: bool
+) -> None:
+    """Raise one descriptive error before reducers or frequency inference run.
+
+    Args:
+        desc_table_type: Implemented reporting mode under test.
+        annualize_vol: Whether the rejected call would otherwise infer a frequency.
+    """
+    returns = _zero_row_input("one-column-frame")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(ValueError, match="^data must contain at least one observation$"):
+            _DESC_TABLE_MODULE.compute_desc_table(
+                df=returns,
+                desc_table_type=desc_table_type,
+                annualize_vol=annualize_vol,
+            )
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    ("named-series", "multi-column-frame", "zero-column-frame"),
+)
+def test_compute_desc_table_rejects_every_zero_row_pandas_shape(input_shape: str) -> None:
+    """Apply the zero-row contract independently of the declared Series/DataFrame shape.
+
+    Args:
+        input_shape: Empty pandas shape whose labels must not alter the public error.
+    """
+    returns = _zero_row_input(input_shape)
+    original_returns = returns.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(ValueError, match="^data must contain at least one observation$"):
+            _DESC_TABLE_MODULE.compute_desc_table(
+                df=returns,
+                desc_table_type=DescTableType.SHORT,
+            )
+
+    if isinstance(returns, pd.DataFrame):
+        pd.testing.assert_frame_equal(returns, cast(pd.DataFrame, original_returns))
+    else:
+        pd.testing.assert_series_equal(returns, cast(pd.Series, original_returns))
+
+
+@pytest.mark.parametrize("desc_table_type", _IMPLEMENTED_MODES)
+def test_compute_desc_table_allows_dated_panels_without_asset_columns(
+    desc_table_type: DescTableType,
+) -> None:
+    """Return the selected empty schema when dates exist but no asset column is declared.
+
+    Args:
+        desc_table_type: Implemented reporting mode whose complete schema is expected.
+    """
+    returns = pd.DataFrame(index=_DATES)
+
+    actual = _compute_without_warnings(returns, desc_table_type)
+
+    assert actual.empty
+    assert actual.index.equals(returns.columns)
+    assert tuple(actual.columns) == _EXPECTED_MODE_COLUMNS[desc_table_type]
+
+
+# =============================================================================
+# Pandas-shape, formatting, and annualization controls
+# =============================================================================
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_compute_desc_table_preserves_named_series_dataframe_consistency(nullable: bool) -> None:
+    """Return the same one-row normality table for equivalent named pandas inputs.
+
+    Args:
+        nullable: Whether the selected one-point history uses nullable ``Float64`` storage.
+    """
+    frame = _mixed_returns(nullable=nullable).filter(items=[_ONE_OBSERVATION])
+    series = cast(pd.Series, frame[_ONE_OBSERVATION])
+    original_frame = frame.copy(deep=True)
+    original_series = series.copy(deep=True)
+
+    frame_result = _compute_without_warnings(frame, DescTableType.WITH_NORMAL_PVAL)
+    series_result = _compute_without_warnings(series, DescTableType.WITH_NORMAL_PVAL)
+
+    expected = _expected_table(DescTableType.WITH_NORMAL_PVAL).filter(
+        items=[_ONE_OBSERVATION], axis="index"
+    )
+    pd.testing.assert_frame_equal(frame_result, expected)
+    pd.testing.assert_frame_equal(series_result, expected)
+    pd.testing.assert_frame_equal(frame, original_frame)
+    pd.testing.assert_series_equal(series, original_series)
+
+
+def test_compute_desc_table_preserves_custom_formats_at_sample_boundaries() -> None:
+    """Apply caller formats to defined and undefined statistics without warning.
+
+    A two-point sample has mean one, sample standard deviation ``sqrt(2)``, zero skewness, and
+    excess kurtosis ``-2``. The custom formats must affect those values while the normality
+    result remains the established ``nan`` representation.
+    """
+    returns = _mixed_returns(nullable=False).filter(items=[_TWO_OBSERVATIONS])
+
+    actual = _compute_without_warnings(
+        returns,
+        DescTableType.WITH_NORMAL_PVAL,
+        var_format="{:.3f}",
+        norm_variable_display_type="{:.2f}",
+    )
+
+    expected = pd.DataFrame(
+        {
+            "Avg": ("1.000",),
+            "Std": ("1.414",),
+            "Skew": ("0.00",),
+            "Kurt": ("-2.00",),
+            "P-val": ("nan",),
+        },
+        index=pd.Index([_TWO_OBSERVATIONS]),
+    )
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_compute_desc_table_preserves_monthly_annualization_and_tstat_formula() -> None:
+    """Keep existing annualization and optional t-statistics for eligible samples.
+
+    Monthly frequency multiplies each mean by 12 and each sample standard deviation by
+    ``sqrt(12)``. The displayed t-statistic remains the accepted ``12 * mean / annualized std``;
+    this regression establishes sample eligibility without changing that separate convention.
+    """
+    returns = _mixed_returns(nullable=False)
+
+    actual = _compute_without_warnings(
+        returns,
+        DescTableType.SHORT,
+        annualize_vol=True,
+        is_add_tstat=True,
+    )
+
+    expected = pd.DataFrame(
+        {
+            "Avg": ("1.00", "1.00", "1.00", "1.00", "1.00", "1.00", "nan"),
+            "Std An": ("nan", "4.90", "7.48", "10.14", "19.49", "22.05", "nan"),
+            "T-stat": ("nan", "2.4", "1.6", "1.2", "0.6", "0.5", "nan"),
+        },
+        index=pd.Index(_ASSETS),
+    )
+    pd.testing.assert_frame_equal(actual, expected)


### PR DESCRIPTION
## What changed

Define deterministic zero-row rejection and warning-free per-statistic sample minima while preserving every descriptive statistic that remains mathematically defined.

Zero-row pandas inputs previously produced warnings and mode-dependent partial results or incidental exceptions, while undersized dated columns passed into NumPy/SciPy reducers and emitted sample-size warnings even when their still-defined neighboring statistics could be retained.

## Behavior

`compute_desc_table()` now raises `ValueError: data must contain at least one observation` for zero-row Series and DataFrames. For dated panels, sample standard deviation, skewness, and kurtosis require two non-missing observations, and the displayed normality p-value requires 20; undersized results use the existing formatted missing value while means, positive probabilities, extrema, quantiles, medians, last values, and ranks remain available whenever defined. Public signatures and sufficient-sample formulas are unchanged, and the accepted legacy compatibility path inherits the same canonical behavior.

## Regression evidence

Before the fix, the new boundary module produced `43 failed, 9 passed`, reproducing one-observation NumPy warnings, undersized SciPy normality warnings, and inconsistent zero-row outcomes. The deterministic mixed panel independently specifies one, two, seven, eight, nineteen, twenty, and all-missing column expectations under ordinary and nullable floating dtypes. After the fix, the complete focused descriptive-table, identity, core-API, and module-layout matrix passes all `342` cases without application warnings.

## Verification

- Changed-line Ruff: zero violations.
- Changed-line Pyright: zero diagnostics (four inherited or indirect diagnostics excluded).
- Focused descriptive-table, identity, core-API, and module-layout checks: `342 passed`.
- Complete `src/qis/perfstats/tests/` suite: `439 passed`.
- Sphinx warning-as-error build: passed.
- Full `src/qis/` suite: `1917 passed`, with 16 known third-party seaborn/Matplotlib warnings.
- Public-API synchronization: current at 406 names.
- Dependency and committed-diff checks: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/desc_table.py`, and `src/qis/perfstats/tests/desc_table_sample_boundaries_test.py`.

Out of scope: This PR does not change public signatures or exports, sufficient-sample calculations, positive-probability denominators, score ties, quantile interpolation, optional t-statistic formula/sign handling, annualization inference, constant finite-column moment policy, dependencies, or unrelated plotting code.

## Checklist

- [ ] Tests cover the changed public behavior or defect.
- [ ] Point-in-time code uses no observations later than the decision time.
- [ ] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [ ] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [ ] The changed-lines ruff gate and production docstring gate pass.
- [ ] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [ ] New runtime dependencies or public-signature changes are called out explicitly.