### PR TITLE
fix: validate calendar indexes before resampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   documented observation selection.
 - Made `append_time_series()` apply its stable keep-last duplicate-date rule before overlap
   diagnostics and empty-newer initialization.
+- Added deterministic calendar-index validation before resampling, backfilling, and infrequent
+  return interpolation can expose incidental pandas errors or discard invalidly labelled data.
 
 ## [5.21.2] - 2026-08-31
 

--- a/src/qis/perfstats/tests/timeseries_calendar_index_test.py
+++ b/src/qis/perfstats/tests/timeseries_calendar_index_test.py
@@ -1,0 +1,325 @@
+"""Regression tests for calendar indexes in time-series reconstruction paths.
+
+``bfill_timeseries`` constructs a requested calendar grid, and
+``interpolate_infrequent_returns`` subtracts timestamps to parameterize a Brownian bridge. Both
+operations therefore require nonempty providers to use ``DatetimeIndex`` objects without ``NaT``.
+They should reject invalid grids at their public boundary instead of silently discarding values or
+leaking incidental pandas errors.
+
+Empty providers remain schema declarations and need no date-axis validation. The valid mixed-panel
+control combines timezone-aware, unsorted, duplicate, nullable, finite, and all-missing states to
+confirm that the guard preserves established provider selection, values, metadata, warnings,
+caller ownership, and return shape.
+"""
+
+import warnings
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.perfstats.returns import to_returns
+from qis.perfstats.timeseries_bfill import bfill_timeseries, interpolate_infrequent_returns
+
+
+# =============================================================================
+# Shared deterministic fixtures and comparison helpers
+# =============================================================================
+
+_DATES = pd.date_range("2024-01-01", periods=5, freq="D")
+
+_PanelShape = Literal["series", "frame"]
+_InvalidIndex = Literal["non-date", "NaT"]
+
+
+def _make_panel(
+    values: tuple[float, ...],
+    index: pd.Index,
+    shape: _PanelShape,
+    *,
+    name: str,
+) -> pd.Series | pd.DataFrame:
+    """Create one Series or single-column DataFrame provider.
+
+    Args:
+        values: Literal observations assigned in order.
+        index: Provider labels.
+        shape: Return a Series or DataFrame.
+        name: Series name or DataFrame column label.
+
+    Returns:
+        Fresh provider with ordinary floating storage.
+    """
+    series = pd.Series(values, index=index, name=name, dtype=np.float64)
+    if shape == "series":
+        return series
+    return series.to_frame()
+
+
+def _assert_panel_equal(
+    actual: pd.Series | pd.DataFrame,
+    expected: pd.Series | pd.DataFrame,
+) -> None:
+    """Assert complete shape-specific equality.
+
+    Args:
+        actual: Public result or caller-owned provider.
+        expected: Independently constructed result or provider snapshot.
+    """
+    if isinstance(actual, pd.Series):
+        assert isinstance(expected, pd.Series)
+        pd.testing.assert_series_equal(actual, expected, check_exact=True, check_freq=False)
+    else:
+        assert isinstance(expected, pd.DataFrame)
+        pd.testing.assert_frame_equal(actual, expected, check_exact=True, check_freq=False)
+
+
+def _invalid_index(kind: _InvalidIndex) -> pd.Index:
+    """Return one unsupported nonempty index for a calendar operation.
+
+    Args:
+        kind: Construct non-date labels or a date index containing ``NaT``.
+
+    Returns:
+        Two-row invalid index.
+    """
+    if kind == "non-date":
+        return pd.RangeIndex(2, name="row")
+    return pd.DatetimeIndex((_DATES[0], pd.NaT), name="date")
+
+
+def _expected_error(argument_name: str, kind: _InvalidIndex) -> tuple[type[Exception], str]:
+    """Return the deterministic public exception contract.
+
+    Args:
+        argument_name: Public parameter carrying the invalid index.
+        kind: Invalid index category.
+
+    Returns:
+        Exact exception class and anchored message pattern.
+    """
+    if kind == "non-date":
+        return TypeError, rf"^{argument_name} must use a DatetimeIndex for calendar operations$"
+    return ValueError, rf"^{argument_name} index must not contain NaT$"
+
+
+# =============================================================================
+# Backfill calendar-index failures
+# =============================================================================
+
+
+@pytest.mark.parametrize("shape", ("series", "frame"))
+@pytest.mark.parametrize("argument_name", ("df_newer", "df_older"))
+@pytest.mark.parametrize("invalid_kind", ("non-date", "NaT"))
+def test_bfill_timeseries_rejects_invalid_nonempty_provider_index(
+    invalid_kind: _InvalidIndex,
+    argument_name: str,
+    shape: _PanelShape,
+) -> None:
+    """Reject each invalid provider before calendar construction can lose its values.
+
+    Args:
+        invalid_kind: Non-date or undefined date boundary under test.
+        argument_name: Newer or older provider receiving that boundary.
+        shape: Public pandas container under test.
+    """
+    newer_index: pd.Index = pd.DatetimeIndex(_DATES[3:], name="date")
+    older_index: pd.Index = pd.DatetimeIndex(_DATES[:2], name="date")
+    if argument_name == "df_newer":
+        newer_index = _invalid_index(invalid_kind)
+    else:
+        older_index = _invalid_index(invalid_kind)
+    newer = _make_panel((0.40, 0.50), newer_index, shape, name="Asset")
+    older = _make_panel((0.10, 0.20), older_index, shape, name="Asset")
+    original_newer = newer.copy(deep=True)
+    original_older = older.copy(deep=True)
+    exception_type, message = _expected_error(argument_name, invalid_kind)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(exception_type, match=message):
+            bfill_timeseries(df_newer=newer, df_older=older, freq="D")
+
+    _assert_panel_equal(newer, original_newer)
+    _assert_panel_equal(older, original_older)
+
+
+# =============================================================================
+# Empty-provider and valid mixed-panel controls
+# =============================================================================
+
+
+@pytest.mark.parametrize("shape", ("series", "frame"))
+@pytest.mark.parametrize("empty_argument", ("df_newer", "df_older"))
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "Float64"))
+def test_bfill_timeseries_preserves_empty_non_date_provider_schema(
+    nullable: bool,
+    empty_argument: str,
+    shape: _PanelShape,
+) -> None:
+    """Skip date validation for an empty provider while preserving the available history.
+
+    Args:
+        nullable: Use ordinary or pandas nullable floating storage.
+        empty_argument: Newer or older provider declared without observations.
+        shape: Public pandas container under test.
+    """
+    dtype = pd.Float64Dtype() if nullable else np.dtype("float64")
+    available = pd.Series((0.10, 0.20), index=_DATES[:2], dtype=dtype, name="Asset")
+    empty = pd.Series([], index=pd.RangeIndex(0, name="row"), dtype=dtype, name="Asset")
+    available_panel: pd.Series | pd.DataFrame = (
+        available if shape == "series" else available.to_frame()
+    )
+    empty_panel: pd.Series | pd.DataFrame = empty if shape == "series" else empty.to_frame()
+    if empty_argument == "df_newer":
+        newer, older = empty_panel, available_panel
+    else:
+        newer, older = available_panel, empty_panel
+    original_newer = newer.copy(deep=True)
+    original_older = older.copy(deep=True)
+    expected = available if shape == "series" else available.to_frame()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = bfill_timeseries(df_newer=newer, df_older=older, freq="D")
+
+    _assert_panel_equal(actual, expected)
+    _assert_panel_equal(newer, original_newer)
+    _assert_panel_equal(older, original_older)
+
+
+def test_bfill_timeseries_preserves_valid_timezone_aware_mixed_panel() -> None:
+    """Keep stable duplicate selection and ragged nullable values on a valid date grid.
+
+    Older rows arrive as January 2, January 1, and January 2, so stable chronological repair
+    retains the final January 2 value of 25%. Newer rows arrive as January 4 then January 3 and
+    supply the literal 40% and 30% tail. The all-missing neighbor remains undefined throughout.
+    """
+    timezone = "America/New_York"
+    older_index = pd.DatetimeIndex(
+        ("2024-01-02", "2024-01-01", "2024-01-02"),
+        tz=timezone,
+        name="date",
+    )
+    newer_index = pd.DatetimeIndex(
+        ("2024-01-04", "2024-01-03"),
+        tz=timezone,
+        name="date",
+    )
+    older = pd.DataFrame(
+        {"finite": (0.20, 0.10, 0.25), "all_missing": (pd.NA, pd.NA, pd.NA)},
+        index=older_index,
+        dtype="Float64",
+    )
+    newer = pd.DataFrame(
+        {"finite": (0.40, 0.30), "all_missing": (pd.NA, pd.NA)},
+        index=newer_index,
+        dtype="Float64",
+    )
+    original_newer = newer.copy(deep=True)
+    original_older = older.copy(deep=True)
+    expected = pd.DataFrame(
+        {
+            "finite": (0.10, 0.25, 0.30, 0.40),
+            "all_missing": (pd.NA, pd.NA, pd.NA, pd.NA),
+        },
+        index=pd.date_range("2024-01-01", periods=4, freq="D", tz=timezone, name="date"),
+        dtype="Float64",
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = bfill_timeseries(df_newer=newer, df_older=older, freq="D")
+
+    assert isinstance(actual, pd.DataFrame)
+    pd.testing.assert_frame_equal(actual, expected, check_exact=True)
+    pd.testing.assert_frame_equal(newer, original_newer, check_exact=True)
+    pd.testing.assert_frame_equal(older, original_older, check_exact=True)
+
+
+# =============================================================================
+# Non-calendar return conversion control
+# =============================================================================
+
+
+def test_to_returns_preserves_non_date_index_without_resampling() -> None:
+    """Keep arbitrary row labels valid when return conversion requests no calendar operation.
+
+    Prices ``[100, 110, 121]`` independently imply relative returns ``[missing, 10%, 10%]``.
+    The calendar guard must not reject or relabel this supported no-resampling calculation.
+    """
+    prices = pd.Series((100.0, 110.0, 121.0), index=pd.RangeIndex(3, name="row"), name="Asset")
+    original = prices.copy(deep=True)
+    expected = pd.Series((np.nan, 0.10, 0.10), index=prices.index, name=prices.name)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = to_returns(prices, freq=None, ffill_nans=False)
+
+    assert isinstance(actual, pd.Series)
+    pd.testing.assert_series_equal(
+        actual,
+        expected,
+        check_exact=False,
+        rtol=1.0e-12,
+        atol=0.0,
+    )
+    pd.testing.assert_series_equal(prices, original, check_exact=True)
+
+
+# =============================================================================
+# Brownian-bridge calendar-index failures
+# =============================================================================
+
+
+@pytest.mark.parametrize("infrequent_shape", ("series", "frame"))
+@pytest.mark.parametrize("argument_name", ("infrequent_returns", "pivot_returns"))
+@pytest.mark.parametrize("invalid_kind", ("non-date", "NaT"))
+def test_interpolate_infrequent_returns_rejects_invalid_nonempty_index(
+    invalid_kind: _InvalidIndex,
+    argument_name: str,
+    infrequent_shape: _PanelShape,
+) -> None:
+    """Reject unsupported bridge grids before timestamp subtraction or slicing.
+
+    Args:
+        invalid_kind: Non-date or undefined date boundary under test.
+        argument_name: Reported or pivot input receiving that boundary.
+        infrequent_shape: Series or DataFrame reported-return shape.
+    """
+    infrequent_index: pd.Index = pd.DatetimeIndex(_DATES[[0, 4]], name="date")
+    pivot_index: pd.Index = pd.DatetimeIndex(_DATES, name="date")
+    if argument_name == "infrequent_returns":
+        infrequent_index = _invalid_index(invalid_kind)
+    else:
+        pivot_index = (
+            pd.RangeIndex(5, name="row")
+            if invalid_kind == "non-date"
+            else pd.DatetimeIndex(
+                (_DATES[0], _DATES[1], pd.NaT, _DATES[3], _DATES[4]),
+                name="date",
+            )
+        )
+    infrequent_series = pd.Series((0.02, 0.03), index=infrequent_index, name="Private")
+    infrequent: pd.Series | pd.DataFrame = (
+        infrequent_series if infrequent_shape == "series" else infrequent_series.to_frame()
+    )
+    pivot = pd.Series((0.01, -0.02, 0.015, -0.005, 0.025), index=pivot_index, name="Market")
+    original_infrequent = infrequent.copy(deep=True)
+    original_pivot = pivot.copy(deep=True)
+    exception_type, message = _expected_error(argument_name, invalid_kind)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(exception_type, match=message):
+            interpolate_infrequent_returns(
+                infrequent_returns=infrequent,
+                pivot_returns=pivot,
+                span=3,
+                annualization_factor=365,
+                vol_adjustment=1.0,
+            )
+
+    _assert_panel_equal(infrequent, original_infrequent)
+    pd.testing.assert_series_equal(pivot, original_pivot, check_exact=True)

--- a/src/qis/perfstats/timeseries_bfill.py
+++ b/src/qis/perfstats/timeseries_bfill.py
@@ -18,6 +18,7 @@ import pandas as pd
 from typing import Optional, Union, List, Tuple, cast
 # qis
 import qis.utils.df_ops as dfo
+import qis.utils.df_freq as dfr
 import qis.utils.np_ops as npo
 import qis.perfstats.returns as ret
 import qis.models.linear.ewm as ewm
@@ -56,7 +57,16 @@ def interpolate_infrequent_returns(infrequent_returns: Union[pd.Series, pd.DataF
 
     Returns:
         the interpolated returns on the index of ``pivot_returns``, in the shape of the input
+
+    Raises:
+        TypeError: If a nonempty input does not use a ``DatetimeIndex``.
+        ValueError: If a nonempty input index contains ``NaT``, or if ``infrequent_returns``
+            contains missing values.
     """
+    # Both paths perform timestamp slicing and subtraction, so validate their grids up front.
+    dfr.validate_calendar_index(infrequent_returns, argument_name="infrequent_returns")
+    dfr.validate_calendar_index(pivot_returns, argument_name="pivot_returns")
+
     # call recursion here
     if isinstance(infrequent_returns, pd.DataFrame):
         infrequent_return_backfills = {}
@@ -158,10 +168,12 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
     Args:
         df_newer: Newer Series or DataFrame whose labels and columns define the output. Its rows
             are interpreted in increasing date order without modifying the caller's object. A
-            zero-row object retains its declared schema; a zero-column DataFrame is invalid.
+            nonempty provider requires a ``DatetimeIndex`` without ``NaT``. A zero-row object
+            retains its declared schema; a zero-column DataFrame is invalid.
         df_older: Older object of the same pandas type, used before each newer history begins. Its
             rows are also interpreted in increasing date order without modifying the caller. A
-            zero-row object or zero-column DataFrame is treated as an unavailable provider.
+            nonempty provider requires a ``DatetimeIndex`` without ``NaT``. A zero-row object or
+            zero-column DataFrame is treated as an unavailable provider.
         freq: Frequency of the returned date grid.
         fill_method: Return-gap policy. ``None`` preserves missing returns, ``'to_zero'`` fills
             missing returns with zero after each column begins, and ``'ffill'`` carries its last
@@ -178,8 +190,9 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
         empty object with that schema is returned.
 
     Raises:
-        ValueError: If the newer DataFrame has no columns, or if ``fill_method`` is not ``None``,
-            ``'to_zero'``, or ``'ffill'``.
+        TypeError: If a nonempty provider does not use a ``DatetimeIndex``.
+        ValueError: If a nonempty provider index contains ``NaT``, the newer DataFrame has no
+            columns, or ``fill_method`` is not ``None``, ``'to_zero'``, or ``'ffill'``.
         NotImplementedError: If the newer and older inputs are not both Series or both
             DataFrames.
     """
@@ -200,6 +213,10 @@ def bfill_timeseries(df_newer: Union[pd.DataFrame, pd.Series],  # more recent da
         pass
     else:
         raise NotImplementedError(f"type1={type(df_newer)}, type2={type(df_older)}") 
+
+    # Only providers contributing observations need a valid calendar axis; empty schemas remain.
+    dfr.validate_calendar_index(df_newer, argument_name="df_newer")
+    dfr.validate_calendar_index(df_older, argument_name="df_older")
 
     # Provider row order carries no information; boundaries and fills must run chronologically.
     if not df_newer.index.is_monotonic_increasing:

--- a/src/qis/utils/df_freq.py
+++ b/src/qis/utils/df_freq.py
@@ -19,6 +19,31 @@ import qis.utils.dates as da
 FillnaOptions = Literal["bfill", "ffill", "pad"]
 
 
+def validate_calendar_index(data: Union[pd.DataFrame, pd.Series],
+                            argument_name: str
+                            ) -> None:
+    """Validate the date axis required by calendar operations.
+
+    Empty objects remain valid schema declarations because they contribute no observations to a
+    schedule. The validator deliberately leaves sorting and duplicate-date policy to the calling
+    operation.
+
+    Args:
+        data: Series or DataFrame about to undergo calendar scheduling or timestamp arithmetic.
+        argument_name: Public parameter name used in deterministic error messages.
+
+    Raises:
+        TypeError: If a nonempty object does not use a ``DatetimeIndex``.
+        ValueError: If a nonempty object's index contains ``NaT``.
+    """
+    if data.empty:
+        return
+    if not isinstance(data.index, pd.DatetimeIndex):
+        raise TypeError(f"{argument_name} must use a DatetimeIndex for calendar operations")
+    if data.index.hasnans:
+        raise ValueError(f"{argument_name} index must not contain NaT")
+
+
 def _apply_fill(df: Union[pd.DataFrame, pd.Series],
                 fill_na_method: Optional[FillnaOptions]
                 ) -> Union[pd.DataFrame, pd.Series]:
@@ -49,7 +74,8 @@ def df_asfreq(df: Union[pd.DataFrame, pd.Series],
     with optional inclusion of the original start/end dates.
 
     Args:
-        df: input time series
+        df: Input time series. Calendar resampling requires a nonempty object to use a
+            ``DatetimeIndex`` without ``NaT``; arbitrary indexes remain valid when ``freq=None``.
         freq: pandas frequency string; None returns df unchanged
         method: fill method passed to pd.DataFrame.reindex()
         fill_na_method: residual fill applied after reindex (handles leading/trailing NaNs)
@@ -58,12 +84,21 @@ def df_asfreq(df: Union[pd.DataFrame, pd.Series],
         include_end_date: if True, ensures df's last date is in the output index
         tz: timezone string passed to date schedule generation
 
+    Raises:
+        TypeError: If calendar resampling is requested for a nonempty object without a
+            ``DatetimeIndex``.
+        ValueError: If calendar resampling is requested for a nonempty object whose index contains
+            ``NaT``.
+
     Note:
         Using include_start_date / include_end_date may produce an irregular index.
         A df whose index is not in chronological order is sorted before resampling.
     """
     if freq is None or df.empty:
         return df
+
+    # Validate the structural requirement only when a calendar schedule will be constructed.
+    validate_calendar_index(df, argument_name="df")
 
     # Everything below assumes the panel is in chronological order: the pre-reindex ffill
     # carries values forward in ROW order, and reindex(method='ffill') raises

--- a/src/qis/utils/tests/df_freq_calendar_index_test.py
+++ b/src/qis/utils/tests/df_freq_calendar_index_test.py
@@ -1,0 +1,197 @@
+"""Regression tests for calendar-index validation in ``df_asfreq``.
+
+Calendar resampling requires timestamp labels because it constructs a date schedule and carries
+observations to scheduled dates. Non-date labels remain valid when no resampling is requested,
+and empty objects remain useful schema declarations. These tests distinguish those pass-through
+contracts from nonempty calendar operations, which should reject unsupported indexes before
+pandas exposes an incidental attribute or schedule-generation error.
+
+The deterministic valid control combines an unsorted timezone-aware index, a missing nullable
+value, and literal daily expectations. It therefore confirms that validation changes only invalid
+input failures while preserving chronological repair, timezone metadata, nullable storage,
+caller ownership, and resampled values.
+"""
+
+import warnings
+from typing import Literal
+
+import pandas as pd
+import pytest
+
+from qis.utils.df_freq import df_asfreq
+
+
+# =============================================================================
+# Shared deterministic fixtures
+# =============================================================================
+
+_NON_DATE_ERROR = r"^df must use a DatetimeIndex for calendar operations$"
+_NAT_ERROR = r"^df index must not contain NaT$"
+
+_PanelShape = Literal["series", "frame"]
+
+
+def _make_panel(index: pd.Index, shape: _PanelShape) -> pd.Series | pd.DataFrame:
+    """Create one ordinary floating panel with the requested public shape.
+
+    Args:
+        index: Labels assigned to the two deterministic observations.
+        shape: Return a Series or one-column DataFrame.
+
+    Returns:
+        Fresh panel containing the literal values one and two.
+    """
+    series = pd.Series((1.0, 2.0), index=index, name="Asset")
+    if shape == "series":
+        return series
+    return series.to_frame()
+
+
+def _assert_panel_unchanged(
+    actual: pd.Series | pd.DataFrame,
+    expected: pd.Series | pd.DataFrame,
+) -> None:
+    """Assert that a rejected or accepted call preserves its caller-owned input.
+
+    Args:
+        actual: Panel supplied to ``df_asfreq``.
+        expected: Independent snapshot taken before the call.
+    """
+    if isinstance(actual, pd.Series):
+        assert isinstance(expected, pd.Series)
+        pd.testing.assert_series_equal(actual, expected, check_exact=True)
+    else:
+        assert isinstance(expected, pd.DataFrame)
+        pd.testing.assert_frame_equal(actual, expected, check_exact=True)
+
+
+# =============================================================================
+# Invalid nonempty calendar indexes
+# =============================================================================
+
+
+@pytest.mark.parametrize("shape", ("series", "frame"))
+def test_df_asfreq_rejects_non_date_index_before_calendar_resampling(
+    shape: _PanelShape,
+) -> None:
+    """Name the invalid public argument instead of exposing ``RangeIndex.tz``.
+
+    Args:
+        shape: Public pandas container under test.
+    """
+    panel = _make_panel(pd.RangeIndex(2, name="row"), shape)
+    original = panel.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(TypeError, match=_NON_DATE_ERROR):
+            df_asfreq(panel, freq="D")
+
+    _assert_panel_unchanged(panel, original)
+
+
+@pytest.mark.parametrize("shape", ("series", "frame"))
+def test_df_asfreq_rejects_nat_before_calendar_resampling(shape: _PanelShape) -> None:
+    """Reject an undefined calendar boundary before constructing a date schedule.
+
+    Args:
+        shape: Public pandas container under test.
+    """
+    index = pd.DatetimeIndex(("2024-01-01", pd.NaT), name="date")
+    panel = _make_panel(index, shape)
+    original = panel.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(ValueError, match=_NAT_ERROR):
+            df_asfreq(panel, freq="D")
+
+    _assert_panel_unchanged(panel, original)
+
+
+# =============================================================================
+# Supported pass-through and valid calendar controls
+# =============================================================================
+
+
+@pytest.mark.parametrize("shape", ("series", "frame"))
+def test_df_asfreq_preserves_non_date_index_when_frequency_is_none(shape: _PanelShape) -> None:
+    """Keep arbitrary labels valid when the caller requests no calendar operation.
+
+    Args:
+        shape: Public pandas container under test.
+    """
+    panel = _make_panel(pd.Index(("first", "second"), name="row"), shape)
+    original = panel.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = df_asfreq(panel, freq=None)
+
+    _assert_panel_unchanged(actual, original)
+    _assert_panel_unchanged(panel, original)
+
+
+@pytest.mark.parametrize("shape", ("series", "frame"))
+def test_df_asfreq_preserves_empty_non_date_schema(shape: _PanelShape) -> None:
+    """Allow an empty declaration because no observation enters a calendar schedule.
+
+    Args:
+        shape: Public pandas container under test.
+    """
+    series = pd.Series([], index=pd.RangeIndex(0, name="row"), dtype="Float64", name="Asset")
+    panel: pd.Series | pd.DataFrame = series if shape == "series" else series.to_frame()
+    original = panel.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = df_asfreq(panel, freq="D")
+
+    _assert_panel_unchanged(actual, original)
+    _assert_panel_unchanged(panel, original)
+
+
+@pytest.mark.parametrize("shape", ("series", "frame"))
+def test_df_asfreq_preserves_valid_timezone_aware_nullable_values(shape: _PanelShape) -> None:
+    """Sort and resample a valid nullable panel without changing its numerical contract.
+
+    The supplied rows arrive as January 3, January 1, and January 2. After chronological repair,
+    the already-daily panel retains its supplied missing January 2 observation, giving the
+    independently expected sequence ``[1, missing, 3]``.
+
+    Args:
+        shape: Public pandas container under test.
+    """
+    index = pd.DatetimeIndex(
+        ("2024-01-03", "2024-01-01", "2024-01-02"),
+        tz="UTC",
+        name="date",
+    )
+    series = pd.Series((3.0, 1.0, pd.NA), index=index, dtype="Float64", name="Asset")
+    panel: pd.Series | pd.DataFrame = series if shape == "series" else series.to_frame()
+    original = panel.copy(deep=True)
+    expected_series = pd.Series(
+        (1.0, pd.NA, 3.0),
+        index=pd.DatetimeIndex(
+            ("2024-01-01", "2024-01-02", "2024-01-03"),
+            tz="UTC",
+            name="date",
+        ),
+        dtype="Float64",
+        name="Asset",
+    )
+    expected: pd.Series | pd.DataFrame = (
+        expected_series if shape == "series" else expected_series.to_frame()
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = df_asfreq(
+            panel,
+            freq="D",
+            include_start_date=True,
+            include_end_date=True,
+        )
+
+    _assert_panel_unchanged(actual, expected)
+    _assert_panel_unchanged(panel, original)


### PR DESCRIPTION
## What changed

Reject invalid nonempty calendar indexes at the shared resampling, backfill, and timestamp-arithmetic boundaries with deterministic argument-specific errors while preserving empty declarations, no-resampling paths, and all valid numerical behavior.

## Behavior

Nonempty inputs to `df_asfreq()` calendar resampling, `bfill_timeseries()`, and `interpolate_infrequent_returns()` now require a `DatetimeIndex` without `NaT`. Unsupported index types raise `TypeError`; `NaT` raises `ValueError`; signatures, exports, and valid results do not change.

## Regression evidence

- **Fail before:** On accepted `upstream/main` `4d7d486`, the final 36-case regression matrix produced `20 failed, 16 passed`: non-date inputs leaked incidental pandas attribute, slice, or mixed-label errors, while eight `NaT` cases did not raise the required boundary error.
- **Independent expectation:** Calendar schedule construction and timestamp subtraction require defined timestamp labels, whereas empty schema declarations and `freq=None` perform no calendar operation and must remain valid.
- **Pass after:** All 36 boundary and unchanged-behavior cases pass with exact exception classes/messages, independently calculated return/backfill values, Series/DataFrame parity, nullable and timezone-aware coverage, warnings-as-errors, metadata, and caller ownership.

## Verification

- Changed-line Ruff and differential Pyright report zero PR-attributable diagnostics.
- Complete utils tests plus the focused perfstats module: `60 passed`.
- Complete `perfstats` suite: `658 passed`.
- Sphinx warning-as-error build: succeeded.
- Full repository suite: `2203 passed, 16 warnings`; all warnings are known third-party seaborn/Matplotlib deprecations.
- Public API synchronization is current at `413` names; dependency integrity and whitespace checks passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/utils/df_freq.py`, `src/qis/utils/tests/df_freq_calendar_index_test.py`, `src/qis/perfstats/timeseries_bfill.py`, and `src/qis/perfstats/tests/timeseries_calendar_index_test.py`.

Out of scope: Universal container validation, non-date rejection outside calendar operations, centralized sorting or duplicate policy, and removal of transformation- or formula-local guards.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.