### PR TITLE
fix: select volatility estimator by finite sample count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Made realized-volatility estimator selection depend on each column's finite observation count
+  so missing-row padding cannot change the estimator or suppress a sparse-window result.
 - Corrected missing and near-zero percentages in legend diagnostics and defined all-missing
   histories without an index error.
 - Made standard-deviation legend modes consistently use warning-free sample spreads after their

--- a/src/qis/perfstats/returns.py
+++ b/src/qis/perfstats/returns.py
@@ -489,11 +489,12 @@ def compute_pa_excess_compounded_returns(returns: Union[pd.Series, pd.DataFrame]
 def estimate_vol(sampled_returns: Union[pd.DataFrame, pd.Series, np.ndarray]) -> np.ndarray:
     """Estimate volatility from return samples.
 
-    For samples >=20, uses standard deviation with ddof=1.
-    For smaller samples, uses RMS to avoid mean adjustment bias.
+    For columns with 20 or more finite observations, uses standard deviation with ddof=1.
+    For smaller finite samples, uses RMS to avoid mean adjustment bias.
 
     Args:
-        sampled_returns: Return time series
+        sampled_returns: Return time series. Each column selects its estimator from its own finite
+            observation count; missing rows do not count toward the threshold
 
     Returns:
         Volatility estimate for a one-dimensional input or one estimate per DataFrame column.
@@ -504,17 +505,14 @@ def estimate_vol(sampled_returns: Union[pd.DataFrame, pd.Series, np.ndarray]) ->
         sampled_values = sampled_returns.to_numpy(dtype=float, na_value=np.nan)
     else:
         sampled_values = np.asarray(sampled_returns, dtype=float)
-    n = sampled_values.shape[0]
 
     def estimate_column(values: np.ndarray) -> np.float64:
-        """Apply the existing window-size estimator to one return column."""
+        """Apply the finite-sample estimator to one return column."""
         finite_values = values[np.isfinite(values)]
         num_observations = finite_values.size
-        if n >= 20:
-            # Sample standard deviation needs two observations; unavailable columns stay missing.
-            if num_observations >= 2:
-                return np.float64(np.std(finite_values, ddof=1))
-            return np.float64(np.nan)
+        # Missing rows carry no sample information, so each column selects independently.
+        if num_observations >= 20:
+            return np.float64(np.std(finite_values, ddof=1))
         # The small-window RMS convention is defined as soon as one return is observed.
         if num_observations >= 1:
             return np.float64(np.sqrt(np.mean(np.square(finite_values))))

--- a/src/qis/perfstats/tests/estimate_vol_finite_count_test.py
+++ b/src/qis/perfstats/tests/estimate_vol_finite_count_test.py
@@ -1,0 +1,290 @@
+"""Regression coverage for finite-observation volatility estimator selection.
+
+``estimate_vol`` uses RMS for small samples so it does not subtract a noisy sample mean, then
+switches to sample standard deviation once 20 observations are available. Missing rows carry no
+return information and therefore must not select the estimator. The boundary is evaluated per
+column so ragged histories in one DataFrame can use different estimators without affecting one
+another.
+
+The direct fixtures exercise the exact 0, 1, 2, 19, 20, and 21 observation boundaries, unchanged
+fully observed samples, missing-row placement, ordinary and nullable pandas storage, mixed column
+states, and caller ownership. Expected values use closed-form sums for the literal sequence
+``0.001 * [1, ..., n]``. A public ``compute_sampled_vols`` fixture independently compounds five
+literal returns into prices and annualizes their RMS by ``sqrt(252)``.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# qis
+from qis.perfstats.returns import compute_sampled_vols, estimate_vol
+
+
+# =============================================================================
+# Shared deterministic fixtures
+# =============================================================================
+
+_BASE_RETURNS = np.array((0.01, -0.01, 0.02, -0.02, 0.03), dtype=float)
+_BOUNDARY_RETURNS = 0.001 * np.arange(1.0, 22.0)
+_COLUMN_COUNTS = (21, 20, 19, 2, 1, 0)
+_COLUMNS = tuple(f"n{count}" for count in _COLUMN_COUNTS)
+_EXPECTED_BY_COUNT = {
+    0: np.nan,
+    1: 0.001,
+    2: 0.0015811388300841897,
+    19: 0.011401754250991379,
+    20: 0.005916079783099616,
+    21: 0.006204836822995429,
+}
+_JANUARY_DATES = pd.bdate_range("2022-01-03", "2022-01-31")
+_MIXED_DATES = pd.bdate_range("2022-01-03", periods=25)
+_NAME = "Late Start"
+_RTOL = 1.0e-12
+
+
+def _as_nullable_frame(frame: pd.DataFrame, nullable: bool) -> pd.DataFrame:
+    """Optionally convert a frame to pandas nullable floating storage.
+
+    Args:
+        frame: Ordinary floating fixture.
+        nullable: Whether to use pandas ``Float64`` storage.
+
+    Returns:
+        The fixture in the requested floating representation.
+    """
+    return frame.astype(pd.Float64Dtype()) if nullable else frame
+
+
+def _as_nullable_series(series: pd.Series, nullable: bool) -> pd.Series:
+    """Optionally convert a Series to pandas nullable floating storage.
+
+    Args:
+        series: Ordinary floating fixture.
+        nullable: Whether to use pandas ``Float64`` storage.
+
+    Returns:
+        The fixture in the requested floating representation.
+    """
+    return series.astype(pd.Float64Dtype()) if nullable else series
+
+
+def _boundary_values(num_observations: int, total_rows: int) -> np.ndarray:
+    """Place the requested finite boundary sample before trailing missing rows.
+
+    Args:
+        num_observations: Number of finite returns to include.
+        total_rows: Total output length after missing padding.
+
+    Returns:
+        One-dimensional return sample with the requested finite count.
+    """
+    values = np.full(total_rows, np.nan, dtype=float)
+    values[:num_observations] = _BOUNDARY_RETURNS[:num_observations]
+    return values
+
+
+def _mixed_count_frame(nullable: bool) -> pd.DataFrame:
+    """Create all estimator-selection states in one DataFrame call.
+
+    Args:
+        nullable: Whether to use pandas ``Float64`` storage.
+
+    Returns:
+        Mixed panel with 21, 20, 19, 2, 1, and 0 finite returns by column.
+    """
+    values = np.full((len(_MIXED_DATES), len(_COLUMN_COUNTS)), np.nan, dtype=float)
+    for column, count in enumerate(_COLUMN_COUNTS):
+        values[:count, column] = _BOUNDARY_RETURNS[:count]
+    frame = pd.DataFrame(values, index=_MIXED_DATES, columns=_COLUMNS)
+    return _as_nullable_frame(frame, nullable)
+
+
+def _padding_variant(placement: str) -> np.ndarray:
+    """Place the same five returns in an unpadded or missing-padded sample.
+
+    Args:
+        placement: One of ``none``, ``leading``, ``trailing``, or ``interior``.
+
+    Returns:
+        Return sample with unchanged finite observations.
+
+    Raises:
+        ValueError: If ``placement`` is unsupported.
+    """
+    if placement == "none":
+        return _BASE_RETURNS.copy()
+    values = np.full(25, np.nan, dtype=float)
+    if placement == "leading":
+        values[-len(_BASE_RETURNS) :] = _BASE_RETURNS
+    elif placement == "trailing":
+        values[: len(_BASE_RETURNS)] = _BASE_RETURNS
+    elif placement == "interior":
+        values[[0, 3, 9, 15, 24]] = _BASE_RETURNS
+    else:
+        raise ValueError(f"unsupported placement={placement!r}")
+    return values
+
+
+def _late_start_prices(nullable: bool) -> pd.Series:
+    """Compound five literal returns after fifteen leading missing prices.
+
+    Args:
+        nullable: Whether to use pandas ``Float64`` storage.
+
+    Returns:
+        January price Series with five finite returns in a 21-row window.
+    """
+    prices = np.full(len(_JANUARY_DATES), np.nan, dtype=float)
+    first_price = len(_JANUARY_DATES) - len(_BASE_RETURNS) - 1
+    prices[first_price] = 100.0
+    prices[first_price + 1 :] = 100.0 * np.cumprod(1.0 + _BASE_RETURNS)
+    series = pd.Series(prices, index=_JANUARY_DATES, name=_NAME)
+    return _as_nullable_series(series, nullable)
+
+
+# =============================================================================
+# Direct estimator boundaries
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("num_observations", "expected"),
+    tuple(_EXPECTED_BY_COUNT.items()),
+)
+def test_estimate_vol_selects_estimator_by_finite_observation_count(
+    num_observations: int,
+    expected: float,
+) -> None:
+    """Select RMS or sample spread from finite count despite 25 total rows.
+
+    For ``x_k = 0.001 * k``, independently summing squares gives
+    ``RMS(n) = 0.001 * sqrt((n + 1) * (2n + 1) / 6)``. Subtracting the arithmetic mean gives
+    ``sample_std(n) = 0.001 * sqrt(n * (n + 1) / 12)``. The parameterized references apply RMS
+    below 20 finite observations and sample standard deviation from 20 onward.
+
+    Args:
+        num_observations: Number of finite values before trailing missing rows.
+        expected: Independently calculated volatility under the finite-count contract.
+    """
+    sampled_returns = _boundary_values(num_observations, total_rows=25)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = estimate_vol(sampled_returns)
+
+    assert np.asarray(actual).shape == ()
+    np.testing.assert_allclose(actual, expected, rtol=_RTOL, equal_nan=True)
+
+
+@pytest.mark.parametrize("num_observations", (19, 20, 21))
+def test_estimate_vol_preserves_fully_observed_threshold_values(
+    num_observations: int,
+) -> None:
+    """Retain accepted RMS and sample-spread values when no rows are missing.
+
+    Args:
+        num_observations: Fully observed sample length around the estimator switch.
+    """
+    sampled_returns = _BOUNDARY_RETURNS[:num_observations]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = estimate_vol(sampled_returns)
+
+    np.testing.assert_allclose(
+        actual,
+        _EXPECTED_BY_COUNT[num_observations],
+        rtol=_RTOL,
+    )
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("ordinary", "nullable"))
+def test_estimate_vol_selects_each_mixed_dataframe_column_independently(
+    nullable: bool,
+) -> None:
+    """Apply the finite-count boundary independently across one mixed panel.
+
+    Args:
+        nullable: Whether the input uses pandas nullable floating storage.
+    """
+    sampled_returns = _mixed_count_frame(nullable)
+    original_returns = sampled_returns.copy()
+    expected = np.array([_EXPECTED_BY_COUNT[count] for count in _COLUMN_COUNTS])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = estimate_vol(sampled_returns)
+
+    assert isinstance(actual, np.ndarray)
+    assert actual.shape == expected.shape
+    np.testing.assert_allclose(actual, expected, rtol=_RTOL, equal_nan=True)
+    pd.testing.assert_frame_equal(sampled_returns, original_returns)
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("ordinary", "nullable"))
+@pytest.mark.parametrize("placement", ("none", "leading", "trailing", "interior"))
+def test_estimate_vol_is_invariant_to_missing_row_placement(
+    nullable: bool,
+    placement: str,
+) -> None:
+    """Return the same five-observation RMS for every missing-row placement.
+
+    The direct sum of squared literal returns is ``0.0019``; division by five and square root
+    gives ``0.019493588689617928`` independently of any missing labels.
+
+    Args:
+        nullable: Whether the input uses pandas nullable floating storage.
+        placement: Position of the missing padding around the finite returns.
+    """
+    values = _padding_variant(placement)
+    sampled_returns = pd.Series(values, index=pd.bdate_range("2022-01-03", periods=len(values)))
+    sampled_returns = _as_nullable_series(sampled_returns, nullable)
+    original_returns = sampled_returns.copy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = estimate_vol(sampled_returns)
+
+    np.testing.assert_allclose(actual, 0.019493588689617928, rtol=_RTOL)
+    pd.testing.assert_series_equal(sampled_returns, original_returns)
+
+
+# =============================================================================
+# Public annualized-volatility integration
+# =============================================================================
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("ordinary", "nullable"))
+def test_compute_sampled_vols_annualizes_sparse_window_rms(nullable: bool) -> None:
+    """Annualize five finite January returns by RMS rather than total window rows.
+
+    The five-return RMS is ``0.019493588689617928``; multiplying by ``sqrt(252)`` gives
+    ``0.3094511269974631``. Fifteen leading missing prices make the January window contain 21 rows
+    without adding return observations.
+
+    Args:
+        nullable: Whether the input uses pandas nullable floating storage.
+    """
+    prices = _late_start_prices(nullable)
+    original_prices = prices.copy()
+    expected = pd.Series(
+        (0.3094511269974631,),
+        index=pd.DatetimeIndex(("2022-01-31",)),
+        name=_NAME,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = compute_sampled_vols(
+            prices,
+            freq_vol="ME",
+            include_start_date=True,
+            include_end_date=True,
+        )
+
+    assert isinstance(actual, pd.Series)
+    pd.testing.assert_series_equal(actual, expected, rtol=_RTOL)
+    pd.testing.assert_series_equal(prices, original_prices)

--- a/src/qis/perfstats/tests/regime_volatility_missing_test.py
+++ b/src/qis/perfstats/tests/regime_volatility_missing_test.py
@@ -200,6 +200,19 @@ def _annualized_sample_std(values: np.ndarray) -> float:
     return float(np.sqrt(sample_variance * _BUSINESS_PERIODS_PER_YEAR))
 
 
+def _annualized_rms(values: np.ndarray) -> float:
+    """Calculate annualized RMS independently from QIS.
+
+    Args:
+        values: Finite daily simple returns in one monthly window.
+
+    Returns:
+        Root mean square multiplied by ``sqrt(252)``.
+    """
+    mean_square = float(np.sum(np.square(values)) / len(values))
+    return float(np.sqrt(mean_square * _BUSINESS_PERIODS_PER_YEAR))
+
+
 def _expected_mixed_vols() -> pd.DataFrame:
     """Construct the mixed-panel volatility reference from literal returns.
 
@@ -222,9 +235,14 @@ def _expected_mixed_vols() -> pd.DataFrame:
         in_window = (_MIXED_DATES >= start) & (_MIXED_DATES <= end)
         window_values = late_start_returns[in_window]
         finite_values = window_values[np.isfinite(window_values)]
-        expected_late_start.append(
-            _annualized_sample_std(finite_values) if len(finite_values) >= 2 else np.nan
-        )
+        # Select from observed returns so ragged-window padding cannot change the reference.
+        if len(finite_values) >= 20:
+            expected_vol = _annualized_sample_std(finite_values)
+        elif len(finite_values) >= 1:
+            expected_vol = _annualized_rms(finite_values)
+        else:
+            expected_vol = np.nan
+        expected_late_start.append(expected_vol)
     return pd.DataFrame(
         {
             _HEALTHY: expected_healthy,
@@ -255,7 +273,8 @@ def test_estimate_vol_uses_only_finite_values_and_preserves_scalar_type() -> Non
     assert isinstance(short_vol, np.float64)
     assert isinstance(long_vol, np.float64)
     assert np.isclose(short_vol, np.sqrt(12.5))
-    assert np.isclose(long_vol, np.sqrt(2.0))
+    # Missing and infinite padding leaves the two finite observations in the RMS regime.
+    assert np.isclose(long_vol, np.sqrt(5.0))
     np.testing.assert_allclose(panel_vol, np.array([np.sqrt(12.5), np.nan]), equal_nan=True)
 
 
@@ -303,7 +322,7 @@ def test_compute_sampled_vols_preserves_mixed_window_states(
     """Estimate eligible columns while unavailable neighbors remain missing and quiet.
 
     Healthy expected values use the independent sample-variance formula above. The all-missing
-    column remains missing in every month; the one-return January window is also missing. The
+    column remains missing in every month; the one-return January window uses annualized RMS. The
     overlapping February window includes that boundary return, while the sufficiently observed
     all-zero March control equals zero.
 


### PR DESCRIPTION
## What changed

Select the RMS or sample-standard-deviation volatility estimator independently for each column from its finite observation count, so missing-row padding cannot change the estimator or make a sparse estimate disappear. Add deterministic direct and public-integration coverage for exact threshold boundaries, mixed ordinary and nullable panels, missing-data placement, type/shape preservation, warnings, and caller ownership.

## Behavior

Zero finite returns remain missing; one through nineteen finite returns use RMS; twenty or more use sample standard deviation with `ddof=1`. Each DataFrame column selects its own estimator. Public signatures, annualization, return sampling, non-finite filtering, labels, result shapes, and input ownership remain unchanged.

## Regression evidence

- **Fail before:** Against accepted pre-fix code, the new deterministic module produced `13 failed, 8 passed`: missing-row padding selected a different estimator, a single finite return became missing at twenty total rows, and both public annualized-volatility cases used the wrong row-count policy.
- **Independent expectation:** Closed-form RMS and sample-standard-deviation formulas establish exact results at 0, 1, 2, 19, 20, and 21 finite observations; a separate `math.fsum` and `statistics.stdev` cross-check matched the fixed implementation without using its NumPy reducers.
- **Pass after:** The focused PR 57 and accepted PR 56 interaction modules passed (`68 passed`), the complete perfstats suite passed (`679 passed`), and the full repository suite passed (`2225 passed, 16` known third-party warnings).

## Verification

- New-file formatting, changed-line Ruff, differential Pyright, public-API synchronization, dependency integrity, and whitespace checks passed.
- Focused PR 57 plus accepted PR 56 interaction coverage: `68 passed`.
- Complete `src/qis/perfstats/tests/` suite: `679 passed`.
- Sphinx warning-as-error build: passed.
- Full `src/qis/` suite: `2225 passed, 16 warnings`; all warnings are known third-party seaborn/Matplotlib deprecations.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/returns.py`, `src/qis/perfstats/tests/estimate_vol_finite_count_test.py`, and `src/qis/perfstats/tests/regime_volatility_missing_test.py`.

Out of scope: Public signatures, exports, annualization factors, return sampling, non-finite filtering, and volatility-regime quantile policy.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.