### PR TITLE
fix: support unformatted descriptive legends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Made time-series descriptive legends use native scalar text when their public plotting format
+  is `None`.
+
 ## [5.22.1] - 2026-09-05
 
 ### Changed

--- a/src/qis/docs/plotting_kwargs.md
+++ b/src/qis/docs/plotting_kwargs.md
@@ -42,7 +42,8 @@ entirely, which is what you want when several panels share one.
 `var_format: Optional[str] = '{:,.2f}'` — a Python format string applied to the values in the
 legend, the tick labels and any data labels. This is where percent, ratio and price displays are
 chosen: `'{:.0%}'` for a percentage, `'{:,.2f}'` for a ratio, `'{:,.0f}'` for a level. `None`
-leaves axis ticks to Matplotlib and uses native scalar text for ordinary statistic legends.
+leaves axis ticks to Matplotlib and uses native scalar text for statistic legends, including
+descriptive tables where supported.
 
 `xvar_format`, `yvar_format` — the same, per axis, on plots where the two axes carry different
 units. A scatter of return against volatility wants `xvar_format='{:.0%}'` and

--- a/src/qis/plots/tests/desc_table_none_format_test.py
+++ b/src/qis/plots/tests/desc_table_none_format_test.py
@@ -1,0 +1,338 @@
+"""Regression tests for unformatted descriptive legends on time-series plots.
+
+``plot_time_series`` accepts ``var_format=None`` so Matplotlib can choose the axis tick labels
+and ordinary statistic legends can use native scalar text. A requested descriptive table shares
+that public argument, so it must compose with the same native-text convention rather than call
+``format`` on ``None`` after the plot has already been drawn.
+
+The principal fixture combines complete, ragged, and all-missing columns in one ordered panel.
+Every displayed ``DescTableType`` is exercised with ordinary ``float64`` and nullable
+``Float64`` storage under warnings-as-errors. Exact short-table controls use independently
+calculated means and sample standard deviations, and every successful plot is rendered through
+the Matplotlib canvas before its caller-owned data and figure are released.
+"""
+
+from typing import Literal, Protocol, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+import qis as qis_module
+from qis.perfstats.desc_table import DescTableType
+
+
+pytestmark = pytest.mark.filterwarnings("error")
+
+
+class _QisPublicProtocol(Protocol):
+    """Typed test-side interface for the public time-series plot."""
+
+    def plot_time_series(
+        self,
+        df: pd.DataFrame | pd.Series,
+        *,
+        desc_table_type: DescTableType,
+        var_format: str | None,
+        x_date_freq: str | None,
+        legend_loc: str | None = "upper left",
+        legend_labels: list[str] | None = None,
+        ax: Axes | None = None,
+    ) -> Figure | None:
+        """Draw a time series with an optional descriptive legend."""
+        raise NotImplementedError
+
+
+_QIS = cast(_QisPublicProtocol, qis_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and rendering helpers
+# =============================================================================
+
+_ALL_TABLE_TYPES = tuple(
+    table_type for table_type in DescTableType if table_type is not DescTableType.NONE
+)
+_DATES = pd.date_range("2024-01-31", periods=24, freq="ME", name="Date")
+_COMPLETE_VALUES = tuple(np.tile(np.array([0.0, 1.0, 2.0, 3.0]), 6))
+
+
+def _mixed_panel(*, nullable: bool) -> pd.DataFrame:
+    """Create complete, ragged, and all-missing histories in one panel.
+
+    Args:
+        nullable: Store every column as pandas nullable ``Float64`` when true.
+
+    Returns:
+        Ordered three-column panel with materially different missing-data states.
+    """
+    missing = pd.NA if nullable else np.nan
+    dtype = pd.Float64Dtype() if nullable else float
+    return pd.DataFrame(
+        {
+            "Complete": _COMPLETE_VALUES,
+            "Ragged": (missing,) * 12 + _COMPLETE_VALUES[:12],
+            "Missing": (missing,) * 24,
+        },
+        index=_DATES,
+        dtype=dtype,
+    )
+
+
+def _reference_series(*, nullable: bool) -> pd.Series:
+    """Create a named sample whose mean and sample spread both equal two.
+
+    Args:
+        nullable: Store values as pandas nullable ``Float64`` when true.
+
+    Returns:
+        Named Series containing the exact sample ``[0.0, 2.0, 4.0]``.
+    """
+    dtype = pd.Float64Dtype() if nullable else float
+    return pd.Series((0.0, 2.0, 4.0), name="Asset", dtype=dtype)
+
+
+def _legend_snapshot(ax: Axes) -> tuple[str, tuple[str, ...]]:
+    """Capture the rendered descriptive legend title and rows.
+
+    Args:
+        ax: Axis containing a descriptive-table legend.
+
+    Returns:
+        Legend title followed by its rows in display order.
+    """
+    legend = ax.get_legend()
+    assert legend is not None
+    return (
+        legend.get_title().get_text(),
+        tuple(text.get_text() for text in legend.get_texts()),
+    )
+
+
+def _render_table(
+    data: pd.DataFrame | pd.Series,
+    table_type: DescTableType,
+    var_format: str | None,
+) -> tuple[str, tuple[str, ...]]:
+    """Render one caller-owned descriptive-table plot and capture its legend.
+
+    Args:
+        data: Series or ordered mixed-history panel to plot.
+        table_type: Descriptive-table schema displayed in the legend.
+        var_format: Explicit Python format string, or native scalar formatting.
+
+    Returns:
+        Rendered legend title and rows.
+    """
+    original = data.copy()
+    fig, ax = plt.subplots()
+
+    try:
+        result = _QIS.plot_time_series(
+            data,
+            desc_table_type=table_type,
+            var_format=var_format,
+            x_date_freq=None,
+            ax=ax,
+        )
+        fig.canvas.draw()
+
+        assert result is None
+        if isinstance(data, pd.DataFrame):
+            assert isinstance(original, pd.DataFrame)
+            pd.testing.assert_frame_equal(data, original)
+        else:
+            assert isinstance(original, pd.Series)
+            pd.testing.assert_series_equal(data, original)
+        return _legend_snapshot(ax)
+    finally:
+        plt.close(fig)
+
+
+def _split_legend(
+    snapshot: tuple[str, tuple[str, ...]],
+) -> tuple[tuple[str, ...], tuple[tuple[str, ...], ...]]:
+    """Normalize table spacing while retaining every displayed token.
+
+    Args:
+        snapshot: Rendered descriptive legend title and rows.
+
+    Returns:
+        Whitespace-separated title and row tokens.
+    """
+    title, rows = snapshot
+    return tuple(title.split()), tuple(tuple(row.split()) for row in rows)
+
+
+# =============================================================================
+# Native descriptive-table formatting
+# =============================================================================
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+@pytest.mark.parametrize(
+    "table_type",
+    _ALL_TABLE_TYPES,
+    ids=tuple(table_type.name.lower() for table_type in _ALL_TABLE_TYPES),
+)
+def test_none_format_matches_native_text_for_every_descriptive_table(
+    table_type: DescTableType,
+    nullable: bool,
+) -> None:
+    """Make ``None`` equivalent to native scalar text for every table schema.
+
+    Args:
+        table_type: Public descriptive-table schema displayed in the legend.
+        nullable: Whether the mixed panel uses nullable floating storage.
+    """
+    data = _mixed_panel(nullable=nullable)
+
+    actual = _render_table(data, table_type, None)
+    expected = _render_table(data, table_type, "{}")
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+@pytest.mark.parametrize(
+    ("var_format", "expected_rows"),
+    (
+        (
+            None,
+            (
+                ("Complete", "1.5", "1.1420804814403216"),
+                ("Ragged", "1.5", "1.1677484162422844"),
+                ("Missing", "nan", "nan"),
+            ),
+        ),
+        (
+            "{:.3f}",
+            (
+                ("Complete", "1.500", "1.142"),
+                ("Ragged", "1.500", "1.168"),
+                ("Missing", "nan", "nan"),
+            ),
+        ),
+    ),
+    ids=("native", "explicit"),
+)
+def test_short_table_returns_independently_calculated_text(
+    var_format: str | None,
+    expected_rows: tuple[tuple[str, ...], ...],
+    nullable: bool,
+) -> None:
+    """Preserve exact native and explicit text for mixed-history short tables.
+
+    The complete sample has variance ``30 / 23``; the twelve observed ragged values have
+    variance ``15 / 11``. Both means are exactly ``1.5``.
+
+    Args:
+        var_format: Explicit three-decimal format or native scalar formatting.
+        expected_rows: Independently calculated rows after table-spacing normalization.
+        nullable: Whether the mixed panel uses nullable floating storage.
+    """
+    title, rows = _split_legend(
+        _render_table(_mixed_panel(nullable=nullable), DescTableType.SHORT, var_format)
+    )
+
+    assert title == ("Avg", "Std")
+    assert rows == expected_rows
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_none_format_preserves_series_dataframe_short_table_parity(nullable: bool) -> None:
+    """Render identical native short-table values from Series and DataFrame inputs.
+
+    Args:
+        nullable: Whether the exact reference sample uses nullable floating storage.
+    """
+    series = _reference_series(nullable=nullable)
+    series_snapshot = _render_table(series, DescTableType.SHORT, None)
+    frame_snapshot = _render_table(series.to_frame(), DescTableType.SHORT, None)
+
+    assert series_snapshot == frame_snapshot
+    assert _split_legend(series_snapshot) == (
+        ("Avg", "Std"),
+        (("Asset", "2.0", "2.0"),),
+    )
+
+
+# =============================================================================
+# Existing table bypasses and figure ownership
+# =============================================================================
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+@pytest.mark.parametrize("bypass", ("labels", "hidden"))
+def test_none_format_preserves_existing_descriptive_table_bypasses(
+    bypass: Literal["labels", "hidden"],
+    nullable: bool,
+) -> None:
+    """Keep caller labels and hidden legends independent of table formatting.
+
+    Args:
+        bypass: Existing option that prevents a descriptive table from being displayed.
+        nullable: Whether the mixed panel uses nullable floating storage.
+    """
+    data = _mixed_panel(nullable=nullable)
+    original = data.copy()
+    fig, ax = plt.subplots()
+    labels = ["First", "Second", "Third"] if bypass == "labels" else None
+    legend_loc = "upper left" if bypass == "labels" else None
+
+    try:
+        result = _QIS.plot_time_series(
+            data,
+            desc_table_type=DescTableType.SHORT,
+            var_format=None,
+            x_date_freq=None,
+            legend_loc=legend_loc,
+            legend_labels=labels,
+            ax=ax,
+        )
+        fig.canvas.draw()
+
+        assert result is None
+        if labels is not None:
+            assert _legend_snapshot(ax)[1] == tuple(labels)
+        else:
+            legend = ax.get_legend()
+            assert legend is not None
+            assert not legend.get_visible()
+        pd.testing.assert_frame_equal(data, original)
+    finally:
+        plt.close(fig)
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("float64", "nullable-float64"))
+def test_none_format_returns_a_caller_closeable_descriptive_figure(nullable: bool) -> None:
+    """Return the internally allocated descriptive figure after successful rendering.
+
+    Args:
+        nullable: Whether the mixed panel uses nullable floating storage.
+    """
+    data = _mixed_panel(nullable=nullable)
+    original = data.copy()
+    existing_figures = set(plt.get_fignums())
+    figure: Figure | None = None
+
+    try:
+        figure = _QIS.plot_time_series(
+            data,
+            desc_table_type=DescTableType.SHORT,
+            var_format=None,
+            x_date_freq=None,
+        )
+
+        assert isinstance(figure, Figure)
+        figure.canvas.draw()
+        assert len(set(plt.get_fignums()) - existing_figures) == 1
+        pd.testing.assert_frame_equal(data, original)
+    finally:
+        if figure is not None:
+            plt.close(figure)
+        for figure_number in set(plt.get_fignums()) - existing_figures:
+            plt.close(figure_number)

