### PR TITLE
fix: align displayed t-statistic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Aligned descriptive-table and legend t-statistics with the signed sample mean divided by its
+  standard error, independently of volatility annualization, and made undefined legend samples
+  warning-free.
+
 ## [5.20.0] - 2026-08-29
 
 ### Added

--- a/src/qis/perfstats/desc_table.py
+++ b/src/qis/perfstats/desc_table.py
@@ -9,9 +9,8 @@ value. Values come back as formatted strings because the table renderer takes th
 
 ``annualize_vol`` scales the standard deviation by the square root of the factor inferred from
 the index via ``infer_annualisation_factor_from_df``, reporting ``STD_AN`` rather than ``STD``.
-``is_add_tstat`` divides the mean by that volatility, nan unless both adjusted mean and
-volatility are positive; with ``annualize_vol`` off ``an_factor`` is 1.0, so neither side is
-annualised. Risk-adjusted statistics are ``perf_stats.py``.
+``is_add_tstat`` reports the signed sample mean divided by its standard error, independently of
+whether the volatility column is annualised. Risk-adjusted statistics are ``perf_stats.py``.
 """
 # packages
 import numpy as np
@@ -82,6 +81,34 @@ def _reduce_observed(
     return values
 
 
+def compute_sample_mean_tstat(
+        mean: np.ndarray,
+        sample_std: np.ndarray,
+        observation_counts: np.ndarray) -> np.ndarray:
+    """Compute signed one-sample t-statistics from column summaries.
+
+    Args:
+        mean: Sample mean for each column.
+        sample_std: Sample standard deviation with ``ddof=1`` for each column.
+        observation_counts: Non-missing sample size for each column.
+
+    Returns:
+        Mean divided by its standard error, with NaN for undersized or zero-volatility samples.
+    """
+    # Sample inference uses observed counts and is independent of display annualization.
+    eligible_columns = (
+        np.greater_equal(observation_counts, 2)
+        & np.greater(sample_std, 0.0)
+        & np.isfinite(sample_std)
+    )
+    return np.divide(
+        mean * np.sqrt(observation_counts),
+        sample_std,
+        out=np.full_like(mean, np.nan, dtype=float),
+        where=eligible_columns,
+    )
+
+
 def _add_moment_columns(
         descriptive_table: pd.DataFrame,
         data: np.ndarray,
@@ -139,8 +166,8 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
         var_format: format applied to the statistics
         annualize_vol: report volatility per annum rather than per period; reduced modes omit
             the volatility column selected by this convention
-        is_add_tstat: add the t-statistic of the mean when adjusted mean and volatility are
-            positive; otherwise report the formatted missing value
+        is_add_tstat: add the signed sample mean divided by its standard error; samples with fewer
+            than two observations or non-positive sample volatility remain formatted as missing
         norm_variable_display_type: format applied to the t-statistic
 
     Returns:
@@ -164,6 +191,7 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
 
     # Normalize nullable pandas values so numerical reducers receive np.nan rather than pd.NA.
     data_np = df.to_numpy(dtype=float, na_value=np.nan)
+    observation_counts = np.sum(np.logical_not(np.isnan(data_np)), axis=0)
     # Skip all-missing dated columns so undefined base statistics remain NaN without warnings.
     mean = _reduce_observed(data_np, lambda values: np.nanmean(values, axis=0))
     std = _reduce_observed(
@@ -185,15 +213,11 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
     descriptive_table[volatility_column] = [var_format.format(x) for x in vol]
 
     if is_add_tstat:
-        an_mean = an_factor * mean
-        # A zero-volatility sample has no defined displayed statistic.
-        tstats = np.divide(
-            an_mean, vol,
-            out=np.full_like(an_mean, np.nan, dtype=float),
-            where=np.logical_and(
-                np.greater(an_mean, 0.0),
-                np.greater(vol, 0.0),
-            ),
+        # Keep inference signed and sample-based even when volatility is displayed annually.
+        tstats = compute_sample_mean_tstat(
+            mean=mean,
+            sample_std=std,
+            observation_counts=observation_counts,
         )
         descriptive_table[PerfStat.T_STAT.to_str()] = [norm_variable_display_type.format(x) for x in tstats]
 

--- a/src/qis/perfstats/tests/desc_table_all_missing_test.py
+++ b/src/qis/perfstats/tests/desc_table_all_missing_test.py
@@ -361,9 +361,9 @@ def test_compute_desc_table_all_missing_column_preserves_custom_formats_and_tsta
     """Format defined neighboring statistics while retaining undefined missing statistics.
 
     The finite control ``1, ..., 8`` has mean 4.5, sample standard deviation ``sqrt(6)``, and
