### PR TITLE
fix: handle missing volatility windows without warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserved unavailable realized-volatility windows without reduction warnings and added a
+  descriptive error for volatility-regime benchmarks with no finite observations.
+
 ## [5.21.1] - 2026-08-30
 
 ### Added

--- a/src/qis/perfstats/regime_classifier.py
+++ b/src/qis/perfstats/regime_classifier.py
@@ -743,7 +743,8 @@ class BenchmarkVolsQuantilesRegime(RegimeClassifier):
             color per ID are also available through ``get_regime_ids_colors()``.
 
         Raises:
-            ValueError: If fewer than ``q`` volatility quantile bands contain observations.
+            ValueError: If the benchmark has no finite volatility observations or fewer than
+                ``q`` volatility quantile bands contain observations.
         """
         vols = ret.compute_sampled_vols(
             prices=prices[benchmark],
@@ -753,6 +754,12 @@ class BenchmarkVolsQuantilesRegime(RegimeClassifier):
         )
 
         valid_vols = vols.dropna()
+        if valid_vols.empty:
+            # Reject an unusable benchmark before the quantile helper derives all-NaN bin edges.
+            raise ValueError(
+                f"Volatility regime benchmark '{benchmark}' has no finite volatility "
+                f"observations for q={self.q}."
+            )
         if self.q > 0 and not valid_vols.empty:
             # Require every requested band to contain data before publishing its ID and color.
             quantile_classification, quantile_edges = cast(

--- a/src/qis/perfstats/returns.py
+++ b/src/qis/perfstats/returns.py
@@ -486,7 +486,8 @@ def compute_pa_excess_compounded_returns(returns: Union[pd.Series, pd.DataFrame]
     return compounded_return_pa
 
 
-def estimate_vol(sampled_returns: Union[pd.DataFrame, pd.Series, np.ndarray]) -> np.ndarray:
+def estimate_vol(sampled_returns: Union[pd.DataFrame, pd.Series, np.ndarray]
+                 ) -> Union[np.ndarray, float]:
     """Estimate volatility from return samples.
 
     For samples >=20, uses standard deviation with ddof=1.
@@ -496,20 +497,28 @@ def estimate_vol(sampled_returns: Union[pd.DataFrame, pd.Series, np.ndarray]) ->
         sampled_returns: Return time series
 
     Returns:
