### PR TITLE
fix: validate return endpoints by mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Applied return-mode-specific endpoint validity in `to_returns()`: ratio and log returns now
+  require finite positive endpoints, while difference and level modes accept finite signed levels.
 - Made `append_time_series()` preserve the newer provider's names, column order, axis metadata,
   and declared empty schema while aligning compatible older history and handling unavailable
   providers deterministically.

--- a/src/qis/perfstats/config.py
+++ b/src/qis/perfstats/config.py
@@ -32,12 +32,14 @@ class ReturnTypes(Enum):
     ``is_log_returns`` map onto LOG and RELATIVE.
 
     Attributes:
-        RELATIVE: arithmetic return, S1 / S0 - 1; additive across assets within a period
-        LOG: log return, ln(S1 / S0); additive across periods for one asset
-        DIFFERENCE: absolute change, S1 - S0; for series already in rate or spread space,
-            where a ratio is meaningless
-        LEVEL: the end-of-period level itself, S1
-        LEVEL0: the start-of-period level, S0
+        RELATIVE: arithmetic return, S1 / S0 - 1, for finite positive endpoints; additive across
+            assets within a period
+        LOG: log return, ln(S1 / S0), for finite positive endpoints; additive across periods for
+            one asset
+        DIFFERENCE: absolute change, S1 - S0, for finite signed series already in rate or spread
+            space, where a ratio is meaningless
+        LEVEL: the finite signed end-of-period level itself, S1
+        LEVEL0: the finite signed start-of-period level, S0
     """
     RELATIVE = 'Relative'  # =S1/S0-1
     LOG = 'Log'  # =ln(S1/S0)

--- a/src/qis/perfstats/returns.py
+++ b/src/qis/perfstats/returns.py
@@ -13,8 +13,8 @@ The conversion is stated, never implied. ``to_returns`` takes ``is_log_returns``
 ``returns_to_nav`` and ``log_returns_to_nav`` invert them on the matching convention; passing
 log returns to the arithmetic inverse compounds the wrong quantity and raises nothing. Prices
 are resampled by ``prices_at_freq`` before differencing, so ``freq`` selects the return
-frequency rather than resampling returns after the fact, and non-positive prices are masked to
-NaN rather than producing a spurious return.
+frequency rather than resampling returns after the fact. Ratio and log returns require finite
+positive levels at both endpoints; difference and level modes also accept finite signed values.
 
 Annualisation is geometric and driven by elapsed calendar time, not by observation count:
 ``compute_pa_return`` raises the total return to 1/num_years, where num_years counts calendar
@@ -36,7 +36,7 @@ from math import isfinite
 from numbers import Integral, Real
 import numpy as np
 import pandas as pd
-from typing import Union, Dict, Optional
+from typing import Union, Dict, Optional, cast
 
 # qis
 import qis.utils.dates as da
@@ -97,7 +97,8 @@ def to_returns(prices: Union[pd.Series, pd.DataFrame],
     Args:
         prices: Numeric price time series. Pandas nullable floating values are supported
         is_log_returns: If True, compute log returns (overrides return_type)
-        return_type: Type of return calculation (LOG, RELATIVE, DIFFERENCE, LEVEL, LEVEL0)
+        return_type: Type of return calculation. LOG and RELATIVE require finite positive
+            endpoints; DIFFERENCE, LEVEL, and LEVEL0 accept finite signed levels
         freq: Resampling frequency (e.g., 'D', 'W', 'M')
         include_start_date: Include period start date when resampling
         include_end_date: Include period end date when resampling
@@ -107,9 +108,10 @@ def to_returns(prices: Union[pd.Series, pd.DataFrame],
         **kwargs: Additional arguments
 
     Returns:
-        Return time series matching the input's pandas shape and labels. A missing or non-positive
-        normalized current price produces a missing observation, and nullable floating inputs
-        retain a nullable output dtype
+        Return time series matching the input's pandas shape and labels. LOG and RELATIVE are
+        missing unless both endpoints are finite and positive. DIFFERENCE is missing unless both
+        signed endpoints are finite; LEVEL and LEVEL0 are missing unless their returned level is
+        finite. Nullable floating inputs retain a nullable output dtype
     """
     # Resample prices to specified frequency
     prices = prices_at_freq(prices=prices, freq=freq,
@@ -117,25 +119,40 @@ def to_returns(prices: Union[pd.Series, pd.DataFrame],
                             include_end_date=include_end_date,
                             ffill_nans=ffill_nans)
 
-    # Keep validation label-aligned and compatible with pandas nullable floating dtypes.
-    ind_good = prices.notna() & prices.gt(0.0)
-
-    # Compute returns based on type
+    # Validate the endpoints consumed by each convention, and neutralize invalid inputs before
+    # arithmetic so masked observations cannot leak divide or log warnings.
+    finite_prices: Union[pd.Series, pd.DataFrame] = prices.notna() & prices.abs().lt(np.inf)
     if return_type == ReturnTypes.LOG or is_log_returns:
-        returns = np.log(prices).diff(1)
+        # Log returns require positive levels at both endpoints of the period.
+        valid_prices: Union[pd.Series, pd.DataFrame] = finite_prices & prices.gt(0.0)
+        calculation_prices: Union[pd.Series, pd.DataFrame] = prices.where(valid_prices, other=1.0)
+        log_prices = cast(Union[pd.Series, pd.DataFrame], np.log(calculation_prices))
+        returns = log_prices.diff(1)
+        valid_returns = valid_prices & valid_prices.shift(1, fill_value=False)
     elif return_type == ReturnTypes.RELATIVE:
-        returns = np.divide(prices, prices.shift(1)).add(-1.0)
+        # Ratio returns share the log convention's positive two-endpoint domain.
+        valid_prices = finite_prices & prices.gt(0.0)
+        calculation_prices = prices.where(valid_prices, other=1.0)
+        returns = calculation_prices.div(calculation_prices.shift(1)).sub(1.0)
+        valid_returns = valid_prices & valid_prices.shift(1, fill_value=False)
     elif return_type == ReturnTypes.DIFFERENCE:
-        returns = prices - prices.shift(1)
+        # Signed rates and spreads may cross zero, so differences require only finite endpoints.
+        calculation_prices = prices.where(finite_prices, other=0.0)
+        returns = calculation_prices - calculation_prices.shift(1)
+        valid_returns = finite_prices & finite_prices.shift(1, fill_value=False)
     elif return_type == ReturnTypes.LEVEL:
+        # LEVEL reports the current observation and therefore validates only that returned value.
         returns = prices
+        valid_returns = finite_prices
     elif return_type == ReturnTypes.LEVEL0:
+        # LEVEL0 reports the predecessor, so its validity mask shifts with the returned value.
         returns = prices.shift(1)
+        valid_returns = finite_prices.shift(1, fill_value=False)
     else:
         raise NotImplementedError(f"{return_type}")
 
-    # Mask invalid observations
-    returns = returns.where(ind_good, other=np.nan)
+    # Remove neutral calculation values after applying the selected convention's endpoint rule.
+    returns = returns.where(valid_returns, other=np.nan)
 
     # Handle first observation
     if is_first_zero:

--- a/src/qis/perfstats/tests/returns_price_validity_test.py
+++ b/src/qis/perfstats/tests/returns_price_validity_test.py
@@ -1,0 +1,367 @@
+"""Return-mode endpoint-validity regressions for ``to_returns``.
+
+The five public return modes consume different price endpoints. Ratio and logarithmic returns
+require two finite positive levels, while absolute changes and level observations are also
+meaningful for finite signed rates and spreads. These tests use independently constructed literal
+references to keep those domains separate.
+
+One mixed panel combines healthy prices, zero and negative signed levels, missing values,
+positive and negative infinity, and recovery after each boundary. Running the same panel with
+ordinary ``float64`` and nullable ``Float64`` columns verifies that pandas' physical missing-data
+representation cannot change the numerical contract or warning behavior.
+"""
+
+import math
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.perfstats.config import ReturnTypes
+from qis.perfstats.returns import to_returns
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent references
+# =============================================================================
+
+_DATES = pd.date_range("2024-01-01", periods=4, freq="D", name="Date")
+
+_HEALTHY = "Healthy price"
+_ZERO_RECOVERY = "Zero recovery"
+_NEGATIVE_RECOVERY = "Negative recovery"
+_MISSING_RECOVERY = "Missing recovery"
+_POSITIVE_INFINITY_RECOVERY = "Positive infinity recovery"
+_NEGATIVE_INFINITY_RECOVERY = "Negative infinity recovery"
+_SIGNED_SPREAD = "Signed spread"
+
+_TOLERANCE = 1.0e-12
+
+
+def _as_nullable(frame: pd.DataFrame) -> pd.DataFrame:
+    """Convert every column to pandas nullable floating point.
+
+    Args:
+        frame: NumPy-backed deterministic panel.
+
+    Returns:
+        An equivalent panel whose columns use pandas ``Float64``.
+    """
+    return frame.astype(pd.Float64Dtype())
+
+
+def _make_price_panel(nullable: bool) -> pd.DataFrame:
+    """Create every endpoint state in one deliberately ordered panel.
+
+    Args:
+        nullable: Whether to use pandas nullable floating columns.
+
+    Returns:
+        Mixed price, rate, and spread histories for all return modes.
+    """
+    prices = pd.DataFrame(
+        {
+            _HEALTHY: (100.0, 110.0, 121.0, 133.1),
+            _ZERO_RECOVERY: (100.0, 0.0, 110.0, 121.0),
+            _NEGATIVE_RECOVERY: (100.0, -100.0, 110.0, 121.0),
+            _MISSING_RECOVERY: (100.0, np.nan, 110.0, 121.0),
+            _POSITIVE_INFINITY_RECOVERY: (100.0, np.inf, 110.0, 121.0),
+            _NEGATIVE_INFINITY_RECOVERY: (100.0, -np.inf, 110.0, 121.0),
+            _SIGNED_SPREAD: (-1.0, 0.0, 1.0, -2.0),
+        },
+        index=_DATES,
+    )
+    return _as_nullable(prices) if nullable else prices
+
+
+def _make_expected_returns(return_type: ReturnTypes, nullable: bool) -> pd.DataFrame:
+    """Construct literal results for one return convention.
+
+    Args:
+        return_type: Return convention whose endpoint domain is under test.
+        nullable: Whether expected columns should use pandas nullable floating point.
+
+    Returns:
+        Independently calculated results in the fixture's deliberate column order.
+
+    Raises:
+        AssertionError: If a new return convention lacks an explicit reference.
+    """
+    missing = (np.nan, np.nan, np.nan, 0.10)
+
+    if return_type == ReturnTypes.RELATIVE:
+        expected = pd.DataFrame(
+            {
+                _HEALTHY: (np.nan, 0.10, 0.10, 0.10),
+                _ZERO_RECOVERY: missing,
+                _NEGATIVE_RECOVERY: missing,
+                _MISSING_RECOVERY: missing,
+                _POSITIVE_INFINITY_RECOVERY: missing,
+                _NEGATIVE_INFINITY_RECOVERY: missing,
+                _SIGNED_SPREAD: (np.nan, np.nan, np.nan, np.nan),
+            },
+            index=_DATES,
+        )
+    elif return_type == ReturnTypes.LOG:
+        log_ten_percent = math.log(1.10)
+        log_missing = (np.nan, np.nan, np.nan, log_ten_percent)
+        expected = pd.DataFrame(
+            {
+                _HEALTHY: (np.nan, log_ten_percent, log_ten_percent, log_ten_percent),
+                _ZERO_RECOVERY: log_missing,
+                _NEGATIVE_RECOVERY: log_missing,
+                _MISSING_RECOVERY: log_missing,
+                _POSITIVE_INFINITY_RECOVERY: log_missing,
+                _NEGATIVE_INFINITY_RECOVERY: log_missing,
+                _SIGNED_SPREAD: (np.nan, np.nan, np.nan, np.nan),
+            },
+            index=_DATES,
+        )
+    elif return_type == ReturnTypes.DIFFERENCE:
+        expected = pd.DataFrame(
+            {
+                _HEALTHY: (np.nan, 10.0, 11.0, 12.1),
+                _ZERO_RECOVERY: (np.nan, -100.0, 110.0, 11.0),
+                _NEGATIVE_RECOVERY: (np.nan, -200.0, 210.0, 11.0),
+                _MISSING_RECOVERY: (np.nan, np.nan, np.nan, 11.0),
+                _POSITIVE_INFINITY_RECOVERY: (np.nan, np.nan, np.nan, 11.0),
+                _NEGATIVE_INFINITY_RECOVERY: (np.nan, np.nan, np.nan, 11.0),
+                _SIGNED_SPREAD: (np.nan, 1.0, 1.0, -3.0),
+            },
+            index=_DATES,
+        )
+    elif return_type == ReturnTypes.LEVEL:
+        expected = pd.DataFrame(
+            {
+                _HEALTHY: (100.0, 110.0, 121.0, 133.1),
+                _ZERO_RECOVERY: (100.0, 0.0, 110.0, 121.0),
+                _NEGATIVE_RECOVERY: (100.0, -100.0, 110.0, 121.0),
+                _MISSING_RECOVERY: (100.0, np.nan, 110.0, 121.0),
+                _POSITIVE_INFINITY_RECOVERY: (100.0, np.nan, 110.0, 121.0),
+                _NEGATIVE_INFINITY_RECOVERY: (100.0, np.nan, 110.0, 121.0),
+                _SIGNED_SPREAD: (-1.0, 0.0, 1.0, -2.0),
+            },
+            index=_DATES,
+        )
+    elif return_type == ReturnTypes.LEVEL0:
+        expected = pd.DataFrame(
+            {
+                _HEALTHY: (np.nan, 100.0, 110.0, 121.0),
+                _ZERO_RECOVERY: (np.nan, 100.0, 0.0, 110.0),
+                _NEGATIVE_RECOVERY: (np.nan, 100.0, -100.0, 110.0),
+                _MISSING_RECOVERY: (np.nan, 100.0, np.nan, 110.0),
+                _POSITIVE_INFINITY_RECOVERY: (np.nan, 100.0, np.nan, 110.0),
+                _NEGATIVE_INFINITY_RECOVERY: (np.nan, 100.0, np.nan, 110.0),
+                _SIGNED_SPREAD: (np.nan, -1.0, 0.0, 1.0),
+            },
+            index=_DATES,
+        )
+    else:
+        raise AssertionError(f"Unhandled return type: {return_type}")
+
+    return _as_nullable(expected) if nullable else expected
+
+
+def _select_series(frame: pd.DataFrame, column: str) -> pd.Series:
+    """Select one uniquely labeled column with an explicit Series contract.
+
+    Args:
+        frame: Deterministic fixture or expected-result panel.
+        column: Unique column label to select.
+
+    Returns:
+        The selected Series with its original name and index.
+    """
+    selected = frame[column]
+    assert isinstance(selected, pd.Series)
+    return selected
+
+
+def _assert_frame_close(
+    actual: pd.Series | pd.DataFrame,
+    expected: pd.DataFrame,
+) -> None:
+    """Assert values, missingness, dtype, shape, labels, and column order.
+
+    Args:
+        actual: Result under the public Series-or-DataFrame return annotation.
+        expected: Independently calculated DataFrame reference.
+    """
+    assert isinstance(actual, pd.DataFrame)
+    pd.testing.assert_frame_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+
+
+# =============================================================================
+# Mode-specific endpoint validity
+# =============================================================================
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "Float64"))
+@pytest.mark.parametrize("return_type", tuple(ReturnTypes), ids=lambda mode: mode.name)
+def test_to_returns_applies_mode_specific_endpoint_validity(
+    return_type: ReturnTypes,
+    nullable: bool,
+) -> None:
+    """Apply each public formula only on the endpoints in its documented domain.
+
+    Args:
+        return_type: Return convention under test.
+        nullable: Whether inputs and expected results use pandas nullable floating point.
+    """
+    prices = _make_price_panel(nullable=nullable)
+    original_prices = prices.copy()
+    expected = _make_expected_returns(return_type=return_type, nullable=nullable)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = to_returns(
+            prices=prices,
+            return_type=return_type,
+            ffill_nans=False,
+        )
+
+    _assert_frame_close(actual, expected)
+    pd.testing.assert_frame_equal(prices, original_prices, check_exact=True)
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "Float64"))
+@pytest.mark.parametrize("return_type", tuple(ReturnTypes), ids=lambda mode: mode.name)
+def test_to_returns_preserves_series_parity_for_mode_specific_validity(
+    return_type: ReturnTypes,
+    nullable: bool,
+) -> None:
+    """Match one-column DataFrame results without losing the Series name.
+
+    Args:
+        return_type: Return convention under test.
+        nullable: Whether the signed-spread input uses pandas nullable floating point.
+    """
+    prices = _select_series(_make_price_panel(nullable=nullable), _SIGNED_SPREAD)
+    expected = _select_series(
+        _make_expected_returns(return_type=return_type, nullable=nullable),
+        _SIGNED_SPREAD,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = to_returns(
+            prices=prices,
+            return_type=return_type,
+            ffill_nans=False,
+        )
+
+    assert isinstance(actual, pd.Series)
+    pd.testing.assert_series_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+
+
+# =============================================================================
+# Existing option interactions
+# =============================================================================
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "Float64"))
+def test_to_returns_log_override_uses_positive_endpoint_validity(nullable: bool) -> None:
+    """Apply the log domain when ``is_log_returns`` overrides a signed mode.
+
+    Args:
+        nullable: Whether the mixed panel uses pandas nullable floating point.
+    """
+    prices = _make_price_panel(nullable=nullable)
+    expected = _make_expected_returns(return_type=ReturnTypes.LOG, nullable=nullable)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = to_returns(
+            prices=prices,
+            is_log_returns=True,
+            return_type=ReturnTypes.DIFFERENCE,
+            ffill_nans=False,
+        )
+
+    _assert_frame_close(actual, expected)
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "Float64"))
+@pytest.mark.parametrize(
+    ("ffill_nans", "expected_values"),
+    (
+        pytest.param(True, (np.nan, 0.0, 0.10, 0.10), id="forward-fill"),
+        pytest.param(False, (np.nan, np.nan, np.nan, 0.10), id="preserve-gap"),
+    ),
+)
+def test_to_returns_applies_fill_before_endpoint_validity(
+    nullable: bool,
+    ffill_nans: bool,
+    expected_values: tuple[float, ...],
+) -> None:
+    """Retain the explicit missing-price fill policy before validating endpoints.
+
+    Args:
+        nullable: Whether the missing-price Series uses pandas nullable floating point.
+        ffill_nans: Whether the missing January 2 level carries January 1's price.
+        expected_values: Literal arithmetic-return result after the selected fill policy.
+    """
+    prices = _select_series(_make_price_panel(nullable=nullable), _MISSING_RECOVERY)
+    expected = pd.Series(expected_values, index=_DATES, name=_MISSING_RECOVERY)
+    if nullable:
+        expected = expected.astype(pd.Float64Dtype())
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = to_returns(prices=prices, ffill_nans=ffill_nans)
+
+    assert isinstance(actual, pd.Series)
+    pd.testing.assert_series_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "Float64"))
+def test_to_returns_initializes_only_after_mode_specific_validation(nullable: bool) -> None:
+    """Keep ``is_first_zero`` as a post-validation initialization convention.
+
+    Args:
+        nullable: Whether the zero-recovery Series uses pandas nullable floating point.
+    """
+    prices = _select_series(_make_price_panel(nullable=nullable), _ZERO_RECOVERY)
+    expected = pd.Series(
+        (np.nan, np.nan, 0.0, 0.10),
+        index=_DATES,
+        name=_ZERO_RECOVERY,
+    )
+    if nullable:
+        expected = expected.astype(pd.Float64Dtype())
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = to_returns(
+            prices=prices,
+            ffill_nans=False,
+            is_first_zero=True,
+        )
+
+    assert isinstance(actual, pd.Series)
+    pd.testing.assert_series_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=0.0,
+        atol=_TOLERANCE,
+    )