--- a/src/qis/plots/time_series.py
+++ b/src/qis/plots/time_series.py
@@ -80,7 +80,8 @@ def plot_time_series(df: Union[pd.Series, pd.DataFrame],
         trend_line_colors: colours for those trend lines, defaulting to the series colours
         legend_stats: which statistics each legend entry reports; see :class:`LegendStats`
         desc_table_type: descriptive statistics table drawn beside the plot. Observed infinity
-            is rejected before drawing when this table is displayed
+            is rejected before drawing when this table is displayed; when ``var_format`` is
+            None, table values use native scalar text
         legend_labels: replace the column names in the legend. Statistics from
             ``legend_stats`` are appended to these
         indices_for_shaded_areas: name to (start, end) positional index pairs, shaded to mark
@@ -117,9 +118,11 @@ def plot_time_series(df: Union[pd.Series, pd.DataFrame],
             and legend_labels is None
             and desc_table_type != DescTableType.NONE):
         # Validate descriptive inputs before plotting can mutate or allocate a figure.
+        # Preserve automatic axis ticks while giving descriptive values a text format.
+        table_var_format = '{}' if var_format is None else var_format
         stats_table = compute_desc_table(df=data1,
                                          desc_table_type=desc_table_type,
-                                         var_format=var_format)
+                                         var_format=table_var_format)
 
     if ax is None:
         fig, ax = plt.subplots()


