### PR TITLE
fix: align append schemas and empty providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Made `append_time_series()` preserve the newer provider's names, column order, axis metadata,
+  and declared empty schema while aligning compatible older history and handling unavailable
+  providers deterministically.
 - Validated nonzero-leverage financing values and date-axis compatibility before alignment,
   preserving explicit missing observations and compatible timezone-aware funding.
 

--- a/src/qis/perfstats/tests/timeseries_append_contracts_test.py
+++ b/src/qis/perfstats/tests/timeseries_append_contracts_test.py
@@ -1,0 +1,469 @@
+"""Regression tests for plain time-series append input contracts.
+
+``append_time_series`` combines two providers whose roles are asymmetric: the newer provider
+declares the public result schema, while the older provider may supply a compatible historical
+prefix. These deterministic tests cover Series names, DataFrame labels and axis metadata,
+overlap diagnostics, nullable missing data, empty and zero-column providers, validation,
+warnings, and caller/result ownership. Literal expected objects keep the contract independent of
+the production splice implementation.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.perfstats.timeseries_bfill import append_time_series
+
+
+# =============================================================================
+# Shared deterministic timeline and conversion helpers
+# =============================================================================
+
+_DAILY_DATES = pd.date_range("2024-01-01", periods=6, freq="D")
+_NEWER_COLUMNS = ("newer_only", "ragged", "shared", "older_only")
+_OLDER_COLUMNS = ("older_only", "shared", "ragged")
+_NEWER_INDEX_NAME = "Newer date"
+_NEWER_COLUMNS_NAME = "Newer asset"
+
+
+def _as_float_dtype(frame: pd.DataFrame, use_nullable: bool) -> pd.DataFrame:
+    """Convert a fresh frame to the requested floating-point representation.
+
+    Args:
+        frame: Frame to convert without modifying its caller-owned source.
+        use_nullable: Use pandas nullable ``Float64`` when true and NumPy ``float64`` otherwise.
+
+    Returns:
+        A converted DataFrame with identical labels and values.
+    """
+    dtype = pd.Float64Dtype() if use_nullable else np.dtype("float64")
+    return frame.astype(dtype)
+
+
+def _as_float_series(series: pd.Series, use_nullable: bool) -> pd.Series:
+    """Convert a fresh Series to the requested floating-point representation.
+
+    Args:
+        series: Series to convert without modifying its caller-owned source.
+        use_nullable: Use pandas nullable ``Float64`` when true and NumPy ``float64`` otherwise.
+
+    Returns:
+        A converted Series with identical labels and values.
+    """
+    dtype = pd.Float64Dtype() if use_nullable else np.dtype("float64")
+    return series.astype(dtype)
+
+
+def _append_frames(
+    newer: pd.DataFrame,
+    older: pd.DataFrame,
+    numerical_check_columns: list[str] | None = None,
+) -> tuple[pd.DataFrame, pd.Series | None]:
+    """Append frames while enforcing warning, caller-ownership, and result-type invariants.
+
+    Args:
+        newer: Newer provider passed to the public function.
+        older: Older provider passed to the public function.
+        numerical_check_columns: Optional ordered overlap-diagnostic selection.
+
+    Returns:
+        The appended DataFrame and optional overlap-difference Series.
+    """
+    original_newer = newer.copy(deep=True)
+    original_older = older.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        if numerical_check_columns is None:
+            actual, actual_diff = append_time_series(df_newer=newer, df_older=older)
+        else:
+            actual, actual_diff = append_time_series(
+                df_newer=newer,
+                df_older=older,
+                numerical_check_columns=numerical_check_columns,
+            )
+
+    assert isinstance(actual, pd.DataFrame)
+    assert actual is not newer
+    assert actual is not older
+    pd.testing.assert_frame_equal(newer, original_newer, check_exact=True)
+    pd.testing.assert_frame_equal(older, original_older, check_exact=True)
+    return actual, actual_diff
+
+
+def _append_series(
+    newer: pd.Series,
+    older: pd.Series,
+    numerical_check_columns: list[str] | None = None,
+) -> tuple[pd.Series, pd.Series | None]:
+    """Append Series while enforcing warning, caller-ownership, and result-type invariants.
+
+    Args:
+        newer: Newer provider passed to the public function.
+        older: Older provider passed to the public function.
+        numerical_check_columns: Optional ordered overlap-diagnostic selection.
+
+    Returns:
+        The appended Series and optional overlap-difference Series.
+    """
+    original_newer = newer.copy(deep=True)
+    original_older = older.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        if numerical_check_columns is None:
+            actual, actual_diff = append_time_series(df_newer=newer, df_older=older)
+        else:
+            actual, actual_diff = append_time_series(
+                df_newer=newer,
+                df_older=older,
+                numerical_check_columns=numerical_check_columns,
+            )
+
+    assert isinstance(actual, pd.Series)
+    assert actual is not newer
+    assert actual is not older
+    pd.testing.assert_series_equal(newer, original_newer, check_exact=True)
+    pd.testing.assert_series_equal(older, original_older, check_exact=True)
+    return actual, actual_diff
+
+
+# =============================================================================
+# Mixed-panel schema, metadata, and diagnostic contract
+# =============================================================================
+
+
+def _make_mixed_inputs(use_nullable: bool) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Construct deliberately reordered providers containing every material column state.
+
+    Args:
+        use_nullable: Use pandas nullable ``Float64`` when true and NumPy ``float64`` otherwise.
+
+    Returns:
+        Newer and older frames with different axis names and with the older columns a reordered
+        subset of the newer declaration.
+    """
+    newer = pd.DataFrame(
+        {
+            "newer_only": (40.0, 50.0, 60.0),
+            "ragged": (np.nan, 50.0, 60.0),
+            "shared": (400.0, 500.0, 600.0),
+            "older_only": (np.nan, np.nan, np.nan),
+        },
+        index=_DAILY_DATES[3:].rename(_NEWER_INDEX_NAME),
+    ).rename_axis(_NEWER_COLUMNS_NAME, axis="columns")
+    older = pd.DataFrame(
+        {
+            "older_only": (1.0, 2.0, 3.0, 4.0, 5.0),
+            "shared": (10.0, 20.0, 30.0, 40.0, 50.0),
+            "ragged": (np.nan, 2.0, 3.0, 4.0, 5.0),
+        },
+        index=_DAILY_DATES[:5].rename("Older date"),
+    ).rename_axis("Older asset", axis="columns")
+    return _as_float_dtype(newer, use_nullable), _as_float_dtype(older, use_nullable)
+
+
+def _make_expected_mixed_result(use_nullable: bool) -> pd.DataFrame:
+    """Return the literal newer-schema splice for the mixed providers.
+
+    Args:
+        use_nullable: Use pandas nullable ``Float64`` when true and NumPy ``float64`` otherwise.
+
+    Returns:
+        The older January 1-3 prefix and newer January 4-6 values in exact newer column order.
+    """
+    expected = pd.DataFrame(
+        {
+            "newer_only": (np.nan, np.nan, np.nan, 40.0, 50.0, 60.0),
+            "ragged": (np.nan, 2.0, 3.0, np.nan, 50.0, 60.0),
+            "shared": (10.0, 20.0, 30.0, 400.0, 500.0, 600.0),
+            "older_only": (1.0, 2.0, 3.0, np.nan, np.nan, np.nan),
+        },
+        index=_DAILY_DATES.rename(_NEWER_INDEX_NAME),
+    ).rename_axis(_NEWER_COLUMNS_NAME, axis="columns")
+    return _as_float_dtype(expected, use_nullable)
+
+
+@pytest.mark.parametrize("use_nullable", (False, True), ids=("float64", "Float64"))
+def test_append_time_series_uses_newer_mixed_panel_schema(use_nullable: bool) -> None:
+    """Use the newer schema while preserving all four material column states.
+
+    The overlap is January 4-5. ``ragged`` has one jointly observed difference of ``45`` and
+    ``shared`` has ``(abs(40 - 400) + abs(50 - 500)) / 2 = 405``. Both one-sided columns have an
+    undefined diagnostic. This single mixed panel prevents one column state from hiding another.
+
+    Args:
+        use_nullable: Exercise NumPy-backed and pandas nullable missing-value representations.
+    """
+    newer, older = _make_mixed_inputs(use_nullable)
+    actual, actual_diff = _append_frames(newer, older, list(_NEWER_COLUMNS))
+    expected_diff = pd.Series(
+        (np.nan, 45.0, 405.0, np.nan),
+        index=pd.Index(_NEWER_COLUMNS, name=_NEWER_COLUMNS_NAME),
+    )
+    expected_diff = _as_float_series(expected_diff, use_nullable)
+
+    pd.testing.assert_frame_equal(
+        actual,
+        _make_expected_mixed_result(use_nullable),
+        check_exact=True,
+        check_freq=False,
+    )
+    assert isinstance(actual_diff, pd.Series)
+    pd.testing.assert_series_equal(actual_diff, expected_diff, check_exact=True)
+
+
+# =============================================================================
+# Series naming and empty-provider contract
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("newer_name", "older_name"),
+    (
+        pytest.param("New asset", "New asset", id="same"),
+        pytest.param("New asset", "Old asset", id="different"),
+        pytest.param("New asset", None, id="older-unnamed"),
+        pytest.param(None, "Old asset", id="newer-unnamed"),
+        pytest.param(None, None, id="both-unnamed"),
+    ),
+)
+@pytest.mark.parametrize("use_nullable", (False, True), ids=("float64", "Float64"))
+def test_append_time_series_uses_exact_newer_series_name(
+    newer_name: str | None,
+    older_name: str | None,
+    use_nullable: bool,
+) -> None:
+    """Interpret compatible older values under the exact newer name, including ``None``.
+
+    Args:
+        newer_name: Public name declared by the newer provider.
+        older_name: Independently varied older provider name.
+        use_nullable: Exercise NumPy-backed and pandas nullable floating-point dtypes.
+    """
+    older = _as_float_series(
+        pd.Series((1.0, 2.0, 3.0), index=_DAILY_DATES[:3], name=older_name),
+        use_nullable,
+    )
+    newer = _as_float_series(
+        pd.Series((30.0, 40.0), index=_DAILY_DATES[2:4], name=newer_name),
+        use_nullable,
+    )
+    expected = _as_float_series(
+        pd.Series((1.0, 2.0, 30.0, 40.0), index=_DAILY_DATES[:4], name=newer_name),
+        use_nullable,
+    )
+    diagnostic_columns = [newer_name] if newer_name is not None else None
+
+    actual, actual_diff = _append_series(newer, older, diagnostic_columns)
+
+    pd.testing.assert_series_equal(actual, expected, check_exact=True, check_freq=False)
+    if newer_name is None:
+        assert actual_diff is None
+    else:
+        expected_diff = _as_float_series(
+            pd.Series((27.0,), index=pd.Index([newer_name])),
+            use_nullable,
+        )
+        assert isinstance(actual_diff, pd.Series)
+        pd.testing.assert_series_equal(actual_diff, expected_diff, check_exact=True)
+
+
+@pytest.mark.parametrize("empty_side", ("older", "newer", "both"))
+@pytest.mark.parametrize("use_nullable", (False, True), ids=("float64", "Float64"))
+def test_append_time_series_handles_empty_series_providers(
+    empty_side: str,
+    use_nullable: bool,
+) -> None:
+    """Return available history under the newer Series declaration when a provider is empty.
+
+    Args:
+        empty_side: Whether the older, newer, or both providers contain no observations.
+        use_nullable: Exercise NumPy-backed and pandas nullable floating-point dtypes.
+    """
+    newer_values = () if empty_side in {"newer", "both"} else (6.0, 4.0, 5.0)
+    newer_index = _DAILY_DATES[:0] if not newer_values else _DAILY_DATES[[5, 3, 4]]
+    older_values = () if empty_side in {"older", "both"} else (3.0, 1.0, 2.0)
+    older_index = _DAILY_DATES[:0] if not older_values else _DAILY_DATES[[2, 0, 1]]
+    newer = _as_float_series(
+        pd.Series(newer_values, index=newer_index, name="New asset"), use_nullable
+    )
+    older = _as_float_series(
+        pd.Series(older_values, index=older_index, name="Old asset"), use_nullable
+    )
+    expected_values = (
+        (4.0, 5.0, 6.0)
+        if older_values == () and newer_values
+        else ((1.0, 2.0, 3.0) if older_values else ())
+    )
+    expected_index = (
+        _DAILY_DATES[:0]
+        if expected_values == ()
+        else (_DAILY_DATES[3:] if older_values == () else _DAILY_DATES[:3])
+    )
+    expected = _as_float_series(
+        pd.Series(expected_values, index=expected_index, name="New asset"),
+        use_nullable,
+    )
+
+    actual, actual_diff = _append_series(newer, older, ["New asset"])
+
+    pd.testing.assert_series_equal(actual, expected, check_exact=True, check_freq=False)
+    assert actual_diff is None
+
+
+# =============================================================================
+# DataFrame empty-provider, zero-column, and validation contract
+# =============================================================================
+
+
+@pytest.mark.parametrize("empty_side", ("older", "newer", "both"))
+@pytest.mark.parametrize("use_nullable", (False, True), ids=("float64", "Float64"))
+def test_append_time_series_handles_empty_dataframe_providers(
+    empty_side: str,
+    use_nullable: bool,
+) -> None:
+    """Preserve the newer declaration across all zero-row DataFrame combinations.
+
+    The newer schema deliberately contains a finite, ragged, and all-missing column together.
+    When newer has no rows, the compatible older subset fills its declared columns and the
+    newer-only column remains missing.
+
+    Args:
+        empty_side: Whether the older, newer, or both providers contain no observations.
+        use_nullable: Exercise NumPy-backed and pandas nullable floating-point dtypes.
+    """
+    columns = ("newer_only", "ragged", "finite", "all_missing")
+    newer_values = {
+        "newer_only": (40.0, 50.0, 60.0),
+        "ragged": (np.nan, 5.0, 6.0),
+        "finite": (4.0, 5.0, 6.0),
+        "all_missing": (np.nan, np.nan, np.nan),
+    }
+    newer = pd.DataFrame(newer_values, index=_DAILY_DATES[[5, 3, 4]])
+    if empty_side in {"newer", "both"}:
+        newer = newer.head(0)
+    newer.index.name = _NEWER_INDEX_NAME
+    newer.columns.name = _NEWER_COLUMNS_NAME
+    older = pd.DataFrame(
+        {
+            "finite": (3.0, 1.0, 2.0),
+            "ragged": (3.0, np.nan, 2.0),
+            "all_missing": (np.nan, np.nan, np.nan),
+        },
+        index=_DAILY_DATES[[2, 0, 1]],
+    )
+    if empty_side in {"older", "both"}:
+        older = older.head(0)
+    newer = _as_float_dtype(newer, use_nullable)
+    older = _as_float_dtype(older, use_nullable)
+
+    if empty_side == "older":
+        expected = newer.sort_index(kind="stable")
+    elif empty_side == "newer":
+        expected = pd.DataFrame(
+            {
+                "newer_only": (np.nan, np.nan, np.nan),
+                "ragged": (np.nan, 2.0, 3.0),
+                "finite": (1.0, 2.0, 3.0),
+                "all_missing": (np.nan, np.nan, np.nan),
+            },
+            index=_DAILY_DATES[:3],
+        )
+        expected.index.name = _NEWER_INDEX_NAME
+        expected.columns.name = _NEWER_COLUMNS_NAME
+    else:
+        expected = newer.copy(deep=True)
+    expected = _as_float_dtype(expected.reindex(columns=list(columns)), use_nullable)
+
+    actual, actual_diff = _append_frames(newer, older, list(columns))
+
+    pd.testing.assert_frame_equal(actual, expected, check_exact=True, check_freq=False)
+    assert actual_diff is None
+
+
+def test_append_time_series_ignores_zero_column_older_provider_dates() -> None:
+    """Ignore dates from an older provider that contains no values to append."""
+    newer = pd.DataFrame({"asset": (2.0, 1.0)}, index=_DAILY_DATES[[2, 1]])
+    older = pd.DataFrame(index=_DAILY_DATES[:2])
+    expected = pd.DataFrame({"asset": (1.0, 2.0)}, index=_DAILY_DATES[1:3])
+
+    actual, actual_diff = _append_frames(newer, older)
+
+    pd.testing.assert_frame_equal(actual, expected, check_exact=True, check_freq=False)
+    assert actual_diff is None
+
+
+def test_append_time_series_rejects_zero_column_newer_provider() -> None:
+    """Reject a newer DataFrame that cannot declare any public result columns."""
+    newer = pd.DataFrame(index=_DAILY_DATES[3:])
+    older = pd.DataFrame({"asset": (1.0, 2.0, 3.0)}, index=_DAILY_DATES[:3])
+
+    with pytest.raises(ValueError, match="df_newer must contain at least one column"):
+        append_time_series(df_newer=newer, df_older=older)
+
+
+@pytest.mark.parametrize("provider", ("newer", "older"))
+def test_append_time_series_rejects_duplicate_columns(provider: str) -> None:
+    """Reject ambiguous duplicate labels before pandas raises an incidental alignment error.
+
+    Args:
+        provider: Provider whose DataFrame contains the duplicate column label.
+    """
+    newer = pd.DataFrame(((4.0, 40.0), (5.0, 50.0)), index=_DAILY_DATES[2:4], columns=("a", "b"))
+    older = pd.DataFrame(
+        ((1.0, 10.0), (2.0, 20.0), (3.0, 30.0)), index=_DAILY_DATES[:3], columns=("a", "b")
+    )
+    duplicate = pd.DataFrame(
+        ((1.0, 10.0), (2.0, 20.0)),
+        index=_DAILY_DATES[:2],
+        columns=("a", "a"),
+    )
+    if provider == "newer":
+        newer = duplicate
+    else:
+        older = duplicate
+
+    with pytest.raises(ValueError, match=rf"df_{provider} columns must be unique"):
+        append_time_series(df_newer=newer, df_older=older)
+
+
+def test_append_time_series_rejects_unknown_diagnostic_column() -> None:
+    """Reject diagnostics outside the newer schema before attempting overlap arithmetic."""
+    newer = pd.DataFrame({"asset": (30.0, 40.0)}, index=_DAILY_DATES[2:4])
+    older = pd.DataFrame({"asset": (1.0, 2.0, 3.0)}, index=_DAILY_DATES[:3])
+
+    with pytest.raises(
+        ValueError, match=r"numerical_check_columns not found in df_newer: \['missing'\]"
+    ):
+        append_time_series(
+            df_newer=newer,
+            df_older=older,
+            numerical_check_columns=["missing"],
+        )
+
+
+def test_append_time_series_preserves_empty_diagnostic_selection() -> None:
+    """Return an empty ordered diagnostic when an overlapping call selects no columns."""
+    newer = pd.DataFrame({"asset": (30.0, 40.0)}, index=_DAILY_DATES[2:4])
+    older = pd.DataFrame({"asset": (1.0, 2.0, 3.0)}, index=_DAILY_DATES[:3])
+
+    _, actual_diff = _append_frames(newer, older, [])
+
+    assert isinstance(actual_diff, pd.Series)
+    expected_diff = pd.Series(index=pd.Index([], dtype="str"), dtype="float64")
+    pd.testing.assert_series_equal(actual_diff, expected_diff, check_exact=True)
+
+
+def test_append_time_series_owns_nonextending_result() -> None:
+    """Return an independent chronological result when older history cannot extend newer data."""
+    newer = pd.DataFrame({"asset": (3.0, 1.0, 2.0)}, index=_DAILY_DATES[[2, 0, 1]])
+    older = pd.DataFrame({"asset": (20.0, 30.0)}, index=_DAILY_DATES[1:3])
+    expected = pd.DataFrame({"asset": (1.0, 2.0, 3.0)}, index=_DAILY_DATES[:3])
+
+    actual, actual_diff = _append_frames(newer, older)
+
+    pd.testing.assert_frame_equal(actual, expected, check_exact=True, check_freq=False)
+    assert actual_diff is None

