### PR TITLE
fix: handle all-zero nonzero endpoint legends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Made time-series descriptive legends use native scalar text when their public plotting format
   is `None`.
+- Made all-zero `FIRST_LAST_NON_ZERO` legends display undefined endpoints instead of raising an
+  incidental indexing error.
 
 ## [5.22.1] - 2026-09-05
 

--- a/src/qis/plots/tests/legend_all_zero_first_last_test.py
+++ b/src/qis/plots/tests/legend_all_zero_first_last_test.py
@@ -1,0 +1,343 @@
+"""Regression coverage for all-zero nonzero-endpoint legends.
+
+``LegendStats.FIRST_LAST_NON_ZERO`` treats exact zeros as unavailable positions and displays the
+first and last observations that remain. A history containing no nonzero observations therefore
+has two undefined endpoints, just as an all-missing history does; it must not abort an otherwise
+valid mixed panel.
+
+One ordered fixture combines ordinary and nullable all-zero columns with leading, trailing, and
+interior zeros, an all-missing history, a singleton nonzero history, and an ordinary signed
+history. Exact helper and public-plot labels, custom and native missing displays,
+Series/DataFrame consistency, warnings-as-errors, forced canvas rendering, column order, caller
+ownership, and figure cleanup protect the narrow endpoint-selection contract.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+# qis
+import qis.plots.stackplot as stackplot_module
+import qis.plots.time_series as time_series_module
+import qis.plots.utils as plot_utils_module
+from qis.plots.utils import LegendStats
+
+
+class _PlotUtilsModuleProtocol(Protocol):
+    """Typed test-side interface for the shared legend builder."""
+
+    def get_legend_lines(
+        self,
+        data: pd.DataFrame | pd.Series,
+        *,
+        legend_stats: LegendStats,
+        var_format: str | None,
+        nan_display: float,
+    ) -> list[str]:
+        """Return legend lines for the selected nonzero endpoints.
+
+        Args:
+            data: Series or DataFrame summarized in the legend.
+            legend_stats: Public legend mode under test.
+            var_format: Explicit Python format string, or native scalar formatting.
+            nan_display: Scalar used when no selected endpoint exists.
+
+        Returns:
+            Legend lines in input-column order.
+        """
+        raise NotImplementedError
+
+
+class _StackplotModuleProtocol(Protocol):
+    """Typed test-side interface for the public stacked plot."""
+
+    def plot_stack(
+        self,
+        df: pd.DataFrame,
+        *,
+        x_date_freq: None,
+        legend_stats: LegendStats,
+        var_format: str,
+        ax: Axes,
+    ) -> Figure | None:
+        """Render a stacked plot with nonzero endpoint labels.
+
+        Args:
+            df: Ordinary floating-point panel to stack.
+            x_date_freq: Disabled date-axis formatting for the focused test.
+            legend_stats: Public legend mode under test.
+            var_format: Explicit endpoint format.
+            ax: Matplotlib axis receiving the plot.
+
+        Returns:
+            The created figure, or None when the caller supplies ``ax``.
+        """
+        raise NotImplementedError
+
+
+class _TimeSeriesModuleProtocol(Protocol):
+    """Typed test-side interface for the public time-series plot."""
+
+    def plot_time_series(
+        self,
+        df: pd.DataFrame | pd.Series,
+        *,
+        x_date_freq: None,
+        legend_stats: LegendStats,
+        var_format: str,
+        ax: Axes,
+    ) -> Figure | None:
+        """Render time series with nonzero endpoint labels.
+
+        Args:
+            df: Series or DataFrame plotted by date.
+            x_date_freq: Disabled date-axis formatting for the focused test.
+            legend_stats: Public legend mode under test.
+            var_format: Explicit endpoint format.
+            ax: Matplotlib axis receiving the plot.
+
+        Returns:
+            The created figure, or None when the caller supplies ``ax``.
+        """
+        raise NotImplementedError
+
+
+_PLOT_UTILS = cast(_PlotUtilsModuleProtocol, plot_utils_module)
+_STACKPLOT = cast(_StackplotModuleProtocol, stackplot_module)
+_TIME_SERIES = cast(_TimeSeriesModuleProtocol, time_series_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent expectations
+# =============================================================================
+
+_DATES = pd.date_range("2024-01-31", periods=6, freq="ME")
+
+_FLOAT_ALL_ZERO = "Float All Zero"
+_NULLABLE_ALL_ZERO = "Nullable All Zero"
+_EDGE_ZERO = "Edge Zero"
+_INTERIOR_ZERO = "Interior Zero"
+_ALL_MISSING = "All Missing"
+_SINGLETON_NONZERO = "Singleton Nonzero"
+_SIGNED = "Signed"
+
+_FORMATTED_EXPECTED = (
+    "Float All Zero: first=nan, last=nan",
+    "Nullable All Zero: first=nan, last=nan",
+    "Edge Zero: first=2.00, last=3.00",
+    "Interior Zero: first=1.00, last=4.00",
+    "All Missing: first=nan, last=nan",
+    "Singleton Nonzero: first=5.00, last=5.00",
+    "Signed: first=-2.00, last=3.00",
+)
+
+_CUSTOM_MISSING_EXPECTED = (
+    "Float All Zero: first=-99.00, last=-99.00",
+    "Nullable All Zero: first=-99.00, last=-99.00",
+    "Edge Zero: first=2.00, last=3.00",
+    "Interior Zero: first=1.00, last=4.00",
+    "All Missing: first=-99.00, last=-99.00",
+    "Singleton Nonzero: first=5.00, last=5.00",
+    "Signed: first=-2.00, last=3.00",
+)
+
+_NATIVE_EXPECTED = (
+    "Float All Zero: first=nan, last=nan",
+    "Nullable All Zero: first=nan, last=nan",
+    "Edge Zero: first=2.0, last=3.0",
+    "Interior Zero: first=1.0, last=4.0",
+    "All Missing: first=nan, last=nan",
+    "Singleton Nonzero: first=5.0, last=5.0",
+    "Signed: first=-2.0, last=3.0",
+)
+
+
+def _mixed_values() -> pd.DataFrame:
+    """Create every material zero-selection state in one ordered panel.
+
+    Returns:
+        Six-date panel retaining ordinary and nullable floating-point columns.
+    """
+    values = pd.DataFrame(index=_DATES)
+    values[_FLOAT_ALL_ZERO] = pd.Series((0.0,) * 6, index=_DATES, dtype=float)
+    values[_NULLABLE_ALL_ZERO] = pd.Series((0.0,) * 6, index=_DATES, dtype=pd.Float64Dtype())
+    values[_EDGE_ZERO] = pd.Series((0.0, 2.0, 0.0, 3.0, 0.0, 0.0), index=_DATES, dtype=float)
+    values[_INTERIOR_ZERO] = pd.Series((1.0, 0.0, 2.0, 0.0, 3.0, 4.0), index=_DATES, dtype=float)
+    values[_ALL_MISSING] = pd.Series((pd.NA,) * 6, index=_DATES, dtype=pd.Float64Dtype())
+    values[_SINGLETON_NONZERO] = pd.Series(
+        (0.0, pd.NA, 5.0, 0.0, pd.NA, 0.0), index=_DATES, dtype=pd.Float64Dtype()
+    )
+    values[_SIGNED] = pd.Series((-2.0, -1.0, 0.0, 1.0, 2.0, 3.0), index=_DATES, dtype=float)
+    return values
+
+
+def _legend_lines(
+    data: pd.DataFrame | pd.Series,
+    *,
+    var_format: str | None,
+    nan_display: float = np.nan,
+) -> tuple[str, ...]:
+    """Build exact legend text while treating every warning as a failure.
+
+    Args:
+        data: Series or DataFrame summarized in the legend.
+        var_format: Explicit Python format string, or native scalar formatting.
+        nan_display: Scalar used when no selected endpoint exists.
+
+    Returns:
+        Immutable legend lines in input-column order.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        return tuple(
+            _PLOT_UTILS.get_legend_lines(
+                data,
+                legend_stats=LegendStats.FIRST_LAST_NON_ZERO,
+                var_format=var_format,
+                nan_display=nan_display,
+            )
+        )
+
+
+def _axis_legend_text(axis: Axes) -> tuple[str, ...]:
+    """Read exact legend labels from a rendered axis.
+
+    Args:
+        axis: Axis containing a completed public plot.
+
+    Returns:
+        Legend labels in display order.
+    """
+    legend = axis.get_legend()
+    assert legend is not None
+    return tuple(text.get_text() for text in legend.get_texts())
+
+
+# =============================================================================
+# Shared-helper mixed-panel contract
+# =============================================================================
+
+
+def test_get_legend_lines_handles_all_zero_columns_in_mixed_panel() -> None:
+    """Return undefined endpoints without aborting valid neighboring histories."""
+    values = _mixed_values()
+    original = values.copy()
+
+    actual = _legend_lines(values, var_format="{:.2f}")
+
+    assert actual == _FORMATTED_EXPECTED
+    pd.testing.assert_frame_equal(values, original)
+
+
+@pytest.mark.parametrize(
+    ("var_format", "nan_display", "expected"),
+    (
+        ("{:.2f}", -99.0, _CUSTOM_MISSING_EXPECTED),
+        (None, np.nan, _NATIVE_EXPECTED),
+    ),
+    ids=("custom-missing", "native-format"),
+)
+def test_get_legend_lines_preserves_missing_and_format_contracts(
+    var_format: str | None,
+    nan_display: float,
+    expected: tuple[str, ...],
+) -> None:
+    """Keep configured missing values and native formatting after zero selection.
+
+    Args:
+        var_format: Explicit endpoint format, or native scalar formatting.
+        nan_display: Scalar used when no selected endpoint exists.
+        expected: Independently specified text for the complete mixed panel.
+    """
+    assert (
+        _legend_lines(_mixed_values(), var_format=var_format, nan_display=nan_display) == expected
+    )
+
+
+# =============================================================================
+# Named Series/DataFrame consistency
+# =============================================================================
+
+
+@pytest.mark.parametrize("column", (_FLOAT_ALL_ZERO, _NULLABLE_ALL_ZERO))
+def test_get_legend_lines_all_zero_series_matches_one_column_frame(column: str) -> None:
+    """Return the same undefined endpoints for ordinary and nullable pandas shapes.
+
+    Args:
+        column: Ordinary or nullable all-zero fixture column.
+    """
+    selected = _mixed_values()[column]
+    assert isinstance(selected, pd.Series)
+
+    series_result = _legend_lines(selected, var_format="{:.2f}")
+    frame_result = _legend_lines(selected.to_frame(), var_format="{:.2f}")
+
+    expected = (f"{column}: first=nan, last=nan",)
+    assert series_result == expected
+    assert frame_result == expected
+
+
+# =============================================================================
+# Public rendering contracts
+# =============================================================================
+
+
+def test_plot_time_series_renders_all_zero_endpoints_in_mixed_panel() -> None:
+    """Render the complete mixed endpoint contract through the public line plot."""
+    values = _mixed_values()
+    original = values.copy()
+    figure, axis = plt.subplots()
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _TIME_SERIES.plot_time_series(
+                values,
+                x_date_freq=None,
+                legend_stats=LegendStats.FIRST_LAST_NON_ZERO,
+                var_format="{:.2f}",
+                ax=axis,
+            )
+            figure.canvas.draw()
+
+        assert _axis_legend_text(axis) == _FORMATTED_EXPECTED
+        pd.testing.assert_frame_equal(values, original)
+    finally:
+        plt.close(figure)
+
+
+def test_plot_stack_renders_all_zero_endpoints_with_total_title() -> None:
+    """Render the mode's ordinary stack-plot labels and established total title."""
+    values = _mixed_values().loc[:, [_FLOAT_ALL_ZERO, _EDGE_ZERO]]
+    assert isinstance(values, pd.DataFrame)
+    original = values.copy()
+    figure, axis = plt.subplots()
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _STACKPLOT.plot_stack(
+                values,
+                x_date_freq=None,
+                legend_stats=LegendStats.FIRST_LAST_NON_ZERO,
+                var_format="{:.2f}",
+                ax=axis,
+            )
+            figure.canvas.draw()
+
+        assert _axis_legend_text(axis) == (
+            "Float All Zero: first=nan, last=nan",
+            "Edge Zero: first=2.00, last=3.00",
+        )
+        legend = axis.get_legend()
+        assert legend is not None
+        assert legend.get_title().get_text() == "Total: last=0.00"
+        pd.testing.assert_frame_equal(values, original)
+    finally:
+        plt.close(figure)

