### PR TITLE
fix: handle constant descriptive moments without warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Preserved defined descriptive statistics for finite constant columns while returning undefined
+  skewness, kurtosis, and normality without precision-loss warnings.
 - Preserved unavailable realized-volatility windows without reduction warnings and added a
   descriptive error for volatility-regime benchmarks with no finite observations.
 

--- a/src/qis/perfstats/desc_table.py
+++ b/src/qis/perfstats/desc_table.py
@@ -61,20 +61,35 @@ def _compute_positive_probability(data: np.ndarray) -> np.ndarray:
 def _reduce_observed(
         data: np.ndarray,
         reduction: Callable[[np.ndarray], np.ndarray],
-        minimum_observations: int = 1) -> np.ndarray:
-    """Apply a reduction only to columns meeting its sample-size requirement.
+        minimum_observations: int = 1,
+        require_variation: bool = False) -> np.ndarray:
+    """Apply a reduction only to columns meeting the selected eligibility requirements.
 
     Args:
         data: Two-dimensional numerical observations arranged by row and column.
         reduction: Column-wise reduction returning one value per supplied column.
         minimum_observations: Required number of non-missing values in each column.
+        require_variation: Whether finite zero-spread columns remain undefined.
 
     Returns:
-        Reduction values in input-column order, with NaN for undersized columns.
+        Reduction values in input-column order, with NaN for ineligible columns.
     """
     # Select columns per statistic so undersized samples never reach warning-producing reducers.
     observation_counts = np.sum(np.logical_not(np.isnan(data)), axis=0)
     eligible_columns = np.greater_equal(observation_counts, minimum_observations)
+    if require_variation and np.any(eligible_columns):
+        # Exact finite constants have undefined standardized moments; leave other input policies
+        # unchanged.
+        eligible_positions = np.flatnonzero(eligible_columns)
+        eligible_data = data[:, eligible_columns]
+        minimums = np.nanmin(eligible_data, axis=0)
+        maximums = np.nanmax(eligible_data, axis=0)
+        finite_zero_spread = (
+            np.isfinite(minimums)
+            & np.isfinite(maximums)
+            & np.equal(minimums, maximums)
+        )
+        eligible_columns[eligible_positions] = np.logical_not(finite_zero_spread)
     values = np.full(data.shape[1], np.nan, dtype=float)
     if np.any(eligible_columns):
         values[eligible_columns] = reduction(data[:, eligible_columns])
@@ -120,13 +135,13 @@ def _add_moment_columns(
         data: Two-dimensional numerical observations arranged by row and column.
         value_format: Display format applied to each moment.
     """
-    # Two observations define the displayed moments; smaller samples remain explicitly missing.
+    # Display moments only for samples that have both enough observations and finite variation.
     skews = _reduce_observed(
         data, lambda values: skew(values, axis=0, nan_policy='omit'),
-        minimum_observations=2)
+        minimum_observations=2, require_variation=True)
     kurts = _reduce_observed(
         data, lambda values: kurtosis(values, axis=0, nan_policy='omit'),
-        minimum_observations=2)
+        minimum_observations=2, require_variation=True)
     descriptive_table[PerfStat.SKEWNESS.value.short] = [
         value_format.format(x) for x in skews]
     descriptive_table[PerfStat.KURTOSIS.value.short_n] = [
@@ -162,7 +177,8 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
             column named after it; repeated DataFrame column labels are retained and calculated
             independently
         desc_table_type: which set of statistics to report; positive-probability modes use each
-            column's non-missing observation count as the denominator
+            column's non-missing observation count as the denominator; moment modes retain
+            defined level statistics but report finite zero-spread moments as missing
         var_format: format applied to the statistics
         annualize_vol: report volatility per annum rather than per period; reduced modes omit
             the volatility column selected by this convention
@@ -238,22 +254,22 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
         descriptive_table[PerfStat.POSITIVE.to_str(short=True, short_n=True)] = ['{:.1%}'.format(x) for x in prob]
 
     elif desc_table_type == desc_table_type.WITH_KURTOSIS:
-        # Evaluate moments only for observed columns so SciPy does not warn for empty samples.
+        # Evaluate moments only for eligible varying columns so undefined samples do not warn.
         _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
 
     elif desc_table_type == desc_table_type.WITH_NORMAL_PVAL:
-        # Apply moments and normality only where a sample exists, retaining NaN elsewhere.
+        # Apply moments and normality only to eligible varying samples, retaining NaN elsewhere.
         _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
         # Require SciPy's warning-free accuracy threshold, not only its eight-value hard minimum.
         ps = _reduce_observed(
             data_np,
             lambda values: normaltest(a=values, axis=0, nan_policy=nan_policy)[1],
-            minimum_observations=20)
+            minimum_observations=20, require_variation=True)
         descriptive_table[PerfStat.NORMTEST.value.short_n] = [
             '{:.2f}'.format(x) for x in ps]
 
     elif desc_table_type == desc_table_type.SKEW_KURTOSIS:
-        # Remove setup columns and leave unobserved moments undefined in the reduced schema.
+        # Remove setup columns and leave ineligible moments undefined in the reduced schema.
         descriptive_table = descriptive_table.drop(
             [PerfStat.AVG.value.name, volatility_column], axis=1)
         _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
@@ -270,7 +286,7 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
         descriptive_table[PerfStat.RANK.to_str()] = ['{:.0%}'.format(0.01*x) for x in percentiles]
 
     elif desc_table_type == desc_table_type.EXTENSIVE:
-        # Apply each extended reduction only to columns containing observations.
+        # Apply moments only to varying samples and level reductions to observed samples.
         _add_moment_columns(descriptive_table, data_np, norm_variable_display_type)
         minimums = _reduce_observed(data_np, lambda values: np.nanmin(values, axis=0))
         lower_quantiles = _reduce_observed(
@@ -291,7 +307,7 @@ def compute_desc_table(df: Union[pd.DataFrame, pd.Series],
             = [var_format.format(x) for x in maximums]
 
     elif desc_table_type == desc_table_type.WITH_MEDIAN:
-        # Leave unobserved medians and moments as NaN without invoking warning-producing reducers.
+        # Keep medians for observed samples while leaving ineligible moments warning-free.
         medians = _reduce_observed(data_np, lambda values: np.nanmedian(values, axis=0))
         descriptive_table[PerfStat.MEDIAN.to_str(short=True)] \
             = [var_format.format(x) for x in medians]

--- a/src/qis/perfstats/tests/desc_table_constant_moments_test.py
+++ b/src/qis/perfstats/tests/desc_table_constant_moments_test.py
@@ -1,0 +1,260 @@
+"""Regression coverage for constant descriptive-table moments.
+
+Finite constant histories have useful level statistics but no standardized central moments:
+their means, zero sample volatility, positive probability, extrema, quantiles, median, last value,
+and average tie rank are defined, while skewness, excess kurtosis, and a normality p-value are not.
+The public table should therefore retain the defined strings and report the three moment results
+as ``nan`` without invoking SciPy reducers that warn about catastrophic cancellation.
+
+One 24-month mixed panel combines positive, zero, negative, and ragged constant histories with a
+symmetric finite-variable neighbor. The expectations below come from literal counts and central
+moments rather than another QIS calculation. Matched ordinary ``float64``/``np.nan`` and nullable
+``Float64``/``pd.NA`` inputs also verify labels, column order, named Series/DataFrame consistency,
+warning behavior, and caller ownership.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# qis
+import qis.perfstats.desc_table as desc_table_module
+from qis.perfstats.desc_table import DescTableType
+
+
+class _DescTableModuleProtocol(Protocol):
+    """Typed test-side interface for the public function exercised below."""
+
+    def compute_desc_table(
+        self,
+        *,
+        df: pd.DataFrame | pd.Series,
+        desc_table_type: DescTableType,
+    ) -> pd.DataFrame:
+        """Return a formatted descriptive-statistics table."""
+        raise NotImplementedError
+
+
+_DESC_TABLE_MODULE = cast(_DescTableModuleProtocol, desc_table_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent expectations
+# =============================================================================
+
+_DATES = pd.date_range("2024-01-31", periods=24, freq="ME")
+
+_POSITIVE_CONSTANT = "Positive Constant"
+_ZERO_CONSTANT = "Zero Constant"
+_NEGATIVE_CONSTANT = "Negative Constant"
+_RAGGED_CONSTANT = "Ragged Constant"
+_FINITE_VARIABLE = "Finite Variable"
+
+_ASSETS = (
+    _POSITIVE_CONSTANT,
+    _ZERO_CONSTANT,
+    _NEGATIVE_CONSTANT,
+    _RAGGED_CONSTANT,
+    _FINITE_VARIABLE,
+)
+
+_MOMENT_MODES = (
+    DescTableType.WITH_KURTOSIS,
+    DescTableType.WITH_NORMAL_PVAL,
+    DescTableType.SKEW_KURTOSIS,
+    DescTableType.EXTENSIVE,
+    DescTableType.WITH_MEDIAN,
+)
+
+_DEFINED_CONTROL_MODES = (
+    DescTableType.WITH_POSITIVE_PROB,
+    DescTableType.WITH_SCORE,
+)
+
+_EXPECTED_VALUES: dict[str, tuple[str, ...]] = {
+    "Avg": ("2.00", "0.00", "-3.00", "4.00", "0.00"),
+    "Std": ("0.00", "0.00", "0.00", "0.00", "7.07"),
+    "Positive": ("100.0%", "0.0%", "0.0%", "100.0%", "50.0%"),
+    "Skew": ("nan", "nan", "nan", "nan", "0.0"),
+    "Kurt": ("nan", "nan", "nan", "nan", "-1.2"),
+    "P-val": ("nan", "nan", "nan", "nan", "0.08"),
+    "Last": ("2.00", "0.00", "-3.00", "4.00", "11.50"),
+    "Rank": ("52%", "52%", "52%", "52%", "100%"),
+    "Min": ("2.00", "0.00", "-3.00", "4.00", "-11.50"),
+    "-1std": ("2.00", "0.00", "-3.00", "4.00", "-7.82"),
+    "Median": ("2.00", "0.00", "-3.00", "4.00", "0.00"),
+    "+1std": ("2.00", "0.00", "-3.00", "4.00", "7.82"),
+    "Max": ("2.00", "0.00", "-3.00", "4.00", "11.50"),
+}
+
+_EXPECTED_MODE_COLUMNS: dict[DescTableType, tuple[str, ...]] = {
+    DescTableType.WITH_POSITIVE_PROB: ("Avg", "Std", "Positive"),
+    DescTableType.WITH_KURTOSIS: ("Avg", "Std", "Skew", "Kurt"),
+    DescTableType.WITH_NORMAL_PVAL: ("Avg", "Std", "Skew", "Kurt", "P-val"),
+    DescTableType.WITH_SCORE: ("Avg", "Std", "Last", "Rank"),
+    DescTableType.EXTENSIVE: (
+        "Avg",
+        "Std",
+        "Skew",
+        "Kurt",
+        "Min",
+        "-1std",
+        "Median",
+        "+1std",
+        "Max",
+    ),
+    DescTableType.SKEW_KURTOSIS: ("Skew", "Kurt"),
+    DescTableType.WITH_MEDIAN: ("Avg", "Std", "Median", "Skew", "Kurt"),
+}
+
+
+def _mixed_returns(*, nullable: bool) -> pd.DataFrame:
+    """Create the mixed constant and finite-variable panel.
+
+    The finite neighbor is ``[-11.5, -10.5, ..., 11.5]``. Its mean is zero, its sample variance
+    is 50, its biased skewness is zero, and its biased excess kurtosis is
+    ``-1.204173913043478``. Linear interpolation at positions ``0.16 * 23`` and ``0.84 * 23``
+    gives the displayed quantiles ``-7.82`` and ``7.82``.
+
+    Args:
+        nullable: Whether every column uses pandas nullable ``Float64`` storage.
+
+    Returns:
+        Twenty-four-month panel containing every zero-spread state and a finite neighbor.
+    """
+    returns = pd.DataFrame(
+        {
+            _POSITIVE_CONSTANT: (2.0,) * len(_DATES),
+            _ZERO_CONSTANT: (0.0,) * len(_DATES),
+            _NEGATIVE_CONSTANT: (-3.0,) * len(_DATES),
+            _RAGGED_CONSTANT: (np.nan,) * 4 + (4.0,) * 20,
+            _FINITE_VARIABLE: tuple(float(value) - 11.5 for value in range(len(_DATES))),
+        },
+        index=_DATES,
+    )
+    if nullable:
+        return returns.astype(pd.Float64Dtype())
+    return returns
+
+
+def _expected_table(desc_table_type: DescTableType) -> pd.DataFrame:
+    """Build the expected formatted table for one public mode.
+
+    Args:
+        desc_table_type: Descriptive-table mode under test.
+
+    Returns:
+        Expected schema, row order, and independently specified display strings.
+    """
+    return pd.DataFrame(
+        {column: _EXPECTED_VALUES[column] for column in _EXPECTED_MODE_COLUMNS[desc_table_type]},
+        index=pd.Index(_ASSETS),
+    )
+
+
+def _compute_without_warnings(
+    data: pd.DataFrame | pd.Series,
+    desc_table_type: DescTableType,
+) -> pd.DataFrame:
+    """Call the public function while treating every warning as a failure.
+
+    Args:
+        data: Series or DataFrame supplied to the public function.
+        desc_table_type: Descriptive-table mode under test.
+
+    Returns:
+        Formatted descriptive-statistics table.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        return _DESC_TABLE_MODULE.compute_desc_table(
+            df=data,
+            desc_table_type=desc_table_type,
+        )
+
+
+# =============================================================================
+# Constant-moment regression and defined-statistic controls
+# =============================================================================
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+@pytest.mark.parametrize("desc_table_type", _MOMENT_MODES, ids=lambda mode: mode.name.lower())
+def test_compute_desc_table_constant_moments_remain_undefined_without_warnings(
+    desc_table_type: DescTableType,
+    nullable: bool,
+) -> None:
+    """Retain defined neighbors while zero-spread moments remain warning-free ``nan``.
+
+    Args:
+        desc_table_type: Moment-reporting table schema under test.
+        nullable: Whether the panel uses nullable ``Float64``/``pd.NA`` storage.
+    """
+    returns = _mixed_returns(nullable=nullable)
+    original = returns.copy()
+
+    actual = _compute_without_warnings(returns, desc_table_type)
+
+    pd.testing.assert_frame_equal(actual, _expected_table(desc_table_type))
+    pd.testing.assert_frame_equal(returns, original)
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+@pytest.mark.parametrize(
+    "desc_table_type", _DEFINED_CONTROL_MODES, ids=lambda mode: mode.name.lower()
+)
+def test_compute_desc_table_preserves_defined_constant_statistics(
+    desc_table_type: DescTableType,
+    nullable: bool,
+) -> None:
+    """Preserve constant positive probabilities, last values, and average tie ranks.
+
+    A 24-value constant has average rank ``(1 + 24) / 2 = 12.5`` and therefore percentile
+    ``12.5 / 24``, displayed as ``52%``. The ragged 20-value constant similarly displays ``52%``.
+
+    Args:
+        desc_table_type: Defined-statistic control schema under test.
+        nullable: Whether the panel uses nullable ``Float64``/``pd.NA`` storage.
+    """
+    returns = _mixed_returns(nullable=nullable)
+    original = returns.copy()
+
+    actual = _compute_without_warnings(returns, desc_table_type)
+
+    pd.testing.assert_frame_equal(actual, _expected_table(desc_table_type))
+    pd.testing.assert_frame_equal(returns, original)
+
+
+# =============================================================================
+# Public input-shape consistency
+# =============================================================================
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_compute_desc_table_preserves_constant_series_dataframe_consistency(
+    nullable: bool,
+) -> None:
+    """Return the same warning-free constant row for a named Series and one-column frame.
+
+    Args:
+        nullable: Whether both inputs use nullable ``Float64`` storage.
+    """
+    frame = _mixed_returns(nullable=nullable).filter(items=[_POSITIVE_CONSTANT])
+    series = frame[_POSITIVE_CONSTANT]
+    assert isinstance(series, pd.Series)
+    original_frame = frame.copy()
+    original_series = series.copy()
+
+    frame_result = _compute_without_warnings(frame, DescTableType.WITH_NORMAL_PVAL)
+    series_result = _compute_without_warnings(series, DescTableType.WITH_NORMAL_PVAL)
+    expected = _expected_table(DescTableType.WITH_NORMAL_PVAL).filter(
+        items=[_POSITIVE_CONSTANT], axis="index"
+    )
+
+    pd.testing.assert_frame_equal(frame_result, expected)
+    pd.testing.assert_frame_equal(series_result, expected)
+    pd.testing.assert_frame_equal(frame, original_frame)
+    pd.testing.assert_series_equal(series, original_series)


### PR DESCRIPTION
## What changed

Keep finite exact zero-spread columns out of standardized-moment reducers so their defined descriptive statistics remain available and their undefined skewness, kurtosis, and normality p-values remain formatted as missing without precision-loss warnings.

On accepted main, one 24-month mixed panel containing positive, zero, negative, and ragged constants plus a finite-variable neighbor emits 12 SciPy precision-loss warnings in each moment-only mode and 24 in `WITH_NORMAL_PVAL`, under both ordinary `float64` and nullable `Float64`, even though the resulting display strings are already correct.

## Behavior

Public signatures, defaults, exports, formats, and numerical results are unchanged. Finite exact constants retain their mean, zero sample volatility, positive probability, extrema, quantiles, median, last value, and average tie rank; their standardized moments remain `nan`. Nonzero-spread and non-finite samples keep their established behavior. The only changed observable is removal of inappropriate precision-loss warnings for finite exact constants.

## Regression evidence

Before the fix, `12` of the finalized `16` deterministic cases failed on `RuntimeWarning: Precision loss occurred in moment calculation due to catastrophic cancellation`; the four positive-probability and score controls passed. Independent references use literal constant values and the symmetric neighbor `[-11.5, ..., 11.5]`, whose mean is `0`, sample variance is `50`, skewness is `0`, excess kurtosis is `-1.204173913043478`, 16th/84th percentiles are `-7.82`/`7.82`, and positive share is `12 / 24`. After the fix, all `16` cases pass with exact strings, labels/order, ordinary/nullable parity, Series/DataFrame parity, warnings-as-errors, and unchanged caller inputs.

## Verification

- Focused constant-moment regression: `16 passed`.
- Complete `perfstats` suite: `604 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2104 passed, 16 warnings` in `246.28s`; all warnings are known third-party Seaborn/Matplotlib deprecations.
- Changed-line Ruff and Pyright/Pylance-aligned review: zero contribution-attributable findings.
- Public-API synchronization: current at `409` names.
- New-file formatting, dependency, and whitespace checks: passed for clean head `d145e5a`.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/desc_table.py`, and `src/qis/perfstats/tests/desc_table_constant_moments_test.py`.

Out of scope: Near-identical nonzero-spread moment precision remains PR 58, and observed infinity policy remains PR 59. This PR does not change warning filters, non-finite inputs, public signatures or exports, dependencies, unrelated reducers, or inherited formatting.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.