-        Array of volatility estimates
+        Volatility estimate for a one-dimensional input or one estimate per DataFrame column.
+        A column is missing when it cannot supply the observations required by its selected
+        estimator
     """
-    if isinstance(sampled_returns, np.ndarray):
-        n = sampled_returns.shape[0]
+    if isinstance(sampled_returns, (pd.Series, pd.DataFrame)):
+        sampled_values = sampled_returns.to_numpy(dtype=float, na_value=np.nan)
     else:
-        n = len(sampled_returns.index)
+        sampled_values = np.asarray(sampled_returns, dtype=float)
+    n = sampled_values.shape[0]
 
-    if n >= 20:
-        # Use sample standard deviation for larger samples
-        vol = np.nanstd(sampled_returns, axis=0, ddof=1)
-    else:
-        # Use RMS for small samples to avoid mean adjustment
-        vol = np.sqrt(np.nanmean(np.power(sampled_returns, 2), axis=0))
-    return vol
+    def estimate_column(values: np.ndarray) -> float:
+        """Apply the existing window-size estimator to one return column."""
+        num_observations = int(np.count_nonzero(~np.isnan(values)))
+        if n >= 20:
+            # Sample standard deviation needs two observations; unavailable columns stay missing.
+            return float(np.nanstd(values, ddof=1)) if num_observations >= 2 else np.nan
+        # The small-window RMS convention is defined as soon as one return is observed.
+        return float(np.sqrt(np.nanmean(np.power(values, 2)))) if num_observations >= 1 else np.nan
+
+    if sampled_values.ndim == 1:
+        return estimate_column(sampled_values)
+    return np.asarray([estimate_column(values) for values in sampled_values.T])
 
 
 def compute_sampled_vols(prices: Union[pd.DataFrame, pd.Series],
@@ -528,7 +537,8 @@ def compute_sampled_vols(prices: Union[pd.DataFrame, pd.Series],
         include_end_date: Include period end in resampling
 
     Returns:
-        Annualized volatility time series
+        Annualized volatility time series. Windows without enough observed returns remain missing
+        without affecting eligible Series or DataFrame columns
     """
     # Compute returns at specified frequency
     sampled_returns = to_returns(prices=prices, freq=freq_return,
@@ -544,7 +554,9 @@ def compute_sampled_vols(prices: Union[pd.DataFrame, pd.Series],
     # Compute volatility for each window
     vol_samples = {}
     for key, df in sampled_returns_at_vol_freq.items():
-        vol_samples[key] = estimate_vol(sampled_returns=df.to_numpy())
+        # Normalize nullable pandas values before applying NumPy reducers column by column.
+        sampled_values = df.to_numpy(dtype=float, na_value=np.nan)
+        vol_samples[key] = estimate_vol(sampled_returns=sampled_values)
 
     # Convert to time series and annualize
     if isinstance(prices, pd.Series):

--- a/src/qis/perfstats/tests/regime_volatility_missing_test.py
+++ b/src/qis/perfstats/tests/regime_volatility_missing_test.py
@@ -1,0 +1,393 @@
+"""Regression coverage for missing realized-volatility windows and regimes.
+
+``compute_sampled_vols`` reports one annualized estimate per requested window, while
+``BenchmarkVolsQuantilesRegime`` assigns only finite estimates to quantile regimes. An unavailable
+window should therefore remain missing without NumPy reduction warnings, and an entirely
+unavailable benchmark should fail with a descriptive classifier error before quantile binning.
+Isolated missing windows must not invalidate a later usable benchmark history.
+
+The fixtures exercise ordinary and nullable pandas representations through public APIs. The mixed
+panel places a fully observed history, an all-missing history, and a history with only one finite
+January return in the same vectorized call. Healthy expected volatility is calculated directly
+from squared return deviations and the business-day annualization factor; no QIS volatility or
+classification helper constructs the references.
+"""
+
+from typing import Callable, Dict, Protocol, cast
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# qis
+from qis.perfstats.regime_classifier import BenchmarkVolsQuantilesRegime
+from qis.perfstats.returns import compute_sampled_vols
+
+
+class _VolatilityClassifierProtocol(Protocol):
+    """Typed test-side interface for the public volatility classifier."""
+
+    def compute_sampled_returns_with_regime_id(
+        self,
+        *,
+        prices: pd.DataFrame,
+        benchmark: str,
+        include_start_date: bool,
+        include_end_date: bool,
+    ) -> pd.DataFrame:
+        """Return sampled returns with their volatility regime classification."""
+        raise NotImplementedError
+
+    def get_regime_ids_colors(self) -> Dict[str, str]:
+        """Return the ordered regime-ID-to-color mapping."""
+        raise NotImplementedError
+
+
+# =============================================================================
+# Shared deterministic fixtures
+# =============================================================================
+
+_BENCHMARK = "Benchmark"
+_HEALTHY = "Healthy"
+_ALL_MISSING = "All Missing"
+_LATE_START = "Late Start"
+_RAGGED_ASSET = "Ragged Asset"
+_NUM_BUCKETS = 4
+
+_BUSINESS_PERIODS_PER_YEAR = 252.0
+_ALL_MISSING_DATES = pd.bdate_range("2022-01-03", "2022-12-30")
+_ALL_MISSING_VOL_DATES = pd.DatetimeIndex(
+    (
+        "2022-01-31",
+        "2022-02-28",
+        "2022-03-31",
+        "2022-04-30",
+        "2022-05-31",
+        "2022-06-30",
+        "2022-07-31",
+        "2022-08-31",
+        "2022-09-30",
+        "2022-10-31",
+        "2022-11-30",
+        "2022-12-30",
+    )
+)
+_MIXED_DATES = pd.bdate_range("2022-01-03", "2022-03-31")
+_MIXED_VOL_DATES = pd.DatetimeIndex(("2022-01-31", "2022-02-28", "2022-03-31"))
+_MIXED_VOL_WINDOWS = (
+    (pd.Timestamp("2022-01-03"), pd.Timestamp("2022-01-31")),
+    (pd.Timestamp("2022-01-31"), pd.Timestamp("2022-02-28")),
+    (pd.Timestamp("2022-02-28"), pd.Timestamp("2022-03-31")),
+)
+_RAGGED_DATES = pd.bdate_range("2022-01-03", "2024-12-31")
+
+_EXPECTED_REGIME_IDS = (
+    "Benchmark vol<5%",
+    "Benchmark vol=(5%, 6%]",
+    "Benchmark vol=(6%, 8%]",
+    "Benchmark vol>8%",
+)
+_EXPECTED_REGIME_COLORS = ("#a50026", "#fdbf6f", "#b7e075", "#006837")
+_EXPECTED_REGIME_COUNTS = (9, 8, 8, 8)
+
+
+def _as_nullable(frame: pd.DataFrame) -> pd.DataFrame:
+    """Convert a fixture to pandas nullable floating storage.
+
+    Args:
+        frame: Ordinary floating fixture.
+
+    Returns:
+        Equivalent nullable ``Float64`` fixture.
+    """
+    return frame.astype(pd.Float64Dtype())
+
+
+def _as_ordinary(frame: pd.DataFrame) -> pd.DataFrame:
+    """Retain a fixture as ordinary NumPy floating storage.
+
+    Args:
+        frame: Ordinary floating fixture.
+
+    Returns:
+        Equivalent ``float64`` fixture.
+    """
+    return frame.astype(np.float64)
+
+
+_DTYPE_CONVERTERS: tuple[Callable[[pd.DataFrame], pd.DataFrame], ...] = (
+    _as_ordinary,
+    _as_nullable,
+)
+
+
+def _all_missing_panel() -> pd.DataFrame:
+    """Create a one-column benchmark with no observed prices.
+
+    Returns:
+        All-missing benchmark over twelve complete volatility windows.
+    """
+    return pd.DataFrame({_BENCHMARK: np.nan}, index=_ALL_MISSING_DATES)
+
+
+def _mixed_volatility_panel() -> pd.DataFrame:
+    """Create healthy, all-missing, and one-return window states together.
+
+    The healthy price path alternates one-percent simple returns. The late-starting column has two
+    adjacent January observations, yielding exactly one finite January return; forward filling
+    produces zero returns thereafter. The overlapping February window retains that January 31
+    return, while March is the sufficiently observed all-zero control.
+
+    Returns:
+        Three-column price panel spanning three monthly volatility windows.
+    """
+    healthy_returns = np.where(np.arange(len(_MIXED_DATES)) % 2 == 0, 0.01, -0.01)
+    healthy_prices = 100.0 * np.cumprod(1.0 + healthy_returns)
+    late_start_prices = np.full(len(_MIXED_DATES), np.nan, dtype=float)
+    late_start_prices[_MIXED_DATES.get_loc("2022-01-28")] = 100.0
+    late_start_prices[_MIXED_DATES.get_loc("2022-01-31")] = 101.0
+    return pd.DataFrame(
+        {
+            _HEALTHY: healthy_prices,
+            _ALL_MISSING: np.nan,
+            _LATE_START: late_start_prices,
+        },
+        index=_MIXED_DATES,
+    )
+
+
+def _ragged_usable_panel() -> pd.DataFrame:
+    """Create a late-starting benchmark followed by 33 usable volatility windows.
+
+    Alternating signs keep monthly return means near zero while the absolute amplitude increases
+    by 1.5 basis points per month. Direct ranking therefore leaves regime counts of 9, 8, 8, and 8
+    after the first three benchmark months are made unavailable.
+
+    Returns:
+        Three-year benchmark and dependent-asset price panel.
+    """
+    month_numbers = np.asarray(
+        [(date.year - 2022) * 12 + date.month for date in _RAGGED_DATES],
+        dtype=float,
+    )
+    amplitudes = 0.001 + 0.00015 * month_numbers
+    signs = np.where(np.arange(len(_RAGGED_DATES)) % 2 == 0, 1.0, -1.0)
+    benchmark_returns = amplitudes * signs
+    benchmark_prices = 100.0 * np.cumprod(1.0 + benchmark_returns)
+    asset_prices = 80.0 * np.cumprod(1.0 + 0.5 * benchmark_returns)
+    benchmark_prices[_RAGGED_DATES < pd.Timestamp("2022-04-01")] = np.nan
+    asset_prices[:40] = np.nan
+    return pd.DataFrame(
+        {_BENCHMARK: benchmark_prices, _RAGGED_ASSET: asset_prices},
+        index=_RAGGED_DATES,
+    )
+
+
+def _annualized_sample_std(values: np.ndarray) -> float:
+    """Calculate annualized sample volatility independently from QIS.
+
+    Args:
+        values: Finite daily simple returns in one monthly window.
+
+    Returns:
+        Sample standard deviation multiplied by ``sqrt(252)``.
+    """
+    mean = float(np.sum(values) / len(values))
+    squared_deviations = np.sum(np.square(values - mean))
+    sample_variance = float(squared_deviations / (len(values) - 1))
+    return float(np.sqrt(sample_variance * _BUSINESS_PERIODS_PER_YEAR))
+
+
+def _expected_mixed_vols() -> pd.DataFrame:
+    """Construct the mixed-panel volatility reference from literal returns.
+
+    Returns:
+        Expected healthy, unavailable, and late-starting monthly volatility values.
+    """
+    healthy_returns = np.where(np.arange(len(_MIXED_DATES)) % 2 == 0, 0.01, -0.01).astype(float)
+    healthy_returns[0] = np.nan
+    expected_healthy: list[float] = []
+    for start, end in _MIXED_VOL_WINDOWS:
+        # Included start dates make adjacent monthly windows share the prior month-end return.
+        in_window = (_MIXED_DATES >= start) & (_MIXED_DATES <= end)
+        window_values = healthy_returns[in_window]
+        expected_healthy.append(_annualized_sample_std(window_values[np.isfinite(window_values)]))
+    late_start_returns = np.full(len(_MIXED_DATES), np.nan, dtype=float)
+    late_start_returns[_MIXED_DATES >= pd.Timestamp("2022-01-31")] = 0.0
+    late_start_returns[_MIXED_DATES.get_loc("2022-01-31")] = 0.01
+    expected_late_start: list[float] = []
+    for start, end in _MIXED_VOL_WINDOWS:
+        in_window = (_MIXED_DATES >= start) & (_MIXED_DATES <= end)
+        window_values = late_start_returns[in_window]
+        finite_values = window_values[np.isfinite(window_values)]
+        expected_late_start.append(
+            _annualized_sample_std(finite_values) if len(finite_values) >= 2 else np.nan
+        )
+    return pd.DataFrame(
+        {
+            _HEALTHY: expected_healthy,
+            _ALL_MISSING: [np.nan, np.nan, np.nan],
+            _LATE_START: expected_late_start,
+        },
+        index=_MIXED_VOL_DATES,
+    )
+
+
+# =============================================================================
+# Missing sampled-volatility windows
+# =============================================================================
+
+
+@pytest.mark.parametrize("convert", _DTYPE_CONVERTERS, ids=("ordinary", "nullable"))
+def test_compute_sampled_vols_preserves_all_missing_series_and_frame(
+    convert: Callable[[pd.DataFrame], pd.DataFrame],
+) -> None:
+    """Return twelve missing estimates without warnings for either pandas shape.
+
+    Args:
+        convert: Ordinary or nullable floating fixture conversion.
+    """
+    prices = convert(_all_missing_panel())
+    original_prices = prices.copy()
+    series_prices = prices[_BENCHMARK]
+    assert isinstance(series_prices, pd.Series)
+    expected = pd.Series(np.nan, index=_ALL_MISSING_VOL_DATES, name=_BENCHMARK)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual_series = compute_sampled_vols(
+            prices=series_prices,
+            freq_vol="ME",
+            include_start_date=True,
+            include_end_date=True,
+        )
+        actual_frame = compute_sampled_vols(
+            prices=prices,
+            freq_vol="ME",
+            include_start_date=True,
+            include_end_date=True,
+        )
+
+    assert isinstance(actual_series, pd.Series)
+    assert isinstance(actual_frame, pd.DataFrame)
+    pd.testing.assert_series_equal(actual_series, expected)
+    pd.testing.assert_frame_equal(actual_frame, expected.to_frame())
+    pd.testing.assert_frame_equal(prices, original_prices)
+
+
+@pytest.mark.parametrize("convert", _DTYPE_CONVERTERS, ids=("ordinary", "nullable"))
+def test_compute_sampled_vols_preserves_mixed_window_states(
+    convert: Callable[[pd.DataFrame], pd.DataFrame],
+) -> None:
+    """Estimate eligible columns while unavailable neighbors remain missing and quiet.
+
+    Healthy expected values use the independent sample-variance formula above. The all-missing
+    column remains missing in every month; the one-return January window is also missing. The
+    overlapping February window includes that boundary return, while the sufficiently observed
+    all-zero March control equals zero.
+
+    Args:
+        convert: Ordinary or nullable floating fixture conversion.
+    """
+    prices = convert(_mixed_volatility_panel())
+    original_prices = prices.copy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = compute_sampled_vols(
+            prices=prices,
+            freq_vol="ME",
+            include_start_date=True,
+            include_end_date=True,
+        )
+
+    assert isinstance(actual, pd.DataFrame)
+    pd.testing.assert_frame_equal(actual, _expected_mixed_vols(), rtol=1.0e-12, atol=1.0e-12)
+    pd.testing.assert_frame_equal(prices, original_prices)
+
+
+# =============================================================================
+# Missing volatility-regime benchmarks
+# =============================================================================
+
+
+@pytest.mark.parametrize("convert", _DTYPE_CONVERTERS, ids=("ordinary", "nullable"))
+def test_benchmark_vols_quantiles_regime_rejects_all_missing_benchmark(
+    convert: Callable[[pd.DataFrame], pd.DataFrame],
+) -> None:
+    """Reject an unusable benchmark descriptively before quantile classification.
+
+    Args:
+        convert: Ordinary or nullable floating fixture conversion.
+    """
+    benchmark = convert(_all_missing_panel())
+    asset_prices = pd.Series(
+        100.0 * np.cumprod(1.0 + np.full(len(_ALL_MISSING_DATES), 0.001)),
+        index=_ALL_MISSING_DATES,
+        name=_RAGGED_ASSET,
+    )
+    prices = benchmark.join(asset_prices)
+    original_prices = prices.copy()
+    classifier = cast(
+        _VolatilityClassifierProtocol,
+        BenchmarkVolsQuantilesRegime(freq="ME", q=_NUM_BUCKETS),
+    )
+    expected_message = (
+        "Volatility regime benchmark 'Benchmark' has no finite volatility observations for q=4."
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(ValueError) as exc_info:
+            classifier.compute_sampled_returns_with_regime_id(
+                prices=prices,
+                benchmark=_BENCHMARK,
+                include_start_date=True,
+                include_end_date=True,
+            )
+
+    assert str(exc_info.value) == expected_message
+    pd.testing.assert_frame_equal(prices, original_prices)
+
+
+@pytest.mark.parametrize("convert", _DTYPE_CONVERTERS, ids=("ordinary", "nullable"))
+def test_benchmark_vols_quantiles_regime_preserves_ragged_usable_benchmark(
+    convert: Callable[[pd.DataFrame], pd.DataFrame],
+) -> None:
+    """Ignore unavailable early windows while classifying every later finite window.
+
+    The initial sampled return and first three monthly volatility windows remain unclassified.
+    The 33 later windows occupy the independently ranked groups of 9, 8, 8, and 8 without warnings
+    or changes to labels, colors, column order, or caller data.
+
+    Args:
+        convert: Ordinary or nullable floating fixture conversion.
+    """
+    prices = convert(_ragged_usable_panel())
+    original_prices = prices.copy()
+    classifier = cast(
+        _VolatilityClassifierProtocol,
+        BenchmarkVolsQuantilesRegime(freq="ME", q=_NUM_BUCKETS),
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        classified = classifier.compute_sampled_returns_with_regime_id(
+            prices=prices,
+            benchmark=_BENCHMARK,
+            include_start_date=True,
+            include_end_date=True,
+        )
+
+    actual_regimes = classified["regime"]
+    assert isinstance(actual_regimes, pd.Series)
+    assert classified.columns.tolist() == [_BENCHMARK, _RAGGED_ASSET, "regime"]
+    assert actual_regimes.isna().tolist() == [True] * 4 + [False] * 33
+    assert actual_regimes.value_counts(sort=False).to_dict() == dict(
+        zip(_EXPECTED_REGIME_IDS, _EXPECTED_REGIME_COUNTS)
+    )
+    assert classifier.get_regime_ids_colors() == dict(
+        zip(_EXPECTED_REGIME_IDS, _EXPECTED_REGIME_COLORS)
+    )
+    pd.testing.assert_frame_equal(prices, original_prices)


### PR DESCRIPTION
## What changed

Handle unavailable volatility windows without reducer warnings, support nullable missing values consistently, and raise a descriptive error when a regime benchmark has no finite volatility observations.

All-missing monthly benchmarks formerly emitted one NumPy degrees-of-freedom warning per window and then leaked pandas' `bins must increase monotonically` error. A mixed nullable `Float64` panel instead failed in `estimate_vol()` with `TypeError: boolean value of NA is ambiguous`.

## Behavior

Public signatures, exports, annualization, frequency sampling, and eligible finite volatility estimates are unchanged. Columns that cannot satisfy the existing estimator's observation requirement now return missing without invoking an invalid reducer; nullable missing values are normalized before NumPy; and a benchmark with no finite volatility observations raises a precise domain error before quantile classification.

## Regression evidence

Before the fix, all `8` finalized deterministic cases failed: seven on `RuntimeWarning: Degrees of freedom <= 0 for slice` and the nullable mixed-panel case on `TypeError: boolean value of NA is ambiguous`. Independently calculated expectations cover ordinary and nullable inputs, Series/DataFrame parity, a mixed healthy/all-missing/one-return panel, exact missing placement, the existing `sqrt(252)` annualization and 20-row estimator selection, ragged usable regime counts `9, 8, 8, 8`, labels/colors, warnings, and caller ownership. After the fix, all `8` focused regressions pass.

## Verification

- Focused missing-volatility regressions: `8 passed`.
- Complete perfstats suite: `585 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2084 passed, 16 warnings` in `243.72s`; all warnings are known third-party seaborn/Matplotlib deprecations.
- Changed-line Ruff and Pyright/Pylance-aligned review: zero contribution-attributable findings.
- Public-API synchronization: current at `409` names.
- Dependency, formatter, and whitespace checks: passed for clean commit `3811a29`.

## Scope

Changed files: `CHANGELOG.md`, `src/qis/perfstats/regime_classifier.py`, `src/qis/perfstats/returns.py`, `src/qis/perfstats/tests/regime_volatility_missing_test.py`.

Out of scope: The existing finite-count estimator-selection policy remains PR 57. This PR does not change finite constant/tied-history diagnostics, bucket-count validation, price filling, public signatures or exports, dependencies, or unrelated regime classifiers and formatting.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.