-    t-statistic ``4.5 / sqrt(6) = 1.837117...`` under the established non-annualized convention.
-    The all-missing asset has none of those statistics, and custom formatting must not turn its
-    missing representations into values or warnings.
+    standard error ``sqrt(6) / sqrt(8)``. Its t-statistic is therefore
+    ``4.5 * sqrt(8) / sqrt(6) = 5.196152...``. The all-missing asset has none of those statistics,
+    and custom formatting must not turn its missing representations into values or warnings.
     """
     returns = pd.DataFrame(
         {
@@ -377,7 +377,7 @@ def test_compute_desc_table_all_missing_column_preserves_custom_formats_and_tsta
         {
             'Avg': ('4.500', 'nan'),
             'Std': ('2.449', 'nan'),
-            'T-stat': ('1.837', 'nan'),
+            'T-stat': ('5.196', 'nan'),
         },
         index=[_FINITE_ASSET, _ALL_MISSING_ASSET],
     )

--- a/src/qis/perfstats/tests/desc_table_sample_boundaries_test.py
+++ b/src/qis/perfstats/tests/desc_table_sample_boundaries_test.py
@@ -395,11 +395,12 @@ def test_compute_desc_table_preserves_custom_formats_at_sample_boundaries() -> N
 
 
 def test_compute_desc_table_preserves_monthly_annualization_and_tstat_formula() -> None:
-    """Keep existing annualization and optional t-statistics for eligible samples.
+    """Annualize volatility without changing sample-mean t-statistics.
 
     Monthly frequency multiplies each mean by 12 and each sample standard deviation by
-    ``sqrt(12)``. The displayed t-statistic remains the accepted ``12 * mean / annualized std``;
-    this regression establishes sample eligibility without changing that separate convention.
+    ``sqrt(12)``. The t-statistic instead divides each mean by ``sample std / sqrt(n)`` and is
+    independent of that display choice. The eligible sample sizes two, seven, eight, nineteen,
+    and twenty therefore produce rounded statistics 1.0, 1.2, 1.0, 0.8, and 0.7.
     """
     returns = _mixed_returns(nullable=False)
 
@@ -414,7 +415,7 @@ def test_compute_desc_table_preserves_monthly_annualization_and_tstat_formula() 
         {
             "Avg": ("1.00", "1.00", "1.00", "1.00", "1.00", "1.00", "nan"),
             "Std An": ("nan", "4.90", "7.48", "10.14", "19.49", "22.05", "nan"),
-            "T-stat": ("nan", "2.4", "1.6", "1.2", "0.6", "0.5", "nan"),
+            "T-stat": ("nan", "1.0", "1.2", "1.0", "0.8", "0.7", "nan"),
         },
         index=pd.Index(_ASSETS),
     )

--- a/src/qis/perfstats/tests/desc_table_tstat_boundaries_test.py
+++ b/src/qis/perfstats/tests/desc_table_tstat_boundaries_test.py
@@ -1,11 +1,12 @@
-"""Regression coverage for zero-volatility descriptive t-statistic boundaries.
+"""Regression coverage for descriptive-table t-statistic conventions and boundaries.
 