### PR DESCRIPTION
## What changed

Validate each `to_returns()` convention against the finite or positive endpoint domain its formula actually consumes, while preserving pandas shape, labels, nullable dtypes, fill ordering, and first-observation options.

One current-row positive-price mask previously governed every return mode. A positive recovery after zero or a negative level could therefore produce `inf` or `-2.1` in ratio returns; signed rate/spread levels were suppressed in `DIFFERENCE` and level modes; `LEVEL0` validated the current row instead of the predecessor it returned; and log calculation evaluated invalid levels before masking and emitted warnings.

## Behavior

`RELATIVE` and `LOG` require finite positive predecessor and current levels. `DIFFERENCE` accepts finite signed endpoints, `LEVEL` accepts a finite signed current level, and `LEVEL0` accepts a finite signed predecessor. Invalid calculation inputs are neutralized before arithmetic and removed by the corresponding endpoint mask, so invalid values remain missing without leaking divide or log warnings. Public signatures, defaults, exports, resampling, explicit missing-price fill ordering, labels, dtypes, caller ownership, `drop_first`, and post-validation `is_first_zero` behavior remain unchanged.

## Regression evidence

- **Fail before:** the finalized 28-case module produced `24 failed, 4 passed` against accepted main, reproducing invalid-predecessor recovery, signed-mode suppression, `LEVEL0` row mismatch, log warnings, the log override, and initialization after invalid output.
- **Independent expectation:** literal four-date tables cover one mixed panel containing a healthy positive history, zero and negative recovery, missing recovery, positive and negative infinity recovery, and a signed spread. Expected ratio/log domains, signed differences, current levels, and predecessor levels are calculated independently for ordinary `float64` and nullable `Float64` representations.
- **Pass after:** all `28` focused cases pass warning-free, including Series/DataFrame parity, labels and order, caller ownership, the log override, fill-before-validation, and post-validation initialization; the complete `perfstats` suite passes all `577` cases.

## Verification

- Added-file formatter, whitespace, changed-line Ruff, and changed-line Pyright/Pylance: passed with zero PR-attributable findings.
- Focused endpoint-validity regressions: `28 passed`.
- Complete `perfstats` suite: `577 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2073 passed, 16 warnings`; all warnings are known third-party seaborn/Matplotlib deprecations.
- Public API synchronization: current at `409` names.
- Dependency check: no broken requirements.
- Clean receipt: exact base `486b826`, head `739bfac`, and four-file diff verified.

## Scope

Changed files: `CHANGELOG.md`, `src/qis/perfstats/config.py`, `src/qis/perfstats/returns.py`, `src/qis/perfstats/tests/returns_price_validity_test.py`.

Out of scope: Public signatures, defaults, exports, new dependencies, resampling and frequency policy, missing-price fill policy, first-observation option semantics, return-to-NAV conversion, downstream backfill behavior, and unrelated formatting or typing cleanup.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.