### PR TITLE
fix: report missing and zero legend ratios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected missing and near-zero percentages in legend diagnostics and defined all-missing
+  histories without an index error.
+
 ## [5.21.2] - 2026-08-31
 
 ### Added

--- a/src/qis/plots/tests/legend_missing_ratios_test.py
+++ b/src/qis/plots/tests/legend_missing_ratios_test.py
@@ -1,0 +1,283 @@
+"""Regression coverage for missing and zero ratios in public legend diagnostics.
+
+``LegendStats.MISSING_AVG_LAST`` reports post-inception missing coverage, while
+``LegendStats.AVG_STD_MISSING_ZERO`` reports the same missing coverage together with the share of
+near-zero observations. The denominator begins at each column's first observation so leading
+pre-inception gaps remain outside both ratios. An all-missing history has complete missing
+coverage but no observed window in which a zero ratio can be defined.
+
+One deliberately ordered panel distinguishes complete, leading-ragged, interior-missing,
+zero-heavy, mixed missing/zero, and all-missing histories. Independently specified percentages,
+ordinary and nullable floating storage, public Series/DataFrame consistency, warnings-as-errors,
+exact legend text, and caller ownership keep the diagnostic labels tied to the values they claim
+to display.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+# qis
+import qis.plots.time_series as time_series_module
+from qis.plots.utils import LegendStats
+from qis.utils.df_ops import compute_nans_zeros_ratio_after_first_non_nan
+
+
+class _TimeSeriesModuleProtocol(Protocol):
+    """Typed test-side interface for the public plotting function exercised below."""
+
+    def plot_time_series(
+        self,
+        df: pd.DataFrame | pd.Series,
+        *,
+        x_date_freq: None,
+        legend_stats: LegendStats,
+        var_format: str,
+        ax: Axes,
+    ) -> Figure | None:
+        """Plot a time series with the selected legend diagnostics.
+
+        Args:
+            df: Series or DataFrame supplied to the public plot.
+            x_date_freq: Disabled date-axis formatting for this focused legend test.
+            legend_stats: Missing-data diagnostic mode displayed in the legend.
+            var_format: Display format for level statistics.
+            ax: Matplotlib axis receiving the plot.
+
+        Returns:
+            The created figure, or None when the caller supplies ``ax``.
+        """
+        raise NotImplementedError
+
+
+_TIME_SERIES_MODULE = cast(_TimeSeriesModuleProtocol, time_series_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent expectations
+# =============================================================================
+
+_ALL_MISSING = "All Missing"
+_COMPLETE = "Complete"
+_INTERIOR_MISSING = "Interior Missing"
+_LEADING_GAPS = "Leading Gaps"
+_MIXED = "Mixed"
+_ZEROS = "Zeros"
+
+_DATES = pd.date_range("2024-01-31", periods=6, freq="ME")
+
+_AVG_STD_MISSING_ZERO_LINES = (
+    "Complete: avg=3.50, std=1.87, missing%=0.00%, zeros%=0.00%",
+    "Leading Gaps: avg=2.50, std=1.29, missing%=0.00%, zeros%=0.00%",
+    "Interior Missing: avg=2.50, std=1.29, missing%=33.33%, zeros%=0.00%",
+    "Zeros: avg=1.67, std=1.63, missing%=0.00%, zeros%=33.33%",
+    "Mixed: avg=0.75, std=0.96, missing%=20.00%, zeros%=40.00%",
+    "All Missing: avg=nan, std=nan, missing%=100.00%, zeros%=nan%",
+)
+
+_MISSING_AVG_LAST_LINES = (
+    "Complete: missing%=0.00%, avg=3.50, last=6.00",
+    "Leading Gaps: missing%=0.00%, avg=2.50, last=4.00",
+    "Interior Missing: missing%=33.33%, avg=2.50, last=4.00",
+    "Zeros: missing%=0.00%, avg=1.67, last=4.00",
+    "Mixed: missing%=20.00%, avg=0.75, last=0.00",
+    "All Missing: missing%=100.00%, avg=nan, last=nan",
+)
+
+_EXPECTED_MISSING_RATIOS = np.asarray((0.0, 0.0, 2.0 / 6.0, 0.0, 1.0 / 5.0, 1.0))
+_EXPECTED_ZERO_RATIOS = np.asarray((0.0, 0.0, 0.0, 2.0 / 6.0, 2.0 / 5.0, np.nan))
+
+
+def _mixed_values(*, nullable: bool) -> pd.DataFrame:
+    """Create every materially different post-inception diagnostic state.
+
+    The leading-ragged history confirms that the denominator starts at its first observation.
+    Interior missing values and zeros are separated so a mislabeled ratio cannot satisfy both
+    controls, while the mixed history independently establishes denominators of five.
+
+    Args:
+        nullable: Whether to store values as pandas nullable ``Float64``/``pd.NA``.
+
+    Returns:
+        Six-date panel in the same deliberate order as the expected legend entries.
+    """
+    values = pd.DataFrame(
+        {
+            _COMPLETE: (1.0, 2.0, 3.0, 4.0, 5.0, 6.0),
+            _LEADING_GAPS: (np.nan, np.nan, 1.0, 2.0, 3.0, 4.0),
+            _INTERIOR_MISSING: (1.0, np.nan, np.nan, 2.0, 3.0, 4.0),
+            _ZEROS: (1.0, 0.0, 0.0, 2.0, 3.0, 4.0),
+            _MIXED: (np.nan, 1.0, 0.0, np.nan, 2.0, 0.0),
+            _ALL_MISSING: (np.nan,) * len(_DATES),
+        },
+        index=_DATES,
+    )
+    if nullable:
+        return values.astype(pd.Float64Dtype())
+    return values
+
+
+def _legend_lines(data: pd.DataFrame | pd.Series, legend_stats: LegendStats) -> tuple[str, ...]:
+    """Draw through the public plotting API and return exact legend text.
+
+    Args:
+        data: Time series whose diagnostics are displayed.
+        legend_stats: Missing-data legend mode under test.
+
+    Returns:
+        Legend entries in input-column order.
+    """
+    figure, axis = plt.subplots()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _TIME_SERIES_MODULE.plot_time_series(
+                data,
+                x_date_freq=None,
+                legend_stats=legend_stats,
+                var_format="{:.2f}",
+                ax=axis,
+            )
+        legend = axis.get_legend()
+        assert legend is not None
+        return tuple(text.get_text() for text in legend.get_texts())
+    finally:
+        plt.close(figure)
+
+
+# =============================================================================
+# Missing-versus-zero diagnostic identity
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("legend_stats", "expected"),
+    (
+        (LegendStats.AVG_STD_MISSING_ZERO, _AVG_STD_MISSING_ZERO_LINES[:-1]),
+        (LegendStats.MISSING_AVG_LAST, _MISSING_AVG_LAST_LINES[:-1]),
+    ),
+)
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_plot_time_series_distinguishes_missing_and_zero_ratios(
+    legend_stats: LegendStats,
+    expected: tuple[str, ...],
+    nullable: bool,
+) -> None:
+    """Attach each diagnostic label to its independently calculated ratio.
+
+    Args:
+        legend_stats: Composite or missing-only diagnostic mode.
+        expected: Exact entries for every history with an observed starting point.
+        nullable: Whether the input uses nullable ``Float64``/``pd.NA`` storage.
+    """
+    values = _mixed_values(nullable=nullable).drop(columns=_ALL_MISSING)
+    original_values = values.copy(deep=True)
+
+    actual = _legend_lines(values, legend_stats)
+
+    assert actual == expected
+    pd.testing.assert_frame_equal(values, original_values)
+
+
+# =============================================================================
+# All-missing mixed-panel boundary
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("legend_stats", "expected"),
+    (
+        (LegendStats.AVG_STD_MISSING_ZERO, _AVG_STD_MISSING_ZERO_LINES),
+        (LegendStats.MISSING_AVG_LAST, _MISSING_AVG_LAST_LINES),
+    ),
+)
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_plot_time_series_reports_all_missing_diagnostics_without_errors(
+    legend_stats: LegendStats,
+    expected: tuple[str, ...],
+    nullable: bool,
+) -> None:
+    """Keep finite neighbors intact while reporting an all-missing history.
+
+    Args:
+        legend_stats: Composite or missing-only diagnostic mode.
+        expected: Exact entries including complete missing coverage and undefined zeros.
+        nullable: Whether the input uses nullable ``Float64``/``pd.NA`` storage.
+    """
+    values = _mixed_values(nullable=nullable)
+    original_values = values.copy(deep=True)
+
+    actual = _legend_lines(values, legend_stats)
+
+    assert actual == expected
+    pd.testing.assert_frame_equal(values, original_values)
+
+
+# =============================================================================
+# Named Series/DataFrame consistency
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("legend_stats", "expected"),
+    (
+        (LegendStats.AVG_STD_MISSING_ZERO, (_AVG_STD_MISSING_ZERO_LINES[2],)),
+        (LegendStats.MISSING_AVG_LAST, (_MISSING_AVG_LAST_LINES[2],)),
+    ),
+)
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_missing_ratio_named_series_matches_dataframe(
+    legend_stats: LegendStats,
+    expected: tuple[str, ...],
+    nullable: bool,
+) -> None:
+    """Return identical diagnostics for equivalent Series and one-column frames.
+
+    Args:
+        legend_stats: Composite or missing-only diagnostic mode.
+        expected: Independently specified one-entry legend text.
+        nullable: Whether the input uses nullable ``Float64``/``pd.NA`` storage.
+    """
+    selected = _mixed_values(nullable=nullable)[_INTERIOR_MISSING]
+    assert isinstance(selected, pd.Series)
+    series = selected
+    frame = series.to_frame()
+    original_series = series.copy(deep=True)
+    original_frame = frame.copy(deep=True)
+
+    frame_result = _legend_lines(frame, legend_stats)
+    series_result = _legend_lines(series, legend_stats)
+
+    assert frame_result == expected
+    assert series_result == expected
+    assert series_result == frame_result
+    pd.testing.assert_frame_equal(frame, original_frame)
+    pd.testing.assert_series_equal(series, original_series)
+
+
+# =============================================================================
+# Ratio-helper contract
+# =============================================================================
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_ratio_helper_uses_post_inception_windows_and_defines_all_missing(nullable: bool) -> None:
+    """Return independent missing and zero ratios without changing the input panel.
+
+    Args:
+        nullable: Whether the input uses nullable ``Float64``/``pd.NA`` storage.
+    """
+    values = _mixed_values(nullable=nullable)
+    original_values = values.copy(deep=True)
+
+    missing_ratios, zero_ratios = compute_nans_zeros_ratio_after_first_non_nan(values)
+
+    np.testing.assert_allclose(missing_ratios, _EXPECTED_MISSING_RATIOS)
+    np.testing.assert_allclose(zero_ratios, _EXPECTED_ZERO_RATIOS, equal_nan=True)
+    pd.testing.assert_frame_equal(values, original_values)

--- a/src/qis/plots/utils.py
+++ b/src/qis/plots/utils.py
@@ -749,13 +749,15 @@ class LegendStats(Enum):
     the third and fourth moments, ``TSTAT`` mean over standard error, ``TOTAL`` the sum,
     ``FIRST`` and ``LAST`` the endpoints, ``MIN`` and ``MAX`` the extremes.
 
-    Three modifiers change what the statistics are computed on:
+    Five modifiers change what the statistics are computed on or displayed beside them:
 
     ``NONNAN`` takes the last observed value rather than the value at the last index, which
     differs when a series ends with gaps. ``NONZERO`` excludes zeros, for a series where zero
-    means "no position" rather than "a return of zero". ``MISSING`` prefixes the count of NaN
-    observations, which is how a ragged panel shows its own coverage in the legend. ``SCORE``
-    appends the percentile rank of the last value within its own history.
+    means "no position" rather than "a return of zero". ``MISSING`` reports the percentage of
+    NaN observations after the first observed value, while ``ZERO`` reports the percentage whose
+    absolute value is below the near-zero cutoff over the same window. An all-missing history has
+    100% missing coverage and an undefined zero percentage. ``SCORE`` appends the percentile rank
+    of the last value within its own history.
 
     ``NONE`` prints the column name alone. Formatting of every value follows the ``var_format``
     argument of the plotting function, so the enum chooses the statistics and not their display.
@@ -1135,37 +1137,36 @@ def get_legend_lines(data: Union[pd.DataFrame, pd.Series],
         missing_ratio, zeros_ratio = dfo.compute_nans_zeros_ratio_after_first_non_nan(df=data)
         for idx, column in enumerate(data.columns):
             column_data = data[column]
+            # Keep the two diagnostic labels tied to their independently computed ratios.
+            missing = missing_ratio[idx]
+            zeros = zeros_ratio[idx]
             if np.all(np.isnan(column_data)):
                 avg = nan_display
                 std = nan_display
-                # missing = 1.0
-                zeros = nan_display
             else:
                 avg = np.nanmean(column_data)
                 std = np.nanstd(column_data, ddof=1)
-                # missing = missing_ratio[idx]
-                zeros = zeros_ratio[idx]
             legend_lines.append(f"{column}: avg={var_format.format(avg)}, "
                                 f"std={var_format.format(std)}, "
-                                # f"missing%={'{:0.2%}'.format(missing)}, "
-                                f"missing%={'{:0.2%}'.format(zeros)}")
+                                f"missing%={'{:0.2%}'.format(missing)}, "
+                                f"zeros%={'{:0.2%}'.format(zeros)}")
 
     elif legend_stats == LegendStats.MISSING_AVG_LAST:
         legend_lines = []
-        missing_ratio, zeros_ratio = dfo.compute_nans_zeros_ratio_after_first_non_nan(df=data)
+        missing_ratio, _ = dfo.compute_nans_zeros_ratio_after_first_non_nan(df=data)
         for idx, column in enumerate(data.columns):
             column_data = data[column]
+            # Report missing coverage rather than the helper's separate near-zero ratio.
+            missing = missing_ratio[idx]
             if np.all(np.isnan(column_data)):
                 avg = nan_display
                 last = nan_display
-                zeros = nan_display
             else:
                 nonnan_data = column_data.dropna()
                 avg = np.nanmean(nonnan_data)
                 last = nonnan_data.iloc[-1]
-                zeros = zeros_ratio[idx]
             legend_lines.append(f"{column}: "
-                                f"missing%={'{:0.2%}'.format(zeros)}, "
+                                f"missing%={'{:0.2%}'.format(missing)}, "
                                 f"avg={var_format.format(avg)}, "
                                 f"last={var_format.format(last)}")
 

--- a/src/qis/utils/df_ops.py
+++ b/src/qis/utils/df_ops.py
@@ -119,26 +119,43 @@ def get_nonnan_index(df: Union[pd.Series, pd.DataFrame],
 def compute_nans_zeros_ratio_after_first_non_nan(df: Union[pd.Series, pd.DataFrame],
                                                  zero_cutoff: float = 1e-12
                                                  ) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute missing and near-zero ratios after each series begins.
+
+    Leading missing values before the first observation are outside the denominator. An
+    all-missing series has complete missing coverage and an undefined near-zero ratio because no
+    observed window exists.
+
+    Args:
+        df: Series or time-by-variable DataFrame whose columns are evaluated independently.
+        zero_cutoff: Strict absolute-value threshold used to classify a finite value as near zero.
+
+    Returns:
+        Missing ratios and near-zero ratios aligned to the input column order.
     """