-``compute_desc_table`` conditionally adds a display statistic based on adjusted mean and
-volatility. A constant history has no usable volatility denominator, so its statistic should use
-the established ``nan`` display without emitting a divide-by-zero warning. The deterministic
-panel below covers positive, zero, negative, and ragged constants alongside a finite positive
-control in periodic and monthly annualized modes. Named Series/DataFrame consistency and caller
-ownership are checked separately.
+``compute_desc_table`` labels its optional statistic as a t-statistic of the sample mean. It must
+therefore divide the mean by its standard error, retain the sign, and depend on the non-missing
+sample count rather than the displayed volatility's annualization. A constant or undersized
+history has no usable standard error and should use the established ``nan`` display without a
+warning. The mixed panel below exercises all of those states simultaneously under periodic and
+monthly annualized display conventions. Named Series/DataFrame consistency and caller ownership
+are checked separately.
 """
 
 import warnings
@@ -48,6 +49,9 @@ _ASSETS = pd.Index(
         'Zero Constant',
         'Negative Constant',
         'Positive Variable',
+        'Negative Variable',
+        'Zero Mean Variable',
+        'Ragged Positive Variable',
         'Ragged Positive Constant',
     ],
     name='Asset',
@@ -67,6 +71,9 @@ def _tstat_boundary_returns() -> pd.DataFrame:
             'Zero Constant': [0.0, 0.0, 0.0, 0.0],
             'Negative Constant': [-2.0, -2.0, -2.0, -2.0],
             'Positive Variable': [1.0, 2.0, 3.0, 4.0],
+            'Negative Variable': [-1.0, -2.0, -3.0, -4.0],
+            'Zero Mean Variable': [-1.0, 1.0, -1.0, 1.0],
+            'Ragged Positive Variable': [1.0, np.nan, 2.0, 3.0],
             'Ragged Positive Constant': [2.0, np.nan, 2.0, 2.0],
         },
         index=_DATES,
@@ -75,23 +82,37 @@ def _tstat_boundary_returns() -> pd.DataFrame:
 
 def _expected_table(
         volatility_label: str,
-        variable_volatility: str,
-        variable_tstat: str) -> pd.DataFrame:
+        variable_volatilities: tuple[str, str, str, str]) -> pd.DataFrame:
     """Build the exact display table from independently calculated strings.
 
     Args:
         volatility_label: Periodic or annualized output-column label.
-        variable_volatility: Displayed volatility for the finite control.
-        variable_tstat: Displayed statistic for the finite control.
+        variable_volatilities: Displayed volatility for the positive, negative, zero-mean, and
+            ragged variable histories.
 
     Returns:
         Complete expected table for all constant boundaries and the finite control.
     """
     return pd.DataFrame(
         {
-            'Avg': ['2.00', '0.00', '-2.00', '2.50', '2.00'],
-            volatility_label: ['0.00', '0.00', '0.00', variable_volatility, '0.00'],
-            'T-stat': ['nan', 'nan', 'nan', variable_tstat, 'nan'],
+            'Avg': ['2.00', '0.00', '-2.00', '2.50', '-2.50', '0.00', '2.00', '2.00'],
+            volatility_label: [
+                '0.00',
+                '0.00',
+                '0.00',
+                *variable_volatilities,
+                '0.00',
+            ],
+            'T-stat': [
+                'nan',
+                'nan',
+                'nan',
+                '3.873',
+                '-3.873',
+                '0.000',
+                '3.464',
+                'nan',
+            ],
         },
         index=_ASSETS,
     )
@@ -125,10 +146,10 @@ def _compute_without_warnings(
 # =============================================================================
 
 @pytest.mark.parametrize(
-    ('annualize_vol', 'volatility_label', 'variable_volatility', 'variable_tstat'),
+    ('annualize_vol', 'volatility_label', 'variable_volatilities'),
     [
-        (False, 'Std', '1.29', '1.936'),
-        (True, 'Std An', '4.47', '6.708'),
+        (False, 'Std', ('1.29', '1.29', '1.15', '1.00')),
+        (True, 'Std An', ('4.47', '4.47', '4.00', '3.46')),
     ],
 )
 @pytest.mark.parametrize(
@@ -139,22 +160,21 @@ def _compute_without_warnings(
 def test_compute_desc_table_returns_undefined_tstat_for_zero_volatility(
         annualize_vol: bool,
         volatility_label: str,
-        variable_volatility: str,
-        variable_tstat: str,
+        variable_volatilities: tuple[str, str, str, str],
         use_nullable_dtype: bool) -> None:
-    """Return undefined constant statistics while preserving the finite ratio exactly.
+    """Apply the signed sample-mean statistic independently to every column state.
 
     For the control ``[1, 2, 3, 4]``, the mean is 2.5 and sample volatility is
-    ``sqrt(5 / 3)``. The periodic ratio is therefore 1.936491.... Monthly annualization gives
-    volatility ``sqrt(12) * sqrt(5 / 3) = sqrt(20)`` and adjusted mean 30, producing
-    ``30 / sqrt(20) = 6.708204...``. Every constant has zero volatility and an undefined
-    displayed statistic, including the ragged positive constant.
+    ``sqrt(5 / 3)``. Its standard error is ``sqrt(5 / 3) / sqrt(4)``, so its t-statistic is
+    ``sqrt(15) = 3.872983...``; the negative mirror keeps the opposite sign. The zero-mean
+    variable has statistic zero, and the three-point variable has statistic
+    ``2 * sqrt(3) = 3.464101...``. Annualization changes only the displayed volatility. Every
+    constant has zero volatility and an undefined statistic, including the ragged constant.
 
     Args:
         annualize_vol: Whether to test the periodic or monthly annualized calculation.
         volatility_label: Expected output label for the selected volatility convention.
-        variable_volatility: Expected formatted finite-control volatility.
-        variable_tstat: Expected formatted finite-control statistic.
+        variable_volatilities: Expected formatted variable-column volatilities.
         use_nullable_dtype: Whether to exercise pandas ``Float64`` and ``pd.NA`` inputs.
     """
     returns = _tstat_boundary_returns()
