### PR TITLE
fix: normalize nullable missing legend endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Defaulted legend text to normal weight so fonts without a light face no longer emit Matplotlib
   fallback warnings.
+- Normalized missing indexed legend endpoints so ordinary and nullable floating dtypes use the
+  same configured numeric display.
 - Stabilized exact-constant and finite near-degenerate statistic-legend moments without emitting
   precision-loss warnings.
 - Made statistic legends use native scalar text when their public plotting format is `None`.

--- a/src/qis/plots/tests/legend_nullable_missing_display_test.py
+++ b/src/qis/plots/tests/legend_nullable_missing_display_test.py
@@ -1,0 +1,313 @@
+"""Regression coverage for nullable missing values in indexed legend endpoints.
+
+``LegendStats.LAST``, ``LegendStats.AVG_LAST``, and ``LegendStats.AVG_STD_LAST`` deliberately
+display the value at the final index rather than the last observed value. Equivalent missing
+endpoints must nevertheless use the configured numeric missing display for both ordinary
+``float64``/``np.nan`` and nullable ``Float64``/``pd.NA`` storage.
+
+One ordered mixed panel combines finite, terminal-missing, and all-missing histories in both
+storage representations. Exact public legend text, a non-default ``nan_display`` control,
+Series/DataFrame consistency, warnings-as-errors, labels and order, and caller ownership protect
+the display contract without changing endpoint selection or numerical statistics.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+# qis
+import qis.plots.time_series as time_series_module
+import qis.plots.utils as plot_utils_module
+from qis.plots.utils import LegendStats
+
+
+class _TimeSeriesModuleProtocol(Protocol):
+    """Typed test-side interface for the public plotting function."""
+
+    def plot_time_series(
+        self,
+        df: pd.DataFrame | pd.Series,
+        *,
+        x_date_freq: None,
+        legend_stats: LegendStats,
+        var_format: str,
+        ax: Axes,
+    ) -> Figure | None:
+        """Plot a time series with the selected indexed-endpoint legend.
+
+        Args:
+            df: Series or DataFrame supplied to the public plot.
+            x_date_freq: Disabled date-axis formatting for the focused test.
+            legend_stats: Indexed-endpoint legend mode under test.
+            var_format: Numeric display format for legend values.
+            ax: Matplotlib axis receiving the plot.
+
+        Returns:
+            The created figure, or None when the caller supplies ``ax``.
+        """
+        raise NotImplementedError
+
+
+class _PlotUtilsModuleProtocol(Protocol):
+    """Typed test-side interface for the internal legend-text helper."""
+
+    def get_legend_lines(
+        self,
+        data: pd.DataFrame | pd.Series,
+        legend_stats: LegendStats,
+        var_format: str,
+        nan_display: float,
+    ) -> list[str]:
+        """Build legend entries with an explicit missing-value display.
+
+        Args:
+            data: Series or DataFrame summarized in the legend.
+            legend_stats: Indexed-endpoint legend mode under test.
+            var_format: Numeric display format for legend values.
+            nan_display: Scalar substituted for an undefined or missing value.
+
+        Returns:
+            Legend entries in input-column order.
+        """
+        raise NotImplementedError
+
+
+_PLOT_UTILS_MODULE = cast(_PlotUtilsModuleProtocol, plot_utils_module)
+_TIME_SERIES_MODULE = cast(_TimeSeriesModuleProtocol, time_series_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent expectations
+# =============================================================================
+
+_FLOAT_ALL_MISSING = "float all missing"
+_FLOAT_FINITE = "float finite"
+_FLOAT_TERMINAL_MISSING = "float terminal missing"
+_NULLABLE_ALL_MISSING = "nullable all missing"
+_NULLABLE_FINITE = "nullable finite"
+_NULLABLE_TERMINAL_MISSING = "nullable terminal missing"
+
+_DATES = pd.date_range("2024-01-31", periods=4, freq="ME")
+_TERMINAL_MISSING_POSITION = 3
+
+_DEFAULT_EXPECTATIONS: tuple[tuple[LegendStats, tuple[str, ...]], ...] = (
+    (
+        LegendStats.LAST,
+        (
+            "float finite: last=4.00",
+            "float terminal missing: last=nan",
+            "nullable finite: last=4.00",
+            "nullable terminal missing: last=nan",
+            "float all missing: last=nan",
+            "nullable all missing: last=nan",
+        ),
+    ),
+    (
+        LegendStats.AVG_LAST,
+        (
+            "float finite: avg=2.50, last=4.00",
+            "float terminal missing: avg=2.00, last=nan",
+            "nullable finite: avg=2.50, last=4.00",
+            "nullable terminal missing: avg=2.00, last=nan",
+            "float all missing: avg=nan, last=nan",
+            "nullable all missing: avg=nan, last=nan",
+        ),
+    ),
+    (
+        LegendStats.AVG_STD_LAST,
+        (
+            "float finite: avg=2.50, std=1.29, last=4.00",
+            "float terminal missing: avg=2.00, std=1.00, last=nan",
+            "nullable finite: avg=2.50, std=1.29, last=4.00",
+            "nullable terminal missing: avg=2.00, std=1.00, last=nan",
+            "float all missing: avg=nan, std=nan, last=nan",
+            "nullable all missing: avg=nan, std=nan, last=nan",
+        ),
+    ),
+)
+
+_CUSTOM_NAN_DISPLAY = -99.0
+_CUSTOM_EXPECTATIONS: tuple[tuple[LegendStats, tuple[str, ...]], ...] = (
+    (
+        LegendStats.LAST,
+        (
+            "float finite: last=4.00",
+            "float terminal missing: last=-99.00",
+            "nullable finite: last=4.00",
+            "nullable terminal missing: last=-99.00",
+            "float all missing: last=-99.00",
+            "nullable all missing: last=-99.00",
+        ),
+    ),
+    (
+        LegendStats.AVG_LAST,
+        (
+            "float finite: avg=2.50, last=4.00",
+            "float terminal missing: avg=2.00, last=-99.00",
+            "nullable finite: avg=2.50, last=4.00",
+            "nullable terminal missing: avg=2.00, last=-99.00",
+            "float all missing: avg=-99.00, last=-99.00",
+            "nullable all missing: avg=-99.00, last=-99.00",
+        ),
+    ),
+    (
+        LegendStats.AVG_STD_LAST,
+        (
+            "float finite: avg=2.50, std=1.29, last=4.00",
+            "float terminal missing: avg=2.00, std=1.00, last=-99.00",
+            "nullable finite: avg=2.50, std=1.29, last=4.00",
+            "nullable terminal missing: avg=2.00, std=1.00, last=-99.00",
+            "float all missing: avg=-99.00, std=-99.00, last=-99.00",
+            "nullable all missing: avg=-99.00, std=-99.00, last=-99.00",
+        ),
+    ),
+)
+
+
+def _mixed_values() -> pd.DataFrame:
+    """Create equivalent finite and missing histories with two floating dtypes.
+
+    Returns:
+        Four-date panel in the same deliberate order as the exact expected legend entries.
+    """
+    values = pd.DataFrame(index=_DATES)
+    values[_FLOAT_FINITE] = pd.Series((1.0, 2.0, 3.0, 4.0), index=_DATES, dtype="float64")
+    values[_FLOAT_TERMINAL_MISSING] = pd.Series(
+        (1.0, 2.0, 3.0, np.nan), index=_DATES, dtype="float64"
+    )
+    values[_NULLABLE_FINITE] = pd.Series(
+        (1.0, 2.0, 3.0, 4.0), index=_DATES, dtype=pd.Float64Dtype()
+    )
+    values[_NULLABLE_TERMINAL_MISSING] = pd.Series(
+        (1.0, 2.0, 3.0, pd.NA), index=_DATES, dtype=pd.Float64Dtype()
+    )
+    values[_FLOAT_ALL_MISSING] = pd.Series((np.nan,) * len(_DATES), index=_DATES, dtype="float64")
+    values[_NULLABLE_ALL_MISSING] = pd.Series(
+        (pd.NA,) * len(_DATES), index=_DATES, dtype=pd.Float64Dtype()
+    )
+    return values
+
+
+def _legend_lines(data: pd.DataFrame | pd.Series, legend_stats: LegendStats) -> tuple[str, ...]:
+    """Draw through the public plotting API and return exact legend text.
+
+    Args:
+        data: Time series whose indexed endpoint is displayed.
+        legend_stats: Indexed-endpoint legend mode under test.
+
+    Returns:
+        Legend entries in input-column order.
+    """
+    figure, axis = plt.subplots()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _TIME_SERIES_MODULE.plot_time_series(
+                data,
+                x_date_freq=None,
+                legend_stats=legend_stats,
+                var_format="{:.2f}",
+                ax=axis,
+            )
+        legend = axis.get_legend()
+        assert legend is not None
+        return tuple(text.get_text() for text in legend.get_texts())
+    finally:
+        plt.close(figure)
+
+
+# =============================================================================
+# Public mixed-panel display contract
+# =============================================================================
+
+
+@pytest.mark.parametrize(("legend_stats", "expected"), _DEFAULT_EXPECTATIONS)
+def test_plot_time_series_normalizes_nullable_missing_indexed_endpoints(
+    legend_stats: LegendStats,
+    expected: tuple[str, ...],
+) -> None:
+    """Render equivalent missing endpoints identically without changing their selection.
+
+    Args:
+        legend_stats: Direct indexed-endpoint mode under test.
+        expected: Independently specified text for every dtype and missing-data state.
+    """
+    values = _mixed_values()
+    original_values = values.copy()
+
+    actual = _legend_lines(values, legend_stats)
+
+    assert actual == expected
+    pd.testing.assert_frame_equal(values, original_values)
+
+
+# =============================================================================
+# Named Series/DataFrame consistency
+# =============================================================================
+
+
+@pytest.mark.parametrize(("legend_stats", "expected"), _DEFAULT_EXPECTATIONS)
+def test_plot_time_series_nullable_terminal_missing_series_matches_dataframe(
+    legend_stats: LegendStats,
+    expected: tuple[str, ...],
+) -> None:
+    """Return identical missing-endpoint text for a named Series and one-column frame.
+
+    Args:
+        legend_stats: Direct indexed-endpoint mode under test.
+        expected: Mixed-panel entries containing the independent one-column expectation.
+    """
+    selected = _mixed_values()[_NULLABLE_TERMINAL_MISSING]
+    assert isinstance(selected, pd.Series)
+    series = selected
+    frame = series.to_frame()
+    original_series = series.copy()
+    original_frame = frame.copy()
+
+    expected_line = (expected[_TERMINAL_MISSING_POSITION],)
+    series_result = _legend_lines(series, legend_stats)
+    frame_result = _legend_lines(frame, legend_stats)
+
+    assert series_result == expected_line
+    assert frame_result == expected_line
+    assert series_result == frame_result
+    pd.testing.assert_series_equal(series, original_series)
+    pd.testing.assert_frame_equal(frame, original_frame)
+
+
+# =============================================================================
+# Configured missing-value display
+# =============================================================================
+
+
+@pytest.mark.parametrize(("legend_stats", "expected"), _CUSTOM_EXPECTATIONS)
+def test_get_legend_lines_applies_nan_display_to_indexed_missing_endpoints(
+    legend_stats: LegendStats,
+    expected: tuple[str, ...],
+) -> None:
+    """Honor ``nan_display`` without replacing a missing endpoint by an observation.
+
+    Args:
+        legend_stats: Direct indexed-endpoint mode under test.
+        expected: Exact entries using the independently selected ``-99`` missing marker.
+    """
+    values = _mixed_values()
+    original_values = values.copy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = _PLOT_UTILS_MODULE.get_legend_lines(
+            values,
+            legend_stats=legend_stats,
+            var_format="{:.2f}",
+            nan_display=_CUSTOM_NAN_DISPLAY,
+        )
+
+    assert tuple(actual) == expected
+    pd.testing.assert_frame_equal(values, original_values)

--- a/src/qis/plots/utils.py
+++ b/src/qis/plots/utils.py
@@ -765,6 +765,8 @@ class LegendStats(Enum):
 
     ``NONE`` prints the column name alone. Formatting of every value follows the ``var_format``
     argument of the plotting function; when it is ``None``, values use their native scalar text.
+    A missing indexed endpoint uses the configured numeric missing display regardless of whether
+    the input stores it as ``np.nan`` or ``pd.NA``.
     The enum therefore chooses the statistics and not their display.
 
     A member documented here is computed in ``get_legend_lines``, which is the single place the
@@ -849,6 +851,22 @@ def _compute_legend_tstat_components(
     return avg, std, float(tstat)
 
 
+def _get_indexed_legend_endpoint(data_column: pd.Series, nan_display: float) -> object:
+    """Return the final indexed value with a dtype-independent missing representation.
+
+    Args:
+        data_column: One plotted series whose final indexed value is displayed.
+        nan_display: Configured numeric display value for a missing endpoint.
+
+    Returns:
+        Final indexed value, or ``nan_display`` when that scalar is missing.
+    """
+    last: object = data_column.iloc[-1]
+    missing_mask: np.ndarray = data_column.tail(1).isna().to_numpy(dtype=bool)
+    # Keep indexed selection intact while preventing pd.NA from bypassing numeric formatting.
+    return nan_display if bool(missing_mask[-1]) else last
+
+
 def get_legend_lines(data: Union[pd.DataFrame, pd.Series],
                      legend_stats: LegendStats = LegendStats.NONE,
                      var_format: Optional[str] = '{:.0f}',
@@ -875,8 +893,9 @@ def get_legend_lines(data: Union[pd.DataFrame, pd.Series],
 
     elif legend_stats == LegendStats.LAST:
         legend_lines = []
-        for column in data.columns:
-            legend_lines.append(f"{column}: last={var_format.format(data[column].iloc[-1])}")
+        for column, data_column in data.items():
+            last = _get_indexed_legend_endpoint(data_column, nan_display)
+            legend_lines.append(f"{column}: last={var_format.format(last)}")
 
     elif legend_stats == LegendStats.LAST_NONNAN:
         legend_lines = []
@@ -922,14 +941,12 @@ def get_legend_lines(data: Union[pd.DataFrame, pd.Series],
 
     elif legend_stats == LegendStats.AVG_LAST:
         legend_lines = []
-        for column in data.columns:
-            data_column = data[column]
+        for column, data_column in data.items():
+            last = _get_indexed_legend_endpoint(data_column, nan_display)
             if np.all(np.isnan(data_column)):
                 avg = nan_display
-                last = np.nan
             else:
                 avg = np.nanmean(data_column)
-                last = data_column.iloc[-1]
             legend_lines.append(f"{column}: avg={var_format.format(avg)}, last={var_format.format(last)}")
 
     elif legend_stats == LegendStats.AVG_STD:
@@ -970,13 +987,13 @@ def get_legend_lines(data: Union[pd.DataFrame, pd.Series],
     elif legend_stats == LegendStats.AVG_STD_LAST:
         legend_lines = []
         for column, data_column in data.items():
+            last = _get_indexed_legend_endpoint(data_column, nan_display)
             if np.all(np.isnan(data_column)):
-                avg, std, last = nan_display, nan_display, nan_display
+                avg, std = nan_display, nan_display
             else:
                 avg = np.nanmean(data_column)
                 # Preserve endpoint selection while guarding its companion sample spread.
                 std = _compute_legend_sample_std(data_column, nan_display)
-                last = data_column.iloc[-1]
             legend_lines.append(f"{column}: avg={var_format.format(avg)}, "
                                 f"std={var_format.format(std)}, "
                                 f"last={var_format.format(last)}")


### PR DESCRIPTION
## What changed

Normalize only missing final indexed legend scalars to the configured numeric missing display in `LAST`, `AVG_LAST`, and `AVG_STD_LAST`, so ordinary and nullable floating inputs produce identical public text. Add deterministic mixed-panel, custom-display, Series/DataFrame, warning, and ownership coverage.

## Behavior

The three direct indexed-endpoint modes continue selecting the value at the final index rather than the last observation. Missing endpoints now use `nan_display` regardless of whether pandas stores them as `np.nan` or `pd.NA`; finite endpoints and every numerical statistic are unchanged. Public signatures, exports, enum values, and other legend modes are unchanged.

## Regression evidence

- **Fail before:** All nine finalized cases failed with nullable `<NA>` text or failure to honor the custom missing display.
- **Independent expectation:** The four-date mixed panel fixes finite endpoints at `4`, terminal missing endpoints at the configured display, finite/ragged means at `2.5`/`2`, and sample spreads at `1.29`/`1.00`; all-missing statistics remain undefined.
- **Pass after:** All nine focused cases pass, and the focused interactions plus complete plots suite pass together (`199 passed`).

## Verification

- New-file formatting and changed-line Ruff: clean.
- Differential Pyright: zero attributable diagnostics.
- Focused regression, accepted legend interactions, and complete plots suite: `199 passed`.
- Complete `src/qis/perfstats/tests/` interaction suite: `721 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2366 passed, 16` known third-party warnings.
- Public-API synchronization (`413` names), dependency integrity, and whitespace checks: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/plots/utils.py`, and `src/qis/plots/tests/legend_nullable_missing_display_test.py`.

Out of scope: `LAST` versus last-observed selection semantics, sample-spread and moment calculations, missing/zero ratios, unrelated modes, public signatures, exports, and source cleanup.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.