--- a/src/qis/perfstats/timeseries_bfill.py
+++ b/src/qis/perfstats/timeseries_bfill.py
@@ -19,7 +19,6 @@ from typing import Optional, Union, List, Tuple, cast
 # qis
 import qis.utils.df_ops as dfo
 import qis.utils.np_ops as npo
-import qis.utils.struct_ops as sop
 import qis.perfstats.returns as ret
 import qis.models.linear.ewm as ewm
 from qis.utils.df_ops import df_ffill_negatives
@@ -347,31 +346,54 @@ def append_time_series(df_newer: Union[pd.DataFrame, pd.Series],  # more recent 
     """Append older history before newer data with newer values winning overlaps.
 
     Args:
-        df_newer: Newer Series or DataFrame. Rows are interpreted in increasing index order
-            without modifying the caller's object.
-        df_older: Older object of the same pandas type. Its DataFrame columns must be a subset of
-            the newer columns, and its rows are also interpreted in increasing index order.
+        df_newer: Newer Series or DataFrame. Its Series name or DataFrame columns, axis names,
+            column order, and declared dtypes define the result. Rows are interpreted in
+            increasing index order without modifying the caller's object. A zero-row object may
+            still declare the result, but a DataFrame must contain at least one column.
+        df_older: Older object of the same pandas type. A Series is interpreted under the newer
+            Series name. Nonempty DataFrame columns must be unique and a subset of the newer
+            columns; missing newer columns remain missing in the historical prefix. A zero-row or
+            zero-column older DataFrame is treated as unavailable. Rows are interpreted in
+            increasing index order without modifying the caller's object.
         numerical_check_columns: Columns for which to return mean absolute differences over the
-            aligned overlap. ``None`` skips the diagnostic.
+            aligned overlap. Labels must belong to the newer schema and their requested order is
+            preserved. ``None`` skips the diagnostic.
 
     Returns:
         A chronologically ordered appended object matching the input pandas type, plus the
         optional overlap-difference Series. Newer values take precedence on shared dates;
-        duplicate dates within a provider retain the last supplied observation.
+        duplicate dates within a provider retain the last supplied observation. An unavailable
+        provider returns an independently owned result under the newer declaration and no overlap
+        diagnostic.
 
     Raises:
-        ValueError: If the inputs have different pandas types or their converted columns cannot
-            be aligned.
+        ValueError: If the inputs have different pandas types, the newer DataFrame has no columns,
+            either DataFrame has duplicate columns, older columns fall outside the newer schema,
+            or a diagnostic label falls outside the newer schema.
     """
     is_series = False
+    series_name = None
     if isinstance(df_newer, pd.Series) and isinstance(df_older, pd.Series):
         is_series = True
+        series_name = df_newer.name
         df_newer = df_newer.to_frame()
+        # Series values are structurally compatible regardless of their provider-specific names.
         df_older = df_older.to_frame()
+        df_older.columns = df_newer.columns.copy()
     elif isinstance(df_newer, pd.DataFrame) and isinstance(df_older, pd.DataFrame):
         pass
     else:
         raise ValueError(f"{type(df_older)} not aligned with {type(df_newer)}")
+
+    # Validate provider declarations before endpoint access or pandas alignment can fail indirectly.
+    newer_index_name = df_newer.index.name
+    newer_columns_name = df_newer.columns.name
+    if len(df_newer.columns) == 0:
+        raise ValueError("df_newer must contain at least one column")
+    if not df_newer.columns.is_unique:
+        raise ValueError("df_newer columns must be unique")
+    if not df_older.columns.is_unique:
+        raise ValueError("df_older columns must be unique")
 
     # Row storage order carries no information; boundaries and overlap checks are chronological.
     if not df_newer.index.is_monotonic_increasing:
@@ -379,11 +401,35 @@ def append_time_series(df_newer: Union[pd.DataFrame, pd.Series],  # more recent 
     if not df_older.index.is_monotonic_increasing:
         df_older = df_older.sort_index(kind='stable')
 
-    sop.assert_list_subset(large_list=df_newer.columns.to_list(),
-                           list_sample=df_older.columns.to_list())
+    older_has_no_data = len(df_older.index) == 0 or len(df_older.columns) == 0
+    if not older_has_no_data:
+        missing_older_columns = [column for column in df_older.columns
+                                 if column not in df_newer.columns]
+        if missing_older_columns:
+            raise ValueError(f"df_older columns not found in df_newer: {missing_older_columns}")
+    if numerical_check_columns is not None:
+        missing_numerical_columns = [column for column in numerical_check_columns
+                                     if column not in df_newer.columns]
+        if missing_numerical_columns:
+            raise ValueError("numerical_check_columns not found in df_newer: "
+                             f"{missing_numerical_columns}")
 
-    if df_older.index[0] >= df_newer.index[0]:  # old index is older than new, no need to do anything
-        new_df = df_newer
+    # Start from an owned newer result, then align any usable older provider before splicing.
+    new_df = df_newer.copy()
+    diff = None
+    if not older_has_no_data:
+        df_older = df_older.reindex(columns=df_newer.columns)
+
+    if older_has_no_data:
+        pass
+    elif len(df_newer.index) == 0:
+        # Preserve newer-declared dtypes while filling them from the available older history.
+        new_df = df_newer.reindex(index=df_older.index)
+        new_df.update(df_older)
+        diff = None
+    # No append is needed when the older provider cannot extend the newer history backwards.
+    elif df_older.index[0] >= df_newer.index[0]:
+        new_df = df_newer.copy()
         diff = None
 
     elif df_older.index[-1] >= df_newer.index[0]:  # append
@@ -407,7 +453,11 @@ def append_time_series(df_newer: Union[pd.DataFrame, pd.Series],  # more recent 
     if new_df.index.is_unique is False:  # check if index is unique
         new_df = new_df.iloc[new_df.index.duplicated(keep='last')==False]
 
+    # Restore the newer provider's public metadata after concatenation and duplicate removal.
+    new_df.index.name = newer_index_name
+    new_df.columns.name = newer_columns_name
     if is_series:
-        new_df = new_df.iloc[:, 0]
+        new_df = new_df.iloc[:, 0].copy()
+        new_df.name = series_name
 
     return new_df, diff


### PR DESCRIPTION
## What changed

Make `append_time_series()` use the newer provider's public schema and handle empty providers deterministically while preserving established chronological and newer-precedence behavior.

Differently named Series raised an incidental subset error, unnamed Series returned name `0`, reordered older DataFrame columns controlled output order, newer-only diagnostic columns raised `KeyError`, empty providers raised endpoint `IndexError`, and a nonextending call could return the caller-owned newer object directly.

## Behavior

The newer provider now owns the exact Series name or DataFrame columns, order, axis names, and declared empty schema. Compatible older DataFrame subsets are aligned to that schema; unavailable older data passes through as an owned result; an empty newer declaration accepts compatible older history; and ambiguous zero-column, duplicate-label, or unknown-diagnostic inputs raise descriptive `ValueError`. Public signatures, exports, dependencies, valid same-schema values, chronological sorting, and newer overlap precedence are unchanged.

## Regression evidence

- **Fail before:** the finalized 31-case contract module produced `29 failed, 2 passed` against unchanged accepted main, reproducing the structural, empty-provider, metadata, validation, and ownership defects.
- **Independent expectation:** literal January 1-6 Series and mixed-panel references calculate the older prefix plus newer overlap and exact mean absolute differences of `27`, `45`, and `405`; the panel simultaneously contains shared finite, ragged, older-only, and newer-only columns under ordinary and nullable floating dtypes.
- **Pass after:** all 31 new cases pass, and the focused matrix with the eight accepted PR 28 chronological controls passes all `39` cases.

## Verification

- Added-file formatter, whitespace, changed-line Ruff, and changed-line Pyright/Pylance checks: passed with zero PR-attributable findings.
- Focused append contract and chronology matrix: `39 passed`.
- Complete `perfstats` suite: `549 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2,044 passed, 16 warnings`; all warnings are known third-party Seaborn/Matplotlib deprecations.
- Public API synchronization: current at `409` names; dependency integrity: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/timeseries_bfill.py`, and `src/qis/perfstats/tests/timeseries_append_contracts_test.py`.

Out of scope: Duplicate-date overlap diagnostics are deferred to a separate follow-up. General index-domain and dtype-coercion policy, changes to PR 28's chronological or keep-last output rules, older columns outside the newer schema, and `bfill_timeseries()` are not part of PR 44.

## Checklist

- [ ] Tests cover the changed public behavior or defect.
- [ ] Point-in-time code uses no observations later than the decision time.
- [ ] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [ ] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [ ] The changed-lines ruff gate and production docstring gate pass.
- [ ] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [ ] New runtime dependencies or public-signature changes are called out explicitly.