### PR DESCRIPTION
## What changed

Make `plot_time_series()` translate `var_format=None` to native scalar text only for a requested descriptive legend table, while preserving `None` for Matplotlib axis formatting; document the composition rule and add deterministic regression coverage for every displayed table schema.

## Behavior

Time-series plots with a descriptive legend and `var_format=None` now render native scalar table text instead of raising an incidental `AttributeError`. Explicit format strings, table-bypass paths, descriptive statistics, axis formatting, public signatures, defaults, and exports are unchanged. The implementation composes with PR 68's accepted pre-render validation.

## Regression evidence

Before the fix, every displayed native-format path in the new regression module failed with `AttributeError: 'NoneType' object has no attribute 'format'`. Independently calculated controls require mean and sample standard deviation `2.0` for `[0.0, 2.0, 4.0]`, and mean `1.5` with sample standard deviation `sqrt(30 / 23) = 1.1420804814403216` for the repeated complete sample. After the fix and post-PR-68 rebase, the complete affected plots suite, including all 30 focused cases, reports `268 passed`.

## Verification

- Affected plots suite: `268 passed`.
- Perfstats interaction suite: `750 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2476 passed, 16 warnings`; all warnings are accepted third-party Seaborn/Matplotlib deprecations.
- Changed-line Ruff, differential Pyright, formatting, public API, dependencies, and whitespace: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/docs/plotting_kwargs.md`, `src/qis/plots/time_series.py`, and `src/qis/plots/tests/desc_table_none_format_test.py`.

Out of scope: Direct `compute_desc_table(..., var_format=None)` behavior, Q-Q and histogram format contracts, table-width redesign, numerical statistic changes, public signatures, exports, dependencies, and unrelated formatting.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.