### PR TITLE
fix: preserve explicit benchmark names in regime tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Made statistic legends use native scalar text when their public plotting format is `None`.
 - Stabilized descriptive-table skewness, kurtosis, and normality results for finite samples whose
   spread is very small relative to their level.
+- Made benchmark-aware performance and regime tables share explicit-name and existing-column
+  precedence when resolving a standalone benchmark Series.
 - Made realized-volatility estimator selection depend on each column's finite observation count
   so missing-row padding cannot change the estimator or suppress a sparse-window result.
 - Rejected positive and negative infinity in `compute_desc_table()` with a descriptive error

--- a/src/qis/perfstats/perf_stats.py
+++ b/src/qis/perfstats/perf_stats.py
@@ -175,10 +175,10 @@ def _safe_downside_vol(returns_array: np.ndarray, vol_dt: float) -> float:
     return vol_dt * float(np.std(neg_returns, ddof=1))
 
 
-def _resolve_benchmark(prices: pd.DataFrame,
-                       benchmark: Optional[str],
-                       benchmark_price: Optional[pd.Series]
-                       ) -> Tuple[pd.DataFrame, str]:
+def resolve_benchmark_source(prices: pd.DataFrame,
+                             benchmark: Optional[str],
+                             benchmark_price: Optional[pd.Series]
+                             ) -> Tuple[pd.DataFrame, str]:
     """Normalise the three input modes for benchmark specification.
 
     The benchmark can be supplied in three ways:
@@ -199,8 +199,8 @@ def _resolve_benchmark(prices: pd.DataFrame,
 
     Raises:
         ValueError: If neither benchmark nor benchmark_price is supplied, or if benchmark
-            is given as a name but is not in prices and benchmark_price is None.
-        TypeError: If benchmark_price is supplied but is not a pd.Series.
+            is given as a name but is not in prices and benchmark_price is None, or if
+            benchmark_price is supplied but is not a pd.Series.
     """
     # Case 0: nothing supplied
     if benchmark is None and benchmark_price is None:
