### PR TITLE
fix: validate benchmark source labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Rejected invalid or duplicate resolved benchmark labels before benchmark-aware performance and
+  regime calculations can expose incidental downstream errors.
 - Made time-series descriptive legends use native scalar text when their public plotting format
   is `None`.
 - Made all-zero `FIRST_LAST_NON_ZERO` legends display undefined endpoints instead of raising an

--- a/src/qis/perfstats/perf_stats.py
+++ b/src/qis/perfstats/perf_stats.py
@@ -191,49 +191,54 @@ def resolve_benchmark_source(prices: pd.DataFrame,
 
     Args:
         prices: Asset price DataFrame.
-        benchmark: Optional benchmark column name.
-        benchmark_price: Optional benchmark price Series.
+        benchmark: Optional non-empty benchmark column name.
+        benchmark_price: Optional benchmark price Series. Its name must be a non-empty string
+            when ``benchmark`` is omitted.
 
     Returns:
         Tuple of (prices DataFrame possibly augmented with benchmark column, benchmark name).
 
     Raises:
-        ValueError: If neither benchmark nor benchmark_price is supplied, or if benchmark
-            is given as a name but is not in prices and benchmark_price is None, or if
-            benchmark_price is supplied but is not a pd.Series.
+        ValueError: If neither benchmark source is supplied, the resolved name is not a non-empty
+            string, the selected name occurs more than once in prices, a name-only source is
+            absent from prices, or benchmark_price is not a Series.
     """
-    # Case 0: nothing supplied
-    if benchmark is None and benchmark_price is None:
-        raise ValueError("provide either benchmark name in prices or benchmark_price")
-
-    # Case 1: benchmark name only — must already be in prices
-    if benchmark_price is None:
-        if benchmark not in prices.columns:
-            raise ValueError(f"{benchmark} is not in {prices.columns.to_list()}")
-        return prices, benchmark
+    # Require one usable logical label before selecting or adding a physical benchmark column.
+    if benchmark is not None and (not isinstance(benchmark, str) or not benchmark):
+        raise ValueError("benchmark must be a non-empty string")
 
     # benchmark_price was supplied — type check
-    if not isinstance(benchmark_price, pd.Series):
+    if benchmark_price is not None and not isinstance(benchmark_price, pd.Series):
         raise ValueError(f"benchmark_price must be pd.Series not {type(benchmark_price)}")
 
-    # Case 2: benchmark_price only — use its .name as the column name
     if benchmark is None:
-        name = benchmark_price.name
-        if name in prices.columns:
-            # column already present — trust the existing data
-            return prices, name
-        # reindex to prices' calendar with forward-fill for missing observations
-        aligned = benchmark_price.reindex(index=prices.index, method='ffill').ffill()
-        prices_out = pd.concat([aligned.rename(name), prices], axis=1, sort=True)
-        return prices_out, name
+        if benchmark_price is None:
+            raise ValueError("provide either benchmark name in prices or benchmark_price")
+        series_name = benchmark_price.name
+        if not isinstance(series_name, str) or not series_name:
+            raise ValueError(
+                "benchmark_price must have a non-empty string name when benchmark is not supplied"
+            )
+        name = series_name
+    else:
+        name = benchmark
 
-    # Case 3: both supplied — explicit name overrides Series.name
-    if benchmark in prices.columns:
-        # column already present — trust the existing data, ignore benchmark_price
-        return prices, benchmark
+    # A logical benchmark must never select an ambiguous two-dimensional price source.
+    matches = int(np.count_nonzero(prices.columns == name))
+    if matches > 1:
+        raise ValueError(
+            f"benchmark {name!r} must identify one unique prices column; found {matches}"
+        )
+    if matches == 1:
+        # Existing in-panel data remains authoritative over a supplied Series.
+        return prices, name
+    if benchmark_price is None:
+        raise ValueError(f"{name} is not in {prices.columns.to_list()}")
+
+    # Add a zero-match Series only after label and source cardinality are unambiguous.
     aligned = benchmark_price.reindex(index=prices.index, method='ffill').ffill()
-    prices_out = pd.concat([aligned.rename(benchmark), prices], axis=1, sort=True)
-    return prices_out, benchmark
+    prices_out = pd.concat([aligned.rename(name), prices], axis=1, sort=True)
+    return prices_out, name
 
 
 # =============================================================================
@@ -517,10 +522,11 @@ def compute_ra_perf_table_with_benchmark(prices: pd.DataFrame,
 
     Args:
         prices: DataFrame of asset price levels.
-        benchmark: Column name of the benchmark in ``prices``. Optional if
-            ``benchmark_price`` is supplied.
+        benchmark: Non-empty benchmark column name. Optional if a named ``benchmark_price`` is
+            supplied. The resolved name must occur at most once in ``prices``.
         benchmark_price: Stand-alone benchmark price Series. Optional if ``benchmark``
-            is in ``prices``. See ``resolve_benchmark_source`` for the three-way branching.
+            is in ``prices``. Its name must be a non-empty string when ``benchmark`` is omitted.
+            See ``resolve_benchmark_source`` for the three-way branching.
         perf_params: Performance parameter object. If None, frequency is inferred.
         is_log_returns: If True, compute log returns instead of arithmetic returns
             for the regression.
@@ -530,6 +536,10 @@ def compute_ra_perf_table_with_benchmark(prices: pd.DataFrame,
     Returns:
         DataFrame indexed by asset with all base RA metrics plus ALPHA, ALPHA_AN,
         BETA, R2 and ALPHA_PVALUE columns.
+
+    Raises:
+        ValueError: If the benchmark source has no non-empty string label, the selected label is
+            duplicated in prices, or no usable benchmark source is available.
     """
     # Resolve the three input modes (name only / price only / both) into a
     # consistent (prices_with_benchmark, benchmark_name) pair.

--- a/src/qis/perfstats/regime_classifier.py
+++ b/src/qis/perfstats/regime_classifier.py
@@ -879,10 +879,12 @@ def compute_bnb_regimes_pa_perf_table(prices: pd.DataFrame,
 
     Args:
         prices: Asset price series
-        benchmark: Benchmark column name in prices, or explicit name for ``benchmark_price``
+        benchmark: Non-empty benchmark column name in prices, or explicit name for
+            ``benchmark_price``. The resolved name must occur at most once in prices.
         benchmark_price: Alternative benchmark price series to add to prices. When ``benchmark``
             is supplied, that explicit name takes precedence over the Series name. An existing
-            price column with the resolved name takes precedence over the Series values.
+            price column with the resolved name takes precedence over the Series values. When
+            ``benchmark`` is omitted, the Series name must be a non-empty string.
         freq: Sampling frequency
         return_type: Type of returns to compute
         q: Quantile boundaries or number of quantiles
@@ -897,8 +899,8 @@ def compute_bnb_regimes_pa_perf_table(prices: pd.DataFrame,
         Regime-conditional performance table
 
     Raises:
-        ValueError: If neither benchmark source is provided, a name-only source is absent from
-            prices, or benchmark_price is not a Series.
+        ValueError: If neither benchmark source is provided, the resolved label is invalid or
+            duplicated in prices, a name-only source is absent, or benchmark_price is not a Series.
     """
     # Share source precedence with the benchmark-aware performance table before classification.
     prices, benchmark = pt.resolve_benchmark_source(

--- a/src/qis/perfstats/tests/benchmark_source_validation_test.py
+++ b/src/qis/perfstats/tests/benchmark_source_validation_test.py
@@ -1,0 +1,456 @@
+"""Regression tests for benchmark-source labels and selected-column uniqueness.
+
+The benchmark-aware performance and regime tables share one source resolver. A standalone
+benchmark Series therefore needs a usable label when no explicit name is supplied, and the
+resolved label must identify at most one existing price column before either numerical path
+begins. These tests exercise that common boundary so invalid input raises the same deterministic
+error instead of leaking downstream pandas, regression, or classifier exceptions.
+
+The deterministic panel contains thirteen quarter-end observations, which is enough for both
+public calculations. Valid calls are compared with independently assembled in-panel controls.
+The matrix also preserves explicit-name precedence, nullable floating storage, calendar metadata,
+and caller ownership while rejecting ambiguous duplicate benchmark columns.
+"""
+
+from collections.abc import Hashable
+from typing import Literal, Protocol, cast
+
+import pandas as pd
+import pytest
+
+import qis.perfstats.perf_stats as perf_stats_module
+import qis.perfstats.regime_classifier as regime_classifier_module
+from qis.perfstats.config import PerfParams
+
+
+class _PerfStatsModuleProtocol(Protocol):
+    """Typed test-side interface for benchmark-source resolution and performance tables."""
+
+    def resolve_benchmark_source(
+        self,
+        *,
+        prices: pd.DataFrame,
+        benchmark: str | None,
+        benchmark_price: object | None,
+    ) -> tuple[pd.DataFrame, str]:
+        """Return the normalized price panel and selected benchmark label."""
+        raise NotImplementedError
+
+    def compute_ra_perf_table_with_benchmark(
+        self,
+        *,
+        prices: pd.DataFrame,
+        benchmark: str | None = None,
+        benchmark_price: pd.Series | None = None,
+        perf_params: PerfParams | None = None,
+    ) -> pd.DataFrame:
+        """Return a risk-adjusted table for one benchmark source."""
+        raise NotImplementedError
+
+
+class _RegimeClassifierModuleProtocol(Protocol):
+    """Typed test-side interface for benchmark-aware regime tables."""
+
+    def compute_bnb_regimes_pa_perf_table(
+        self,
+        *,
+        prices: pd.DataFrame,
+        benchmark: str | None = None,
+        benchmark_price: pd.Series | None = None,
+        freq: str = "QE",
+        perf_params: PerfParams | None = None,
+    ) -> pd.DataFrame:
+        """Return a regime table for one benchmark source."""
+        raise NotImplementedError
+
+
+_PERF_STATS = cast(_PerfStatsModuleProtocol, perf_stats_module)
+_REGIME_CLASSIFIER = cast(_RegimeClassifierModuleProtocol, regime_classifier_module)
+
+pytestmark = pytest.mark.filterwarnings("error")
+
+
+# =============================================================================
+# Shared deterministic fixtures and typed dispatch
+# =============================================================================
+
+_DATES = pd.date_range("2021-03-31", periods=13, freq="QE", name="Date")
+_SOURCE_DATES = _DATES - pd.Timedelta(days=1)
+
+_ASSET_NAME = "Asset"
+_BENCHMARK_NAME = "Benchmark"
+
+_ASSET_PRICES = (80.0, 82.0, 79.0, 84.0, 83.0, 88.0, 86.0, 92.0, 91.0, 97.0, 95.0, 101.0, 99.0)
+_BENCHMARK_PRICES = (
+    100.0,
+    90.0,
+    95.0,
+    85.0,
+    92.0,
+    98.0,
+    110.0,
+    105.0,
+    120.0,
+    118.0,
+    135.0,
+    130.0,
+    150.0,
+)
+_IGNORED_BENCHMARK_PRICES = (
+    200.0,
+    180.0,
+    210.0,
+    170.0,
+    220.0,
+    160.0,
+    230.0,
+    150.0,
+    240.0,
+    140.0,
+    250.0,
+    130.0,
+    260.0,
+)
+
+_INFERRED_NAME_ERROR = (
+    "benchmark_price must have a non-empty string name when benchmark is not supplied"
+)
+_EXPLICIT_NAME_ERROR = "benchmark must be a non-empty string"
+_DUPLICATE_ERROR = "benchmark 'Benchmark' must identify one unique prices column; found 2"
+_PERF_PARAMS = PerfParams(freq="QE")
+
+_SourceMode = Literal["both", "name_only", "series_only"]
+_TableKind = Literal["regime", "risk_adjusted"]
+
+
+def _asset_prices() -> pd.DataFrame:
+    """Create the caller-owned asset panel.
+
+    Returns:
+        Complete quarterly asset prices with a named calendar.
+    """
+    return pd.DataFrame({_ASSET_NAME: _ASSET_PRICES}, index=_DATES)
+
+
+def _benchmark_price(
+    *,
+    name: Hashable | None,
+    nullable: bool = False,
+    values: tuple[float, ...] = _BENCHMARK_PRICES,
+) -> pd.Series:
+    """Create a standalone benchmark observed one day before each asset date.
+
+    Args:
+        name: Raw Series label presented to the resolver.
+        nullable: Whether to store values with pandas nullable floating dtype.
+        values: Deterministic benchmark levels.
+
+    Returns:
+        Caller-owned benchmark Series with the requested name and dtype.
+    """
+    dtype: object = pd.Float64Dtype() if nullable else float
+    return pd.Series(values, index=_SOURCE_DATES, name=name, dtype=dtype)
+
+
+def _benchmark_panel(*, duplicate: bool = False) -> pd.DataFrame:
+    """Independently assemble an in-panel benchmark control.
+
+    Args:
+        duplicate: Whether to repeat the selected benchmark label.
+
+    Returns:
+        Benchmark-first price panel with one or two selected columns.
+    """
+    benchmark = pd.Series(_BENCHMARK_PRICES, index=_DATES, name=_BENCHMARK_NAME)
+    panel = pd.concat((benchmark, _asset_prices()), axis=1)
+    if duplicate:
+        second_benchmark = pd.Series(
+            _IGNORED_BENCHMARK_PRICES,
+            index=_DATES,
+            name=_BENCHMARK_NAME,
+        )
+        panel = pd.concat((benchmark, second_benchmark, _asset_prices()), axis=1)
+    return panel
+
+
+def _compute_table(
+    table_kind: _TableKind,
+    *,
+    prices: pd.DataFrame,
+    benchmark: str | None = None,
+    benchmark_price: pd.Series | None = None,
+) -> pd.DataFrame:
+    """Call one benchmark-aware public entry point.
+
+    Args:
+        table_kind: Public calculation to exercise.
+        prices: Caller-owned price panel.
+        benchmark: Optional explicit benchmark label.
+        benchmark_price: Optional standalone benchmark Series.
+
+    Returns:
+        Risk-adjusted or regime-conditional performance table.
+    """
+    if table_kind == "risk_adjusted":
+        return _PERF_STATS.compute_ra_perf_table_with_benchmark(
+            prices=prices,
+            benchmark=benchmark,
+            benchmark_price=benchmark_price,
+            perf_params=_PERF_PARAMS,
+        )
+    return _REGIME_CLASSIFIER.compute_bnb_regimes_pa_perf_table(
+        prices=prices,
+        benchmark=benchmark,
+        benchmark_price=benchmark_price,
+        freq="QE",
+        perf_params=_PERF_PARAMS,
+    )
+
+
+def _duplicate_source(source_mode: _SourceMode) -> tuple[str | None, pd.Series | None]:
+    """Return inputs for one duplicate-column source mode.
+
+    Args:
+        source_mode: Name-only, Series-only, or combined source specification.
+
+    Returns:
+        Explicit label and optional standalone Series for the selected mode.
+    """
+    if source_mode == "name_only":
+        return _BENCHMARK_NAME, None
+    benchmark_price = _benchmark_price(name=_BENCHMARK_NAME)
+    if source_mode == "series_only":
+        return None, benchmark_price
+    return _BENCHMARK_NAME, benchmark_price
+
+
+# =============================================================================
+# Resolved-label validation
+# =============================================================================
+
+
+@pytest.mark.parametrize("invalid_name", (None, "", 7, ("Benchmark", 1)))
+def test_resolver_rejects_invalid_inferred_benchmark_names(
+    invalid_name: Hashable | None,
+) -> None:
+    """Reject every unusable inferred label with one exact boundary error."""
+    with pytest.raises(ValueError, match=f"^{_INFERRED_NAME_ERROR}$"):
+        _PERF_STATS.resolve_benchmark_source(
+            prices=_asset_prices(),
+            benchmark=None,
+            benchmark_price=_benchmark_price(name=invalid_name),
+        )
+
+
+@pytest.mark.parametrize("invalid_name", ("", 7, ("Benchmark", 1)))
+def test_resolver_rejects_invalid_explicit_benchmark_names(
+    invalid_name: Hashable,
+) -> None:
+    """Reject an unusable explicit label even when a valid Series is available."""
+    with pytest.raises(ValueError, match=f"^{_EXPLICIT_NAME_ERROR}$"):
+        _PERF_STATS.resolve_benchmark_source(
+            prices=_asset_prices(),
+            benchmark=cast(str, invalid_name),
+            benchmark_price=_benchmark_price(name=_BENCHMARK_NAME),
+        )
+
+
+@pytest.mark.parametrize("table_kind", ("regime", "risk_adjusted"))
+def test_public_tables_propagate_empty_explicit_name_error(
+    table_kind: _TableKind,
+) -> None:
+    """Reject an empty explicit name before either public numerical calculation."""
+    with pytest.raises(ValueError, match=f"^{_EXPLICIT_NAME_ERROR}$"):
+        _compute_table(
+            table_kind,
+            prices=_asset_prices(),
+            benchmark="",
+            benchmark_price=_benchmark_price(name=_BENCHMARK_NAME),
+        )
+
+
+@pytest.mark.parametrize("table_kind", ("regime", "risk_adjusted"))
+@pytest.mark.parametrize("invalid_name", (None, "", 7, ("Benchmark", 1)))
+def test_public_tables_propagate_invalid_inferred_name_error(
+    invalid_name: Hashable | None,
+    table_kind: _TableKind,
+) -> None:
+    """Fail at the shared input boundary before either numerical calculation."""
+    with pytest.raises(ValueError, match=f"^{_INFERRED_NAME_ERROR}$"):
+        _compute_table(
+            table_kind,
+            prices=_asset_prices(),
+            benchmark_price=_benchmark_price(name=invalid_name),
+        )
+
+
+@pytest.mark.parametrize("table_kind", ("regime", "risk_adjusted"))
+@pytest.mark.parametrize("raw_name", (None, "", 7, ("Benchmark", 1)))
+def test_explicit_name_overrides_invalid_raw_series_name(
+    raw_name: Hashable | None,
+    table_kind: _TableKind,
+) -> None:
+    """Preserve explicit-name precedence over irrelevant raw Series metadata.
+
+    The expected result comes from a separately assembled name-only panel. Exact equality proves
+    that label validation does not alter either valid numerical path.
+    """
+    prices = _asset_prices()
+    benchmark_price = _benchmark_price(name=raw_name)
+    original_prices = prices.copy(deep=True)
+    original_benchmark = benchmark_price.copy(deep=True)
+
+    expected = _compute_table(
+        table_kind,
+        prices=_benchmark_panel(),
+        benchmark=_BENCHMARK_NAME,
+    )
+    actual = _compute_table(
+        table_kind,
+        prices=prices,
+        benchmark=_BENCHMARK_NAME,
+        benchmark_price=benchmark_price,
+    )
+
+    pd.testing.assert_frame_equal(actual, expected)
+    pd.testing.assert_frame_equal(prices, original_prices)
+    pd.testing.assert_series_equal(benchmark_price, original_benchmark)
+
+
+@pytest.mark.parametrize("raw_name", (None, "", 7, ("Benchmark", 1)))
+def test_resolver_explicit_name_preserves_nullable_series(
+    raw_name: Hashable | None,
+) -> None:
+    """Preserve nullable storage and metadata when an explicit valid name is available."""
+    prices = _asset_prices()
+    benchmark_price = _benchmark_price(name=raw_name, nullable=True)
+    original_prices = prices.copy(deep=True)
+    original_benchmark = benchmark_price.copy(deep=True)
+    expected_benchmark = pd.Series(
+        _BENCHMARK_PRICES,
+        index=_DATES,
+        name=_BENCHMARK_NAME,
+        dtype="Float64",
+    )
+    expected = pd.concat((expected_benchmark, prices), axis=1)
+
+    actual, resolved_name = _PERF_STATS.resolve_benchmark_source(
+        prices=prices,
+        benchmark=_BENCHMARK_NAME,
+        benchmark_price=benchmark_price,
+    )
+
+    assert resolved_name == _BENCHMARK_NAME
+    pd.testing.assert_frame_equal(actual, expected)
+    assert actual.index.name == "Date"
+    assert actual[_BENCHMARK_NAME].dtype == pd.Float64Dtype()
+    pd.testing.assert_frame_equal(prices, original_prices)
+    pd.testing.assert_series_equal(benchmark_price, original_benchmark)
+
+
+# =============================================================================
+# Selected-column cardinality
+# =============================================================================
+
+
+@pytest.mark.parametrize("source_mode", ("both", "name_only", "series_only"))
+def test_resolver_rejects_duplicate_selected_benchmark_columns(
+    source_mode: _SourceMode,
+) -> None:
+    """Reject two physical matches before choosing or replacing either column."""
+    prices = _benchmark_panel(duplicate=True)
+    original_prices = prices.copy(deep=True)
+    benchmark, benchmark_price = _duplicate_source(source_mode)
+    original_benchmark = None if benchmark_price is None else benchmark_price.copy(deep=True)
+
+    with pytest.raises(ValueError, match=f"^{_DUPLICATE_ERROR}$"):
+        _PERF_STATS.resolve_benchmark_source(
+            prices=prices,
+            benchmark=benchmark,
+            benchmark_price=benchmark_price,
+        )
+
+    pd.testing.assert_frame_equal(prices, original_prices)
+    if benchmark_price is not None and original_benchmark is not None:
+        pd.testing.assert_series_equal(benchmark_price, original_benchmark)
+
+
+@pytest.mark.parametrize("table_kind", ("regime", "risk_adjusted"))
+@pytest.mark.parametrize("source_mode", ("both", "name_only", "series_only"))
+def test_public_tables_propagate_duplicate_selected_column_error(
+    source_mode: _SourceMode,
+    table_kind: _TableKind,
+) -> None:
+    """Expose the same duplicate-label contract through both public entry points."""
+    benchmark, benchmark_price = _duplicate_source(source_mode)
+
+    with pytest.raises(ValueError, match=f"^{_DUPLICATE_ERROR}$"):
+        _compute_table(
+            table_kind,
+            prices=_benchmark_panel(duplicate=True),
+            benchmark=benchmark,
+            benchmark_price=benchmark_price,
+        )
+
+
+@pytest.mark.parametrize("table_kind", ("regime", "risk_adjusted"))
+def test_zero_and_one_selected_matches_preserve_valid_results(
+    table_kind: _TableKind,
+) -> None:
+    """Preserve Series augmentation at zero matches and panel authority at one match."""
+    expected_panel = _benchmark_panel()
+    expected = _compute_table(
+        table_kind,
+        prices=expected_panel,
+        benchmark=_BENCHMARK_NAME,
+    )
+    added = _compute_table(
+        table_kind,
+        prices=_asset_prices(),
+        benchmark=_BENCHMARK_NAME,
+        benchmark_price=_benchmark_price(name="Ignored"),
+    )
+    authoritative = _compute_table(
+        table_kind,
+        prices=expected_panel,
+        benchmark=_BENCHMARK_NAME,
+        benchmark_price=_benchmark_price(
+            name="Ignored",
+            values=_IGNORED_BENCHMARK_PRICES,
+        ),
+    )
+
+    pd.testing.assert_frame_equal(added, expected)
+    pd.testing.assert_frame_equal(authoritative, expected)
+
+
+def test_resolver_preserves_nullable_zero_and_one_match_modes() -> None:
+    """Preserve nullable augmentation and authoritative existing-column precedence."""
+    benchmark_price = _benchmark_price(name="Ignored", nullable=True)
+    expected_benchmark = pd.Series(
+        _BENCHMARK_PRICES,
+        index=_DATES,
+        name=_BENCHMARK_NAME,
+        dtype="Float64",
+    )
+    expected_added = pd.concat((expected_benchmark, _asset_prices()), axis=1)
+
+    added, added_name = _PERF_STATS.resolve_benchmark_source(
+        prices=_asset_prices(),
+        benchmark=_BENCHMARK_NAME,
+        benchmark_price=benchmark_price,
+    )
+    existing = _benchmark_panel()
+    authoritative, authoritative_name = _PERF_STATS.resolve_benchmark_source(
+        prices=existing,
+        benchmark=_BENCHMARK_NAME,
+        benchmark_price=_benchmark_price(
+            name="Ignored",
+            nullable=True,
+            values=_IGNORED_BENCHMARK_PRICES,
+        ),
+    )
+
+    assert added_name == authoritative_name == _BENCHMARK_NAME
+    pd.testing.assert_frame_equal(added, expected_added)
+    assert authoritative is existing


### PR DESCRIPTION
## What changed

Validate the resolved benchmark label once in the shared source resolver so benchmark-aware performance and regime tables reject missing, empty, non-string, or duplicate selected labels before numerical work.

## Behavior

A valid explicit benchmark name remains authoritative over irrelevant Series-name metadata. An inferred standalone-Series name must be a non-empty string, and the resolved label may identify at most one existing price column. Zero matches still add the supplied aligned Series, while one match keeps the existing in-panel data authoritative. Public signatures, exports, valid numerical results, and caller ownership are unchanged.

## Regression evidence

Against unchanged production code, the finalized matrix reported `21 failed, 15 passed`: invalid inferred names leaked downstream `KeyError` exceptions, and duplicate benchmark columns leaked scalar-conversion or classifier dimensionality errors. Independently assembled benchmark-first panels define the valid zero- and one-match results. After the shared-boundary correction, all `41` PR 74 cases pass, and the combined PR 74, PR 65, and PR 73 interaction set passes all `58` cases.

## Verification

- PR 74 plus PR 65 and PR 73 focused interactions: `58 passed`.
- Complete affected perfstats suite: `809 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2,705 passed, 18 established warnings`.
- Changed-line Ruff and differential Pyright: zero unapproved diagnostics.
- New-file formatting, existing-file baseline review, public API synchronization, dependency integrity, and whitespace checks: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/perf_stats.py`, `src/qis/perfstats/regime_classifier.py`, and `src/qis/perfstats/tests/benchmark_source_validation_test.py`.

Out of scope: Duplicate non-benchmark asset-label policy, benchmark-Series calendar-index validation, nullable public numerical calculations, classifier-policy validation, signatures, exports, dependencies, and unrelated cleanup.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.