--- a/src/qis/plots/utils.py
+++ b/src/qis/plots/utils.py
@@ -757,11 +757,12 @@ class LegendStats(Enum):
 
     ``NONNAN`` takes the last observed value rather than the value at the last index, which
     differs when a series ends with gaps. ``NONZERO`` excludes zeros, for a series where zero
-    means "no position" rather than "a return of zero". ``MISSING`` reports the percentage of
-    NaN observations after the first observed value, while ``ZERO`` reports the percentage whose
-    absolute value is below the near-zero cutoff over the same window. An all-missing history has
-    100% missing coverage and an undefined zero percentage. ``SCORE`` appends the percentile rank
-    of the last value within its own history.
+    means "no position" rather than "a return of zero"; its statistics are undefined when no
+    observations remain. ``MISSING`` reports the percentage of NaN observations after the first
+    observed value, while ``ZERO`` reports the percentage whose absolute value is below the
+    near-zero cutoff over the same window. An all-missing history has 100% missing coverage and an
+    undefined zero percentage. ``SCORE`` appends the percentile rank of the last value within its
+    own history.
 
     ``NONE`` prints the column name alone. Formatting of every value follows the ``var_format``
     argument of the plotting function; when it is ``None``, values use their native scalar text.
@@ -1141,8 +1142,13 @@ def get_legend_lines(data: Union[pd.DataFrame, pd.Series],
             else:
                 data_column = data_column.replace({0.0: np.nan})
                 nonnan_data = data_column.dropna()
-                first = nonnan_data.iloc[0]
-                last = nonnan_data.iloc[-1]
+                # A fully filtered history has the same undefined endpoints as an all-missing one.
+                if nonnan_data.empty:
+                    first = nan_display
+                    last = nan_display
+                else:
+                    first = nonnan_data.iloc[0]
+                    last = nonnan_data.iloc[-1]
             legend_lines.append(f"{column}: first={var_format.format(first)}, last={var_format.format(last)}")
 
     elif legend_stats in [LegendStats.FIRST_AVG_LAST, LegendStats.FIRST_AVG_LAST_SHORT]:


### PR DESCRIPTION
## What changed

Guard the empty sample produced when `FIRST_LAST_NON_ZERO` filters every selected value, document the undefined endpoint contract, and add deterministic mixed-panel and rendered plotting regressions.

## Behavior

An all-zero ordinary or nullable history now displays the configured missing value for both `FIRST_LAST_NON_ZERO` endpoints instead of raising `IndexError`. Nonzero endpoint selection, formatting, labels, other legend modes, public signatures, defaults, and exports are unchanged.

## Regression evidence

On accepted code, all seven new regression cases failed at the unchecked empty filtered sample with `IndexError: single positional indexer is out-of-bounds`. After the guard, the cases pass for ordinary and nullable all-zero histories, a simultaneous mixed-state panel, custom and native formatting, Series/DataFrame parity, and real canvas rendering, while independently specified nonzero and undefined controls remain unchanged.

## Verification

- Focused PR 70 module plus complete affected plots suite: `275 passed`.
- Complete perfstats interaction suite: `750 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2484 passed, 16 warnings`; all warnings are accepted third-party Seaborn/Matplotlib deprecations.
- Changed-line Ruff, differential Pyright, formatting, public API, dependency integrity, and whitespace checks: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/plots/utils.py`, and `src/qis/plots/tests/legend_all_zero_first_last_test.py`.

Out of scope: The definition of zero, the other `NONZERO` modes, infinity policy, numerical reductions, display formatting, labels, public signatures, exports, dependencies, and unrelated formatting.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.