@@ -520,7 +520,7 @@ def compute_ra_perf_table_with_benchmark(prices: pd.DataFrame,
         benchmark: Column name of the benchmark in ``prices``. Optional if
             ``benchmark_price`` is supplied.
         benchmark_price: Stand-alone benchmark price Series. Optional if ``benchmark``
-            is in ``prices``. See ``_resolve_benchmark`` for the three-way branching.
+            is in ``prices``. See ``resolve_benchmark_source`` for the three-way branching.
         perf_params: Performance parameter object. If None, frequency is inferred.
         is_log_returns: If True, compute log returns instead of arithmetic returns
             for the regression.
@@ -533,9 +533,9 @@ def compute_ra_perf_table_with_benchmark(prices: pd.DataFrame,
     """
     # Resolve the three input modes (name only / price only / both) into a
     # consistent (prices_with_benchmark, benchmark_name) pair.
-    prices, benchmark = _resolve_benchmark(prices=prices,
-                                           benchmark=benchmark,
-                                           benchmark_price=benchmark_price)
+    prices, benchmark = resolve_benchmark_source(prices=prices,
+                                                 benchmark=benchmark,
+                                                 benchmark_price=benchmark_price)
 
     if perf_params is None:
         perf_params = PerfParams(freq=pd.infer_freq(prices.index))

--- a/src/qis/perfstats/regime_classifier.py
+++ b/src/qis/perfstats/regime_classifier.py
@@ -879,8 +879,10 @@ def compute_bnb_regimes_pa_perf_table(prices: pd.DataFrame,
 
     Args:
         prices: Asset price series
-        benchmark: Benchmark column name in prices
-        benchmark_price: Alternative benchmark price series to add to prices
+        benchmark: Benchmark column name in prices, or explicit name for ``benchmark_price``
+        benchmark_price: Alternative benchmark price series to add to prices. When ``benchmark``
+            is supplied, that explicit name takes precedence over the Series name. An existing
+            price column with the resolved name takes precedence over the Series values.
         freq: Sampling frequency
         return_type: Type of returns to compute
         q: Quantile boundaries or number of quantiles
@@ -892,21 +894,15 @@ def compute_bnb_regimes_pa_perf_table(prices: pd.DataFrame,
         Regime-conditional performance table
 
     Raises:
-        ValueError: If neither benchmark nor benchmark_price provided
+        ValueError: If neither benchmark source is provided, a name-only source is absent from
+            prices, or benchmark_price is not a Series.
     """
-    if benchmark is None and benchmark_price is None:
-        raise ValueError("Provide either benchmark name in prices or benchmark_price")
-
-    if benchmark is not None and benchmark_price is None:
-        if benchmark not in prices.columns:
-            raise ValueError(f"{benchmark} is not in {prices.columns.to_list()}")
-    elif benchmark_price is not None:
-        if benchmark not in prices.columns:
-            if not isinstance(benchmark_price, pd.Series):
-                raise ValueError(f"benchmark_price must be pd.Series not {type(benchmark_price)}")
-            benchmark_price = benchmark_price.reindex(index=prices.index, method='ffill').ffill()
-            prices = pd.concat([benchmark_price, prices], axis=1, sort=True)
-            benchmark = benchmark_price.name
+    # Share source precedence with the benchmark-aware performance table before classification.
+    prices, benchmark = pt.resolve_benchmark_source(
+        prices=prices,
+        benchmark=benchmark,
+        benchmark_price=benchmark_price,
+    )
 
     regime_classifier = BenchmarkReturnsQuantilesRegime(
         freq=freq,

--- a/src/qis/perfstats/tests/benchmark_source_resolution_test.py
+++ b/src/qis/perfstats/tests/benchmark_source_resolution_test.py
@@ -1,0 +1,379 @@
+"""Regression tests for benchmark-source resolution across public performance tables.
+
+The benchmark-aware risk-adjusted and regime-table entry points accept the same three source
+modes: an in-panel benchmark name, a standalone benchmark Series, or both an explicit name and a
+Series. Those modes must resolve to the same price panel and selected benchmark before either
+entry point performs its distinct numerical calculation.
+
+The deterministic fixture uses thirteen quarter-end asset observations and a benchmark Series
+observed one day before each quarter end. One explicit missing benchmark observation makes the
+forward-filled values independently visible. Tests compare each standalone-Series call with the
+equivalent manually assembled in-panel call, then assert values, labels, ordering, nullable
+storage at the shared boundary, named calendar preservation, source precedence, errors, and
+caller ownership.
+"""
+
+from typing import Literal, Protocol, cast
+
+import pandas as pd
+import pytest
+
+import qis.perfstats.perf_stats as perf_stats_module
+import qis.perfstats.regime_classifier as regime_classifier_module
+from qis.perfstats.config import PerfParams
+
+
+class _PerfStatsModuleProtocol(Protocol):
+    """Typed test-side interface for the benchmark-aware performance table."""
+
+    def resolve_benchmark_source(
+        self,
+        *,
+        prices: pd.DataFrame,
+        benchmark: str | None,
+        benchmark_price: object | None,
+    ) -> tuple[pd.DataFrame, str]:
+        """Return the normalized benchmark panel and selected label."""
+        raise NotImplementedError
+
+    def compute_ra_perf_table_with_benchmark(
+        self,
+        *,
+        prices: pd.DataFrame,
+        benchmark: str | None = None,
+        benchmark_price: pd.Series | None = None,
+        perf_params: PerfParams | None = None,
+    ) -> pd.DataFrame:
+        """Return a risk-adjusted table for one resolved benchmark source."""
+        raise NotImplementedError
+
+
+class _RegimeClassifierModuleProtocol(Protocol):
+    """Typed test-side interface for the benchmark-aware regime table."""
+
+    def compute_bnb_regimes_pa_perf_table(
+        self,
+        *,
+        prices: pd.DataFrame,
+        benchmark: str | None = None,
+        benchmark_price: pd.Series | None = None,
+        freq: str = "QE",
+        perf_params: PerfParams | None = None,
+    ) -> pd.DataFrame:
+        """Return a regime table for one resolved benchmark source."""
+        raise NotImplementedError
+
+
+_PERF_STATS = cast(_PerfStatsModuleProtocol, perf_stats_module)
+_REGIME_CLASSIFIER = cast(_RegimeClassifierModuleProtocol, regime_classifier_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent alignment
+# =============================================================================
+
+_DATES = pd.date_range("2021-03-31", periods=13, freq="QE", name="Date")
+_SOURCE_DATES = _DATES - pd.Timedelta(days=1)
+
+_ASSET_NAME = "Asset"
+_EXPLICIT_BENCHMARK_NAME = "ExplicitName"
+_SERIES_BENCHMARK_NAME = "SeriesName"
+
+_ASSET_PRICES = (80.0, 82.0, 79.0, 84.0, 83.0, 88.0, 86.0, 92.0, 91.0, 97.0, 95.0, 101.0, 99.0)
+_SOURCE_BENCHMARK_PRICES = (
+    100.0,
+    90.0,
+    95.0,
+    85.0,
+    float("nan"),
+    98.0,
+    110.0,
+    105.0,
+    120.0,
+    118.0,
+    135.0,
+    130.0,
+    150.0,
+)
+_ALIGNED_BENCHMARK_PRICES = (
+    100.0,
+    90.0,
+    95.0,
+    85.0,
+    85.0,
+    98.0,
+    110.0,
+    105.0,
+    120.0,
+    118.0,
+    135.0,
+    130.0,
+    150.0,
+)
+_IGNORED_BENCHMARK_PRICES = (
+    200.0,
+    180.0,
+    210.0,
+    170.0,
+    220.0,
+    160.0,
+    230.0,
+    150.0,
+    240.0,
+    140.0,
+    250.0,
+    130.0,
+    260.0,
+)
+
+_PERF_PARAMS = PerfParams(freq="QE")
+
+_TableKind = Literal["risk_adjusted", "regime"]
+
+
+def _asset_prices() -> pd.DataFrame:
+    """Create the caller-owned asset panel.
+
+    Returns:
+        Complete quarterly asset prices with a named calendar.
+    """
+    return pd.DataFrame({_ASSET_NAME: _ASSET_PRICES}, index=_DATES)
+
+
+def _external_benchmark(
+    *,
+    name: str,
+    values: tuple[float, ...] = _SOURCE_BENCHMARK_PRICES,
+    index: pd.DatetimeIndex = _SOURCE_DATES,
+) -> pd.Series:
+    """Create a standalone benchmark Series.
+
+    Args:
+        name: Series label presented by the external source.
+        values: Benchmark observations to store.
+        index: Observation dates for the external source.
+
+    Returns:
+        Benchmark Series with caller-owned metadata.
+    """
+    return pd.Series(values, index=index, name=name, dtype=float)
+
+
+def _expected_panel(benchmark_name: str = _EXPLICIT_BENCHMARK_NAME) -> pd.DataFrame:
+    """Construct the aligned in-panel benchmark without using QIS code.
+
+    The source observation one day before each quarter end carries onto that quarter end. The
+    missing fifth source observation is then filled from the fourth value, producing 85.0 at the
+    fifth quarter end.
+
+    Args:
+        benchmark_name: Label assigned to the independently aligned benchmark.
+
+    Returns:
+        Benchmark-first quarterly panel with exact expected values.
+    """
+    aligned_benchmark = pd.Series(
+        _ALIGNED_BENCHMARK_PRICES,
+        index=_DATES,
+        name=benchmark_name,
+        dtype=float,
+    )
+    return pd.concat((aligned_benchmark, _asset_prices()), axis=1)
+
+
+def _compute_table(
+    table_kind: _TableKind,
+    *,
+    prices: pd.DataFrame,
+    benchmark: str | None = None,
+    benchmark_price: pd.Series | None = None,
+) -> pd.DataFrame:
+    """Call one public benchmark-aware table through a typed interface.
+
+    Args:
+        table_kind: Public entry point to exercise.
+        prices: Caller-owned asset price panel.
+        benchmark: Optional selected benchmark label.
+        benchmark_price: Optional standalone benchmark Series.
+
+    Returns:
+        Public risk-adjusted or regime performance table.
+    """
+    if table_kind == "risk_adjusted":
+        return _PERF_STATS.compute_ra_perf_table_with_benchmark(
+            prices=prices,
+            benchmark=benchmark,
+            benchmark_price=benchmark_price,
+            perf_params=_PERF_PARAMS,
+        )
+    return _REGIME_CLASSIFIER.compute_bnb_regimes_pa_perf_table(
+        prices=prices,
+        benchmark=benchmark,
+        benchmark_price=benchmark_price,
+        freq="QE",
+        perf_params=_PERF_PARAMS,
+    )
+
+
+# =============================================================================
+# Shared valid-source resolution contract
+# =============================================================================
+
+
+def test_resolve_benchmark_source_preserves_nullable_alignment_and_metadata() -> None:
+    """Preserve exact nullable values, labels, calendar, order, and caller ownership."""
+    prices = _asset_prices()
+    benchmark_price = pd.Series(
+        _SOURCE_BENCHMARK_PRICES,
+        index=_SOURCE_DATES,
+        name=_SERIES_BENCHMARK_NAME,
+        dtype="Float64",
+    )
+    original_prices = prices.copy()
+    original_benchmark = benchmark_price.copy()
+    expected_benchmark = pd.Series(
+        _ALIGNED_BENCHMARK_PRICES,
+        index=_DATES,
+        name=_EXPLICIT_BENCHMARK_NAME,
+        dtype="Float64",
+    )
+    expected = pd.concat((expected_benchmark, prices), axis=1)
+
+    actual, resolved_name = _PERF_STATS.resolve_benchmark_source(
+        prices=prices,
+        benchmark=_EXPLICIT_BENCHMARK_NAME,
+        benchmark_price=benchmark_price,
+    )
+
+    assert resolved_name == _EXPLICIT_BENCHMARK_NAME
+    pd.testing.assert_frame_equal(actual, expected)
+    assert actual.columns.tolist() == [_EXPLICIT_BENCHMARK_NAME, _ASSET_NAME]
+    assert actual.index.name == "Date"
+    assert actual[_EXPLICIT_BENCHMARK_NAME].dtype == pd.Float64Dtype()
+    pd.testing.assert_frame_equal(prices, original_prices)
+    pd.testing.assert_series_equal(benchmark_price, original_benchmark)
+
+
+def test_resolve_benchmark_source_rejects_wrong_source_type() -> None:
+    """Preserve explicit source-type validation before downstream pandas operations."""
+    with pytest.raises(ValueError, match="benchmark_price must be pd.Series"):
+        _PERF_STATS.resolve_benchmark_source(
+            prices=_asset_prices(),
+            benchmark=None,
+            benchmark_price=[100.0, 101.0],
+        )
+
+
+@pytest.mark.parametrize("table_kind", ("risk_adjusted", "regime"))
+def test_benchmark_tables_preserve_explicit_name_over_series_name(
+    table_kind: _TableKind,
+) -> None:
+    """Give an explicit benchmark name precedence over the standalone Series name.
+
+    The manually assembled name-only call is the public interaction control. Its benchmark path,
+    source calendar and aligned missing observation are specified independently, so exact frame
+    equality also proves that normalization does not alter numerical calculations.
+    """
+    prices = _asset_prices()
+    benchmark_price = _external_benchmark(name=_SERIES_BENCHMARK_NAME)
+    original_prices = prices.copy()
+    original_benchmark = benchmark_price.copy()
+
+    expected = _compute_table(
+        table_kind,
+        prices=_expected_panel(),
+        benchmark=_EXPLICIT_BENCHMARK_NAME,
+    )
+    actual = _compute_table(
+        table_kind,
+        prices=prices,
+        benchmark=_EXPLICIT_BENCHMARK_NAME,
+        benchmark_price=benchmark_price,
+    )
+
+    pd.testing.assert_frame_equal(actual, expected)
+    assert actual.index.tolist() == [_EXPLICIT_BENCHMARK_NAME, _ASSET_NAME]
+    pd.testing.assert_frame_equal(prices, original_prices)
+    pd.testing.assert_series_equal(benchmark_price, original_benchmark)
+
+
+@pytest.mark.parametrize("table_kind", ("risk_adjusted", "regime"))
+def test_benchmark_tables_trust_existing_series_named_column(
+    table_kind: _TableKind,
+) -> None:
+    """Keep existing in-panel data when a Series-only source has the same name.
+
+    The external path is deliberately different from the in-panel benchmark. Exact equality with
+    the name-only control therefore proves that resolution neither duplicates nor replaces the
+    existing column.
+    """
+    benchmark_name = "Benchmark"
+    prices = _expected_panel(benchmark_name=benchmark_name)
+    benchmark_price = _external_benchmark(
+        name=benchmark_name,
+        values=_IGNORED_BENCHMARK_PRICES,
+        index=_DATES,
+    )
+    original_prices = prices.copy()
+    original_benchmark = benchmark_price.copy()
+
+    expected = _compute_table(table_kind, prices=prices, benchmark=benchmark_name)
+    actual = _compute_table(
+        table_kind,
+        prices=prices,
+        benchmark_price=benchmark_price,
+    )
+
+    pd.testing.assert_frame_equal(actual, expected)
+    assert actual.index.tolist() == [benchmark_name, _ASSET_NAME]
+    pd.testing.assert_frame_equal(prices, original_prices)
+    pd.testing.assert_series_equal(benchmark_price, original_benchmark)
+
+
+@pytest.mark.parametrize("table_kind", ("risk_adjusted", "regime"))
+def test_benchmark_tables_preserve_other_valid_source_modes(
+    table_kind: _TableKind,
+) -> None:
+    """Preserve Series-only augmentation and explicit existing-column precedence."""
+    benchmark_name = "Benchmark"
+    prices = _asset_prices()
+    benchmark_price = _external_benchmark(name=benchmark_name)
+    expected_panel = _expected_panel(benchmark_name=benchmark_name)
+
+    expected = _compute_table(table_kind, prices=expected_panel, benchmark=benchmark_name)
+    series_only = _compute_table(
+        table_kind,
+        prices=prices,
+        benchmark_price=benchmark_price,
+    )
+    explicit_existing = _compute_table(
+        table_kind,
+        prices=expected_panel,
+        benchmark=benchmark_name,
+        benchmark_price=_external_benchmark(
+            name="IgnoredSeriesName",
+            values=_IGNORED_BENCHMARK_PRICES,
+            index=_DATES,
+        ),
+    )
+
+    pd.testing.assert_frame_equal(series_only, expected)
+    pd.testing.assert_frame_equal(explicit_existing, expected)
+
+
+@pytest.mark.parametrize("table_kind", ("risk_adjusted", "regime"))
+def test_benchmark_tables_reject_absent_sources(table_kind: _TableKind) -> None:
+    """Preserve a meaningful error when neither benchmark source is supplied."""
+    with pytest.raises(ValueError, match="either benchmark"):
+        _compute_table(table_kind, prices=_asset_prices())
+
+
+@pytest.mark.parametrize("table_kind", ("risk_adjusted", "regime"))
+def test_benchmark_tables_reject_missing_named_source(table_kind: _TableKind) -> None:
+    """Preserve a meaningful error when the selected in-panel column is absent."""
+    with pytest.raises(ValueError, match="MissingBenchmark is not in"):
+        _compute_table(
+            table_kind,
+            prices=_asset_prices(),
+            benchmark="MissingBenchmark",
+        )


### PR DESCRIPTION
## What changed

Share one benchmark-source resolver between the benchmark-aware performance and regime-table entry points. Add deterministic coverage for explicit-name precedence, existing-column precedence, calendar alignment, nullable metadata, errors, and caller ownership.

## Behavior

An explicit benchmark name now takes precedence over a standalone Series name in both entry points. When no explicit name is supplied and the Series name already exists in the price panel, the existing column remains authoritative instead of being duplicated. Newly added Series data retains the established forward-filled alignment. Public signatures, exports, and numerical regime calculations are unchanged.

## Regression evidence

- **Fail before:** On exact accepted base `50132de`, the explicit-name regime case returned `SeriesName` instead of `ExplicitName`, while the same-name-existing case created duplicate benchmark columns and raised `ValueError: Input array must be 1 dimensional`.
- **Independent expectation:** A manually assembled 13-quarter benchmark-first panel renames the external Series to the explicit label and forward-fills its missing fifth source value to exactly `85.0`; the equivalent name-only calls define the expected public tables.
- **Pass after:** All 12 focused cases pass across both public entry points, including exact table equality, ordering, nullable `Float64`, named-index, error, and ownership assertions.

## Verification

- Changed-line Ruff and new-file formatting: clean.
- Differential Pyright: zero unapproved or attributable diagnostics.
- Focused benchmark-source regression: `12 passed`.
- Complete perfstats suite: `733 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2380 passed, 16 warnings`; all warnings are known third-party seaborn/Matplotlib deprecations.
- Public API synchronization (`413` names), dependency integrity, and whitespace checks: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/perf_stats.py`, `src/qis/perfstats/regime_classifier.py`, and `src/qis/perfstats/tests/benchmark_source_resolution_test.py`.

Out of scope: Unnamed Series and genuinely duplicate input-column policy, public signatures and exports, numerical regime calculations, unrelated alignment behavior, and source cleanup.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.