@@ -164,7 +184,7 @@ def test_compute_desc_table_returns_undefined_tstat_for_zero_volatility(
 
     actual = _compute_without_warnings(returns, annualize_vol)
 
-    expected = _expected_table(volatility_label, variable_volatility, variable_tstat)
+    expected = _expected_table(volatility_label, variable_volatilities)
     pd.testing.assert_frame_equal(actual, expected)
     pd.testing.assert_frame_equal(returns, original_returns)
 

--- a/src/qis/plots/tests/legend_tstat_boundaries_test.py
+++ b/src/qis/plots/tests/legend_tstat_boundaries_test.py
@@ -1,0 +1,240 @@
+"""Regression coverage for public legend t-statistic conventions and boundaries.
+
+``LegendStats.TSTAT`` and ``LegendStats.AVG_STD_TSTAT`` promise a t-statistic of the sample mean,
+so both public plotting paths must use the signed mean divided by its standard error. The statistic
+depends on each column's non-missing sample count, while zero-volatility, one-observation, and
+all-missing histories remain undefined without warnings. One deliberately ordered panel combines
+every relevant state so vectorized or shared legend logic cannot let one column affect another.
+Matched ordinary and nullable floating inputs, named Series/DataFrame consistency, exact legend
+text, and caller ownership complete the public contract.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+# qis
+import qis.plots.time_series as time_series_module
+from qis.plots.utils import LegendStats
+
+
+class _TimeSeriesModuleProtocol(Protocol):
+    """Typed test-side interface for the public plotting function exercised below."""
+
+    def plot_time_series(
+        self,
+        df: pd.DataFrame | pd.Series,
+        *,
+        x_date_freq: None,
+        legend_stats: LegendStats,
+        var_format: str,
+        ax: Axes,
+    ) -> Figure | None:
+        """Plot a time series with the selected legend statistics.
+
+        Args:
+            df: Series or DataFrame supplied to the public plot.
+            x_date_freq: Disabled date-axis formatting for this focused legend test.
+            legend_stats: Summary-statistic mode displayed in the legend.
+            var_format: Display format for mean and standard-deviation values.
+            ax: Matplotlib axis receiving the plot.
+
+        Returns:
+            The created figure, or None when the caller supplies ``ax``.
+        """
+        raise NotImplementedError
+
+
+_TIME_SERIES_MODULE = cast(_TimeSeriesModuleProtocol, time_series_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent expectations
+# =============================================================================
+
+_DATES = pd.date_range("2024-01-31", periods=6, freq="ME")
+
+_POSITIVE_VARIABLE = "Positive Variable"
+_RAGGED_POSITIVE_VARIABLE = "Ragged Positive Variable"
+_NEGATIVE_VARIABLE = "Negative Variable"
+_ZERO_MEAN_VARIABLE = "Zero Mean Variable"
+_POSITIVE_CONSTANT = "Positive Constant"
+_ZERO_CONSTANT = "Zero Constant"
+_NEGATIVE_CONSTANT = "Negative Constant"
+_RAGGED_POSITIVE_CONSTANT = "Ragged Positive Constant"
+_ONE_OBSERVATION = "One Observation"
+_ALL_MISSING = "All Missing"
+
+_TSTAT_LINES = (
+    "Positive Variable: t-stat=3.87",
+    "Ragged Positive Variable: t-stat=3.46",
+    "Negative Variable: t-stat=-3.87",
+    "Zero Mean Variable: t-stat=0.00",
+    "Positive Constant: t-stat=nan",
+    "Zero Constant: t-stat=nan",
+    "Negative Constant: t-stat=nan",
+    "Ragged Positive Constant: t-stat=nan",
+    "One Observation: t-stat=nan",
+    "All Missing: t-stat=nan",
+)
+
+_AVG_STD_TSTAT_LINES = (
+    "Positive Variable: avg=2.50, std=1.29, t-stat=3.87",
+    "Ragged Positive Variable: avg=2.00, std=1.00, t-stat=3.46",
+    "Negative Variable: avg=-2.50, std=1.29, t-stat=-3.87",
+    "Zero Mean Variable: avg=0.00, std=1.15, t-stat=0.00",
+    "Positive Constant: avg=2.00, std=0.00, t-stat=nan",
+    "Zero Constant: avg=0.00, std=0.00, t-stat=nan",
+    "Negative Constant: avg=-2.00, std=0.00, t-stat=nan",
+    "Ragged Positive Constant: avg=2.00, std=0.00, t-stat=nan",
+    "One Observation: avg=1.00, std=nan, t-stat=nan",
+    "All Missing: avg=nan, std=nan, t-stat=nan",
+)
+
+
+def _mixed_values(*, nullable: bool) -> pd.DataFrame:
+    """Create all t-statistic column states in deliberate reporting order.
+
+    The complete positive sample has mean 2.5, sample standard deviation ``sqrt(5 / 3)``, and
+    t-statistic ``sqrt(15)``. The three-point ragged sample has mean 2, sample standard deviation
+    1, and t-statistic ``2 * sqrt(3)``. Its negative mirror and the zero-mean variable establish
+    signed behavior, while constant and undersized samples establish undefined boundaries.
+
+    Args:
+        nullable: Whether to store values as pandas nullable ``Float64``/``pd.NA``.
+
+    Returns:
+        Six-date panel containing every materially different legend state.
+    """
+    values = pd.DataFrame(
+        {
+            _POSITIVE_VARIABLE: (1.0, 2.0, 3.0, 4.0, np.nan, np.nan),
+            _RAGGED_POSITIVE_VARIABLE: (1.0, np.nan, 2.0, np.nan, 3.0, np.nan),
+            _NEGATIVE_VARIABLE: (-1.0, -2.0, -3.0, -4.0, np.nan, np.nan),
+            _ZERO_MEAN_VARIABLE: (-1.0, 1.0, -1.0, 1.0, np.nan, np.nan),
+            _POSITIVE_CONSTANT: (2.0, 2.0, 2.0, 2.0, np.nan, np.nan),
+            _ZERO_CONSTANT: (0.0, 0.0, 0.0, 0.0, np.nan, np.nan),
+            _NEGATIVE_CONSTANT: (-2.0, -2.0, -2.0, -2.0, np.nan, np.nan),
+            _RAGGED_POSITIVE_CONSTANT: (2.0, np.nan, 2.0, np.nan, 2.0, np.nan),
+            _ONE_OBSERVATION: (np.nan, np.nan, 1.0, np.nan, np.nan, np.nan),
+            _ALL_MISSING: (np.nan,) * len(_DATES),
+        },
+        index=_DATES,
+    )
+    if nullable:
+        return values.astype(pd.Float64Dtype())
+    return values
+
+
+def _legend_lines(data: pd.DataFrame | pd.Series, legend_stats: LegendStats) -> tuple[str, ...]:
+    """Draw through the public plotting API and return its exact legend text.
+
+    Args:
+        data: Time series whose summary statistics are displayed.
+        legend_stats: Public legend mode under test.
+
+    Returns:
+        Legend entries in input-column order.
+    """
+    figure, axis = plt.subplots()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _TIME_SERIES_MODULE.plot_time_series(
+                data,
+                x_date_freq=None,
+                legend_stats=legend_stats,
+                var_format="{:.2f}",
+                ax=axis,
+            )
+        legend = axis.get_legend()
+        assert legend is not None
+        return tuple(text.get_text() for text in legend.get_texts())
+    finally:
+        plt.close(figure)
+
+
+# =============================================================================
+# Mixed-panel numerical and undefined-value contract
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("legend_stats", "expected"),
+    (
+        (LegendStats.TSTAT, _TSTAT_LINES),
+        (LegendStats.AVG_STD_TSTAT, _AVG_STD_TSTAT_LINES),
+    ),
+)
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_plot_time_series_applies_signed_sample_mean_tstats_without_warnings(
+    legend_stats: LegendStats,
+    expected: tuple[str, ...],
+    nullable: bool,
+) -> None:
+    """Display exact signed statistics and undefined boundaries in one public call.
+
+    Args:
+        legend_stats: T-statistic-only or mean/standard-deviation/t-statistic legend mode.
+        expected: Independently specified legend entries for that mode.
+        nullable: Whether the input uses nullable ``Float64``/``pd.NA`` storage.
+    """
+    values = _mixed_values(nullable=nullable)
+    original_values = values.copy(deep=True)
+
+    actual = _legend_lines(values, legend_stats)
+
+    assert actual == expected
+    pd.testing.assert_frame_equal(values, original_values)
+
+
+# =============================================================================
+# Named Series/DataFrame consistency
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("legend_stats", "expected"),
+    (
+        (LegendStats.TSTAT, (_TSTAT_LINES[0],)),
+        (LegendStats.AVG_STD_TSTAT, (_AVG_STD_TSTAT_LINES[0],)),
+    ),
+)
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_plot_time_series_tstat_named_series_matches_dataframe(
+    legend_stats: LegendStats,
+    expected: tuple[str, ...],
+    nullable: bool,
+) -> None:
+    """Return identical legend text for equivalent named Series and one-column frames.
+
+    Args:
+        legend_stats: T-statistic-only or mean/standard-deviation/t-statistic legend mode.
+        expected: Independently specified one-entry legend text.
+        nullable: Whether the input uses nullable ``Float64``/``pd.NA`` storage.
+    """
+    series = pd.Series(
+        (1.0, 2.0, 3.0, 4.0, np.nan, np.nan),
+        index=_DATES,
+        name=_POSITIVE_VARIABLE,
+    )
+    if nullable:
+        series = series.astype(pd.Float64Dtype())
+    frame = series.to_frame()
+    original_series = series.copy(deep=True)
+    original_frame = frame.copy(deep=True)
+
+    frame_result = _legend_lines(frame, legend_stats)
+    series_result = _legend_lines(series, legend_stats)
+
+    assert frame_result == expected
+    assert series_result == expected
+    assert series_result == frame_result
+    pd.testing.assert_frame_equal(frame, original_frame)
+    pd.testing.assert_series_equal(series, original_series)

--- a/src/qis/plots/utils.py
+++ b/src/qis/plots/utils.py
@@ -52,6 +52,7 @@ import qis.utils.df_ops as dfo
 import qis.utils.df_str as dfs
 import qis.utils.df_freq as dff
 import qis.utils.struct_ops as sop
+from qis.perfstats.desc_table import compute_sample_mean_tstat
 from qis.plots.table import ROW_HIGHT, COLUMN_WIDTH, FIRST_COLUMN_WIDTH
 
 # public API of this module: everything else is internal plotting machinery and is
@@ -793,6 +794,36 @@ class LegendStats(Enum):
     FIRST_MIN_MAX_LAST = 27
 
 
+def _compute_legend_tstat_components(
+        data_column: pd.Series,
+        nan_display: float) -> Tuple[float, float, float]:
+    """Compute warning-free legend summaries for t-statistic modes.
+
+    Args:
+        data_column: One plotted series, possibly containing missing values.
+        nan_display: Configured display value for an undefined statistic.
+
+    Returns:
+        Sample mean, sample standard deviation, and signed t-statistic.
+    """
+    observed = data_column.dropna().to_numpy(dtype=float)
+    if observed.size == 0:
+        return nan_display, nan_display, nan_display
+
+    avg = float(np.mean(observed))
+    # Guard ddof=1 before reduction so undersized legends remain warning-free.
+    if observed.size < 2:
+        return avg, nan_display, nan_display
+
+    std = float(np.std(observed, ddof=1))
+    tstat = compute_sample_mean_tstat(
+        mean=np.asarray([avg]),
+        sample_std=np.asarray([std]),
+        observation_counts=np.asarray([observed.size]),
+    )[0]
+    return avg, std, float(tstat)
+
+
 def get_legend_lines(data: Union[pd.DataFrame, pd.Series],
                      legend_stats: LegendStats = LegendStats.NONE,
                      var_format: str = '{:.0f}',
@@ -916,26 +947,16 @@ def get_legend_lines(data: Union[pd.DataFrame, pd.Series],
 
     elif legend_stats == LegendStats.TSTAT:
         legend_lines = []
-        for column in data.columns:
-            data_column = data[column]
-            if np.all(np.isnan(data_column)):
-                tstat = nan_display
-            else:
-                avg = np.nanmean(data_column)
-                std = np.nanstd(data_column, ddof=1)
-                tstat = avg / std
+        for column, data_column in data.items():
+            # Use the same signed sample-mean convention as descriptive tables.
+            _, _, tstat = _compute_legend_tstat_components(data_column, nan_display)
             legend_lines.append(f"{column}: t-stat={tstat_format.format(tstat)}")
 
     elif legend_stats == LegendStats.AVG_STD_TSTAT:
         legend_lines = []
-        for column in data.columns:
-            data_column = data[column]
-            if np.all(np.isnan(data_column)):
-                avg, std, tstat = nan_display, nan_display, nan_display
-            else:
-                avg = np.nanmean(data_column)
-                std = np.nanstd(data_column, ddof=1)
-                tstat = avg / std
+        for column, data_column in data.items():
+            # Keep the composite legend's three summaries on one guarded sample.
+            avg, std, tstat = _compute_legend_tstat_components(data_column, nan_display)
             legend_lines.append(f"{column}: avg={var_format.format(avg)}, "
                                 f"std={var_format.format(std)}, "
                                 f"t-stat={tstat_format.format(tstat)}")


### PR DESCRIPTION
## What changed

Align descriptive-table and legend t-statistics with the signed sample mean divided by its standard error, and make undefined legend samples warning-free.

Descriptive tables and legends labeled their output as a t-statistic while reporting mean divided by sample volatility; annualized tables changed that value, negative table statistics were suppressed, and constant or undersized legend samples emitted runtime warnings.

## Behavior

Displays labeled `T-stat` now use `mean * sqrt(nonmissing_count) / sample_std`, retain negative and zero values, and remain independent of display annualization. Samples with fewer than two observations or without positive finite sample volatility display the configured missing value without warnings. Public signatures, defaults, package exports, dependencies, and non-t-statistic reporting behavior are unchanged.

## Regression evidence

- **Fail before:** the approved deterministic matrix produced `14 failed`, covering signed and zero means, ragged sample counts, annualization independence, all-missing neighbors, constant legends, and Series/DataFrame legend behavior.
- **Independent expectation:** literal means, `ddof=1` sample standard deviations, and observed counts—cross-checked with SciPy `ttest_1samp`—give `3.872983346` for `[1, 2, 3, 4]`, `-3.872983346` for its negative mirror, `0.0` for a variable zero-mean sample, and `3.464101615` for the three-observation ragged sample.
- **Pass after:** the focused contract matrix passed all `105` cases; the final combined descriptive-table regressions and complete plots suite passed all `205` cases without application warnings.

## Verification

- Added-file formatting, whitespace, changed-line Ruff, and changed-line Pyright/Pylance: passed with zero PR-attributable findings.
- Focused descriptive-table regressions plus complete `plots` suite: `205 passed`.
- Complete `perfstats` suite: `446 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `1,939 passed, 16 warnings`; all warnings are known third-party Seaborn/Matplotlib deprecations.
- Public API synchronization: current at `409` names; dependency integrity: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/desc_table.py`, `src/qis/perfstats/tests/desc_table_all_missing_test.py`, `src/qis/perfstats/tests/desc_table_sample_boundaries_test.py`, `src/qis/perfstats/tests/desc_table_tstat_boundaries_test.py`, `src/qis/plots/utils.py`, and `src/qis/plots/tests/legend_tstat_boundaries_test.py`.

Out of scope: Public plotting functions currently ignore their documented `var_format` for t-statistics, and several non-t-stat legend modes emit or inconsistently avoid warnings for a single observation. Those separate formatting and cross-mode sample-policy defects are recorded as PRs 53 and 54 rather than expanding this numerical-convention PR.

## Checklist

- [ ] Tests cover the changed public behavior or defect.
- [ ] Point-in-time code uses no observations later than the decision time.
- [ ] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [ ] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [ ] The changed-lines ruff gate and production docstring gate pass.
- [ ] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [ ] New runtime dependencies or public-signature changes are called out explicitly.