-   compute ratio  of missing data
-    """
-    if isinstance(df, pd.Series):
-        df = df.to_frame()
+    data = df.to_frame() if isinstance(df, pd.Series) else df
 
-    missing = []
-    zeros = []
-    for column in df:
-        column_data = df[column]
-        nonnan_cond = column_data.isnull() == False
-        fist_nonnan_index = column_data.loc[nonnan_cond].index[0]
-        after_data = column_data.loc[fist_nonnan_index:]
-        missing.append(after_data.isnull().sum() / len(after_data))
-        zeros.append(after_data.abs().lt(zero_cutoff).sum() / len(after_data))
+    missing: List[float] = []
+    zeros: List[float] = []
+    for _, column_data in data.items():
+        assert isinstance(column_data, pd.Series)
+        column_values: np.ndarray = column_data.to_numpy(dtype=float, na_value=np.nan)
+        nonnan_cond = ~np.isnan(column_values)
+        if not bool(nonnan_cond.any()):
+            # No observation defines a zero-ratio window, but coverage is entirely missing.
+            missing.append(1.0)
+            zeros.append(np.nan)
+            continue
 
-    missing_ratio = np.array(missing)
-    zeros_ratio = np.array(zeros)
+        # Begin both diagnostic denominators at this column's first observed position.
+        first_nonnan_position = int(np.flatnonzero(nonnan_cond)[0])
+        after_values = column_values[first_nonnan_position:]
+        after_count = len(after_values)
+        missing_count = np.count_nonzero(np.isnan(after_values))
+        zero_count = np.count_nonzero(np.abs(after_values) < zero_cutoff)
+        missing.append(float(missing_count / after_count))
+        zeros.append(float(zero_count / after_count))
 
-    return missing_ratio, zeros_ratio
+    return np.asarray(missing, dtype=float), np.asarray(zeros, dtype=float)
 
 
 def get_first_nonnan_values(df: Union[np.ndarray, pd.Series, pd.DataFrame]) -> Union[np.ndarray, float]:


### PR DESCRIPTION
## What changed

Correct the missing and near-zero percentages displayed by the two public legend diagnostic modes and define their all-missing-column behavior.

Both diagnostic modes previously displayed the near-zero ratio under `missing%`; `AVG_STD_MISSING_ZERO` omitted a separate zero label, and an all-missing neighbor raised `IndexError` before the legend could be built.

## Behavior

`MISSING_AVG_LAST` now reports post-inception missing coverage, and `AVG_STD_MISSING_ZERO` reports distinct `missing%` and `zeros%` values. An all-missing history reports `100%` missing and an undefined zero ratio. Public signatures, exports, averages, sample standard deviations, endpoint selection, the strict near-zero cutoff, and the post-first-observation denominator are unchanged.

## Regression evidence

- **Fail before:** all `14` finalized ordinary/nullable cases failed: finite panels exposed the mislabeled or omitted ratios and mixed panels containing an all-missing history raised `IndexError`.
- **Independent expectation:** literal observation counts establish missing ratios `[0, 0, 2/6, 0, 1/5, 1]` and zero ratios `[0, 0, 0, 2/6, 2/5, NaN]` for complete, leading-ragged, interior-missing, zero-heavy, mixed, and all-missing histories.
- **Pass after:** all `14` focused cases pass under ordinary `float64` and nullable `Float64`, including exact legend text, warnings-as-errors, mixed-panel behavior, Series/DataFrame consistency, helper output, and caller ownership.

## Verification

- Complete plots suite, including all focused PR 62 cases: `90 passed`.
- Additional perfstats safety suite: `618 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2133 passed, 16 warnings`; all warnings are known third-party seaborn/Matplotlib deprecations.
- Changed-line Ruff and differential Pyright: zero PR-attributable diagnostics; the new test module also passed the strict formatter preflight.
- Public-API synchronization: current at `413` names.
- Dependency, receipt-integrity, ancestry, formatting, and whitespace checks: passed for clean head `2c063ae` against accepted base `368bf36`.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/plots/utils.py`, `src/qis/utils/df_ops.py`, and `src/qis/plots/tests/legend_missing_ratios_test.py`.

Out of scope: Changing the post-inception denominator, averages, sample standard deviations, endpoint selection, near-zero threshold, formatting, public signatures, exports, or dependencies.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.