### PR TITLE
fix: validate volatility sample types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Honored caller-supplied regime classifiers in the benchmark-regime performance-table wrapper
   instead of silently rebuilding the default quantile policy.
+- Restricted `estimate_vol()` to its documented pandas and NumPy containers with real numeric
+  dtypes, rejected lossy or categorical coercions, and corrected its scalar return annotation.
 
 ## [5.22.2] - 2026-09-05
 

--- a/src/qis/perfstats/returns.py
+++ b/src/qis/perfstats/returns.py
@@ -486,16 +486,19 @@ def compute_pa_excess_compounded_returns(returns: Union[pd.Series, pd.DataFrame]
     return compounded_return_pa
 
 
-def estimate_vol(sampled_returns: Union[pd.DataFrame, pd.Series, np.ndarray]) -> np.ndarray:
+def estimate_vol(sampled_returns: Union[pd.DataFrame, pd.Series, np.ndarray]
+                 ) -> Union[np.ndarray, np.float64]:
     """Estimate volatility from return samples.
 
     For columns with 20 or more finite observations, uses standard deviation with ddof=1.
     For smaller finite samples, uses RMS to avoid mean adjustment bias.
 
     Args:
-        sampled_returns: Return time series. NumPy arrays must have shape `(observations,)` or
-            `(observations, columns)`. Each column selects its estimator from its own finite
-            observation count; missing rows do not count toward the threshold
+        sampled_returns: Real numeric return time series supplied as a pandas Series, pandas
+            DataFrame, or NumPy array. Nullable integer and floating pandas dtypes are supported.
+            NumPy arrays must have shape `(observations,)` or `(observations, columns)`. Each
+            column selects its estimator from its own finite observation count; missing rows do
+            not count toward the threshold
 
     Returns:
         Volatility estimate for a one-dimensional input or one estimate per two-dimensional input
@@ -503,16 +506,35 @@ def estimate_vol(sampled_returns: Union[pd.DataFrame, pd.Series, np.ndarray]) ->
         selected estimator
 
     Raises:
+        TypeError: If the input is not a supported container or contains a non-real-numeric dtype
         ValueError: If a NumPy array is not one- or two-dimensional
     """
+    # Keep runtime acceptance aligned with the three public container families.
+    if not isinstance(sampled_returns, (pd.Series, pd.DataFrame, np.ndarray)):
+        raise TypeError(
+            "sampled_returns must be a pandas Series, pandas DataFrame, or NumPy array"
+        )
+
     if isinstance(sampled_returns, np.ndarray) and sampled_returns.ndim not in (1, 2):
         # Higher ranks have no unambiguous observation/column mapping for this estimator.
         raise ValueError("sampled_returns must be a 1- or 2-dimensional NumPy array")
 
+    if isinstance(sampled_returns, pd.DataFrame):
+        sampled_dtypes = sampled_returns.dtypes
+    else:
+        sampled_dtypes = (sampled_returns.dtype,)
+    # Validate before float coercion can reinterpret booleans, text, dates, or complex values.
+    if any(
+        not pd.api.types.is_any_real_numeric_dtype(dtype) for dtype in sampled_dtypes
+    ):
+        raise TypeError(
+            "sampled_returns must contain only real numeric values or missing values"
+        )
+
     if isinstance(sampled_returns, (pd.Series, pd.DataFrame)):
         sampled_values = sampled_returns.to_numpy(dtype=float, na_value=np.nan)
     else:
-        sampled_values = np.asarray(sampled_returns, dtype=float)
+        sampled_values = sampled_returns.astype(float, copy=False)
 
     def estimate_column(values: np.ndarray) -> np.float64:
         """Apply the finite-sample estimator to one return column."""

--- a/src/qis/perfstats/tests/estimate_vol_input_type_test.py
+++ b/src/qis/perfstats/tests/estimate_vol_input_type_test.py
@@ -1,0 +1,274 @@
+"""Regression coverage for ``estimate_vol`` container and numeric-type boundaries.
+
+Return volatility is defined for real numeric observations held in the three public container
+families: pandas Series, pandas DataFrames, and one- or two-dimensional NumPy arrays. Permissive
+float coercion must not turn undeclared array-like containers, categorical booleans, text,
+datetimes, or complex values into apparently valid return samples.
+
+The accepted fixtures use the Pythagorean pairs ``[3, 4]`` and ``[5, 12]``. Their independently
+calculated small-sample RMS values are ``5 / sqrt(2)`` and ``13 / sqrt(2)``. Tests cover integer,
+floating, and nullable pandas storage; scalar-versus-vector return types; a mixed valid panel; a
+mixed invalid panel; exact domain errors; warning behavior; and caller ownership.
+"""
+
+import warnings
+from typing import cast
+
+import numpy as np
+import pandas as pd
+import pytest
+
+# qis
+from qis.perfstats.returns import estimate_vol
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent expectations
+# =============================================================================
+
+_CONTAINER_ERROR = "sampled_returns must be a pandas Series, pandas DataFrame, or NumPy array"
+_FIRST_COLUMN = "Three Four"
+_SECOND_COLUMN = "Five Twelve"
+_TYPE_ERROR = "sampled_returns must contain only real numeric values or missing values"
+_EXPECTED_FIRST_RMS = 5.0 / np.sqrt(2.0)
+_EXPECTED_SECOND_RMS = 13.0 / np.sqrt(2.0)
+
+
+def _call_with_untyped_input(sampled_returns: object) -> object:
+    """Call the public function with an intentionally unsupported container.
+
+    Args:
+        sampled_returns: Candidate object outside the statically declared container union.
+
+    Returns:
+        Result produced if runtime validation fails to reject the object.
+    """
+    supported_input = cast(pd.Series | pd.DataFrame | np.ndarray, sampled_returns)
+    return estimate_vol(supported_input)
+
+
+def _mixed_numeric_frame(*, nullable: bool) -> pd.DataFrame:
+    """Create equivalent ordinary or nullable real-numeric columns.
+
+    Args:
+        nullable: Whether to use pandas nullable integer and floating storage.
+
+    Returns:
+        Two-column panel containing the independent RMS fixtures and a missing row.
+    """
+    if nullable:
+        return pd.DataFrame(
+            {
+                _FIRST_COLUMN: pd.Series((3, pd.NA, 4), dtype=pd.Int64Dtype()),
+                _SECOND_COLUMN: pd.Series((5.0, pd.NA, 12.0), dtype=pd.Float64Dtype()),
+            }
+        )
+    return pd.DataFrame(
+        {
+            _FIRST_COLUMN: (3.0, np.nan, 4.0),
+            _SECOND_COLUMN: (5.0, np.nan, 12.0),
+        }
+    )
+
+
+def _assert_input_unchanged(
+    actual: pd.Series | pd.DataFrame | np.ndarray,
+    expected: pd.Series | pd.DataFrame | np.ndarray,
+) -> None:
+    """Assert caller ownership with the comparison for the concrete container.
+
+    Args:
+        actual: Input after calling ``estimate_vol``.
+        expected: Independent snapshot taken before the call.
+    """
+    if isinstance(actual, np.ndarray):
+        assert isinstance(expected, np.ndarray)
+        np.testing.assert_array_equal(actual, expected)
+    elif isinstance(actual, pd.Series):
+        assert isinstance(expected, pd.Series)
+        pd.testing.assert_series_equal(actual, expected)
+    else:
+        assert isinstance(actual, pd.DataFrame)
+        assert isinstance(expected, pd.DataFrame)
+        pd.testing.assert_frame_equal(actual, expected)
+
+
+# =============================================================================
+# Accepted real-numeric inputs
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "sampled_returns",
+    (
+        np.array((3, 4), dtype=np.int64),
+        np.array((3.0, np.nan, 4.0), dtype=np.float32),
+        np.array((3.0, np.nan, 4.0), dtype=np.float64),
+    ),
+    ids=("integer", "float32", "float64"),
+)
+def test_estimate_vol_accepts_real_numeric_numpy_dtypes(
+    sampled_returns: np.ndarray,
+) -> None:
+    """Preserve the one-dimensional RMS across real NumPy storage types.
+
+    Args:
+        sampled_returns: Integer or floating NumPy representation of ``[3, 4]``.
+    """
+    original_returns = sampled_returns.copy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = estimate_vol(sampled_returns)
+
+    assert isinstance(actual, np.float64)
+    np.testing.assert_allclose(actual, _EXPECTED_FIRST_RMS)
+    _assert_input_unchanged(sampled_returns, original_returns)
+
+
+@pytest.mark.parametrize(
+    "sampled_returns",
+    (
+        pd.Series((3, 4), dtype=np.int64, name=_FIRST_COLUMN),
+        pd.Series((3.0, np.nan, 4.0), dtype=np.float64, name=_FIRST_COLUMN),
+        pd.Series((3, pd.NA, 4), dtype=pd.Int64Dtype(), name=_FIRST_COLUMN),
+        pd.Series((3.0, pd.NA, 4.0), dtype=pd.Float64Dtype(), name=_FIRST_COLUMN),
+    ),
+    ids=("integer", "float64", "nullable-integer", "nullable-float64"),
+)
+def test_estimate_vol_accepts_real_numeric_pandas_series(
+    sampled_returns: pd.Series,
+) -> None:
+    """Preserve scalar RMS results across ordinary and nullable pandas storage.
+
+    Args:
+        sampled_returns: Real numeric Series representing the ``[3, 4]`` sample.
+    """
+    original_returns = sampled_returns.copy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = estimate_vol(sampled_returns)
+
+    assert isinstance(actual, np.float64)
+    np.testing.assert_allclose(actual, _EXPECTED_FIRST_RMS)
+    _assert_input_unchanged(sampled_returns, original_returns)
+
+
+@pytest.mark.parametrize("nullable", (False, True), ids=("ordinary", "nullable"))
+def test_estimate_vol_accepts_mixed_real_numeric_dataframe(nullable: bool) -> None:
+    """Calculate independent column RMS values in one mixed numeric panel.
+
+    Args:
+        nullable: Whether the columns use pandas nullable numeric storage.
+    """
+    sampled_returns = _mixed_numeric_frame(nullable=nullable)
+    original_returns = sampled_returns.copy()
+    expected = np.array((_EXPECTED_FIRST_RMS, _EXPECTED_SECOND_RMS))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = estimate_vol(sampled_returns)
+
+    assert isinstance(actual, np.ndarray)
+    assert actual.shape == expected.shape
+    np.testing.assert_allclose(actual, expected)
+    _assert_input_unchanged(sampled_returns, original_returns)
+
+
+# =============================================================================
+# Rejected containers and value types
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "sampled_returns",
+    (
+        [3.0, 4.0],
+        (3.0, 4.0),
+        pd.Index((3.0, 4.0)),
+        pd.array((3.0, pd.NA, 4.0), dtype=pd.Float64Dtype()),
+    ),
+    ids=("list", "tuple", "index", "extension-array"),
+)
+def test_estimate_vol_rejects_undeclared_array_like_containers(
+    sampled_returns: object,
+) -> None:
+    """Reject coercible objects outside the three declared container families.
+
+    Args:
+        sampled_returns: Undeclared array-like container accepted by float coercion.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(TypeError, match=f"^{_CONTAINER_ERROR}$"):
+            _call_with_untyped_input(sampled_returns)
+
+
+@pytest.mark.parametrize(
+    "sampled_returns",
+    (
+        np.array((True, False)),
+        np.array((1 + 2j, 3 + 4j)),
+        np.array(("3", "4")),
+        np.array((3.0, 4.0), dtype=object),
+        np.array(("2024-01-01", "2024-01-02"), dtype="datetime64[D]"),
+        np.array((1, 2), dtype="timedelta64[D]"),
+        pd.Series((True, pd.NA, False), dtype=pd.BooleanDtype()),
+        pd.Series((1 + 2j, 3 + 4j)),
+        pd.Series(("3", "4"), dtype=pd.StringDtype()),
+        pd.Series((3.0, 4.0), dtype=object),
+        pd.Series(("3", "4"), dtype="category"),
+        pd.Series(pd.to_datetime(("2024-01-01", "2024-01-02"))),
+        pd.Series(pd.to_timedelta((1, 2), unit="D")),
+    ),
+    ids=(
+        "numpy-boolean",
+        "numpy-complex",
+        "numpy-string",
+        "numpy-object",
+        "numpy-datetime",
+        "numpy-timedelta",
+        "pandas-nullable-boolean",
+        "pandas-complex",
+        "pandas-string",
+        "pandas-object",
+        "pandas-categorical",
+        "pandas-datetime",
+        "pandas-timedelta",
+    ),
+)
+def test_estimate_vol_rejects_non_real_numeric_dtypes(
+    sampled_returns: pd.Series | np.ndarray,
+) -> None:
+    """Reject categorical or lossy coercions before warnings or calculations.
+
+    Args:
+        sampled_returns: NumPy or pandas sample with an unsupported value type.
+    """
+    original_returns = sampled_returns.copy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(TypeError, match=f"^{_TYPE_ERROR}$"):
+            estimate_vol(sampled_returns)
+
+    _assert_input_unchanged(sampled_returns, original_returns)
+
+
+def test_estimate_vol_rejects_mixed_dataframe_with_non_numeric_column() -> None:
+    """Reject an entire mixed panel before reducing its valid numeric neighbor."""
+    sampled_returns = pd.DataFrame(
+        {
+            _FIRST_COLUMN: pd.Series((3.0, pd.NA, 4.0), dtype=pd.Float64Dtype()),
+            "Text": pd.Series(("5", pd.NA, "12"), dtype=pd.StringDtype()),
+        }
+    )
+    original_returns = sampled_returns.copy()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(TypeError, match=f"^{_TYPE_ERROR}$"):
+            estimate_vol(sampled_returns)
+
+    _assert_input_unchanged(sampled_returns, original_returns)


### PR DESCRIPTION
## What changed

Validate `estimate_vol()` containers and dtypes before float conversion, and correct its return annotation to include the established scalar `np.float64` result.

## Behavior

Accept only pandas Series, pandas DataFrames, and one- or two-dimensional NumPy arrays containing real integer or floating data, including nullable pandas numeric dtypes and missing observations. Reject undeclared containers and boolean, complex, text, object, categorical, datetime, or timedelta dtypes with deterministic `TypeError` messages before lossy coercion or warnings. Preserve the accepted estimator thresholds, numerical results, missing-data handling, input ownership, and scalar-versus-vector result shapes.

## Regression evidence

Against unchanged production code, all nine accepted real-numeric controls passed while the eighteen rejection cases failed: sixteen coercible inputs were accepted, and the NumPy and pandas complex cases emitted `ComplexWarning` instead of the defined domain error. Independent Pythagorean fixtures establish RMS results `5 / sqrt(2)` and `13 / sqrt(2)`. After the correction, all `27` focused PR 75 cases pass; the expanded PR 75, PR 66, PR 57, and missing-volatility interaction set passes all `68` cases.

## Verification

- Expanded focused interaction set: `68 passed`.
- Complete affected `perfstats` suite: `837 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2,734 passed, 18 established warnings`.
- Changed-line Ruff and differential strict Pyright: zero unapproved diagnostics.
- New-file formatting, existing-file baseline review, public API synchronization, dependency integrity, and whitespace checks: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/returns.py`, and `src/qis/perfstats/tests/estimate_vol_input_type_test.py`.

Out of scope: The separately recorded finite-scale arithmetic issue in PR 86, estimator formulas and thresholds, NumPy dimensionality semantics already established by PR 66, public exports, release numbering, dependencies, and unrelated cleanup.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.