### PR TITLE
fix: support nullable data in stacked-area plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalized nullable floating data before stacked-area rendering, representing missing values as
+  Matplotlib-compatible `NaN` while leaving stacked-bar behavior unchanged.
+
 ## [5.22.3] - 2026-09-06
 
 ### Added

--- a/src/qis/plots/stackplot.py
+++ b/src/qis/plots/stackplot.py
@@ -44,6 +44,16 @@ def plot_stack(df: pd.DataFrame,
                ax: plt.Subplot = None,
                **kwargs
                ) -> plt.Figure:
+    """Plot DataFrame columns as stacked areas or stacked bars.
+
+    Args:
+        df: Numeric values to stack. Nullable floating columns are supported; stacked-area
+            rendering represents their missing values as NumPy ``nan``.
+        use_bar_plot: Use pandas stacked bars instead of Matplotlib stacked areas.
+
+    Returns:
+        The created figure, or None when the caller supplies ``ax``.
+    """
 
     if ax is None:
         fig, ax = plt.subplots()
@@ -70,7 +80,9 @@ def plot_stack(df: pd.DataFrame,
                                  color=colors, width=1.0, alpha=1.0, edgecolor='none',
                                  linewidth=0, ax=ax)
     else:
-        ax.stackplot(re_indexed_data.index, re_indexed_data.T,
+        # Translate extension scalars only at the renderer boundary and leave caller data intact.
+        stack_values = re_indexed_data.to_numpy(dtype=float, na_value=np.nan).T
+        ax.stackplot(re_indexed_data.index, stack_values,
                      labels=re_indexed_data.columns, step=step, colors=colors,
                      baseline=baseline, edgecolor='none')
 

--- a/src/qis/plots/tests/stackplot_nullable_input_test.py
+++ b/src/qis/plots/tests/stackplot_nullable_input_test.py
@@ -1,0 +1,255 @@
+"""Regression coverage for nullable floating-point stack-plot inputs.
+
+Matplotlib's stacked-area renderer requires a real numeric array, while a transposed pandas
+``Float64`` frame exposes an object array containing Python floats and ``pd.NA``. The public
+``plot_stack()`` boundary must translate nullable missing values to ``np.nan`` before area
+rendering without changing values, labels, stacking geometry, legends, or caller-owned data.
+
+One ordered mixed panel combines ordinary and nullable finite data, ragged and all-missing
+histories, exact zeros, and signed values. Ordinary/nullable artist equivalence, the already
+working stacked-bar control, warnings-as-errors, forced canvas rendering, exact legend text,
+caller ownership, and figure cleanup protect the narrow renderer-normalization contract.
+"""
+
+import warnings
+from typing import Protocol, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.patches import Rectangle
+
+# qis
+import qis.plots.stackplot as stackplot_module
+from qis.plots.utils import LegendStats
+
+
+class _StackplotModuleProtocol(Protocol):
+    """Typed test-side interface for the public stacked plot."""
+
+    def plot_stack(
+        self,
+        df: pd.DataFrame,
+        *,
+        use_bar_plot: bool,
+        x_date_freq: None,
+        legend_stats: LegendStats,
+        var_format: str,
+        ax: Axes,
+    ) -> Figure | None:
+        """Render a stacked plot with deterministic legend labels.
+
+        Args:
+            df: Numeric panel to stack.
+            use_bar_plot: Use bars instead of stacked areas when true.
+            x_date_freq: Disabled date-axis relabeling for this focused contract.
+            legend_stats: Public legend mode under test.
+            var_format: Explicit numeric format used by the expected labels.
+            ax: Matplotlib axis receiving the plot.
+
+        Returns:
+            The created figure, or None when the caller supplies ``ax``.
+        """
+        raise NotImplementedError
+
+
+_STACKPLOT = cast(_StackplotModuleProtocol, stackplot_module)
+
+
+# =============================================================================
+# Shared deterministic fixtures and independent expectations
+# =============================================================================
+
+_ALL_MISSING = "All Missing"
+_ALL_ZERO = "All Zero"
+_DATES = pd.date_range("2024-01-31", periods=5, freq="ME")
+_FINITE = "Finite"
+_NULLABLE_FINITE = "Nullable Finite"
+_RAGGED = "Ragged"
+_SIGNED = "Signed"
+
+_EXPECTED_LEGEND = (
+    "Finite: first=0.100, last=0.500",
+    "Nullable Finite: first=0.500, last=0.100",
+    "Ragged: first=0.200, last=0.400",
+    "All Missing: first=nan, last=nan",
+    "All Zero: first=0.000, last=0.000",
+    "Signed: first=-0.200, last=0.200",
+)
+
+
+def _ordinary_mixed_panel() -> pd.DataFrame:
+    """Return the literal ordinary-float reference panel."""
+    return pd.DataFrame(
+        {
+            _FINITE: (0.1, 0.2, 0.3, 0.4, 0.5),
+            _NULLABLE_FINITE: (0.5, 0.4, 0.3, 0.2, 0.1),
+            _RAGGED: (np.nan, 0.2, 0.3, 0.4, np.nan),
+            _ALL_MISSING: (np.nan, np.nan, np.nan, np.nan, np.nan),
+            _ALL_ZERO: (0.0, 0.0, 0.0, 0.0, 0.0),
+            _SIGNED: (-0.2, 0.0, 0.3, -0.1, 0.2),
+        },
+        index=_DATES,
+        dtype=float,
+    )
+
+
+def _mixed_nullable_panel() -> pd.DataFrame:
+    """Return every material column state with both ordinary and nullable storage."""
+    values = _ordinary_mixed_panel()
+    nullable_columns = {
+        column: pd.Float64Dtype()
+        for column in (_NULLABLE_FINITE, _RAGGED, _ALL_MISSING, _ALL_ZERO, _SIGNED)
+    }
+    return values.astype(nullable_columns)
+
+
+def _render_stack(values: pd.DataFrame, *, use_bar_plot: bool) -> tuple[Figure, Axes]:
+    """Render one stack plot under warnings-as-errors while protecting caller ownership.
+
+    Args:
+        values: Numeric panel to render.
+        use_bar_plot: Use the stacked-bar path instead of the stacked-area path.
+
+    Returns:
+        Open figure and axis for exact artist inspection. The caller must close the figure.
+    """
+    original = values.copy()
+    figure, axis = plt.subplots()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            result = _STACKPLOT.plot_stack(
+                values,
+                use_bar_plot=use_bar_plot,
+                x_date_freq=None,
+                legend_stats=LegendStats.FIRST_LAST,
+                var_format="{:.3f}",
+                ax=axis,
+            )
+            figure.canvas.draw()
+        assert result is None
+        pd.testing.assert_frame_equal(values, original)
+    except Exception:
+        plt.close(figure)
+        raise
+    return figure, axis
+
+
+def _legend_text(axis: Axes) -> tuple[str, ...]:
+    """Return legend labels in their rendered column order.
+
+    Args:
+        axis: Rendered stack-plot axis.
+
+    Returns:
+        Exact legend text for every plotted column.
+    """
+    legend = axis.get_legend()
+    assert legend is not None
+    return tuple(text.get_text() for text in legend.get_texts())
+
+
+def _assert_area_paths_equal(actual: Axes, expected: Axes) -> None:
+    """Compare every stacked-area polygon without relying on raster output.
+
+    Args:
+        actual: Axis rendered from mixed nullable storage.
+        expected: Axis rendered from the ordinary-float reference.
+    """
+    assert len(actual.collections) == len(expected.collections)
+    for actual_collection, expected_collection in zip(actual.collections, expected.collections):
+        actual_paths = actual_collection.get_paths()
+        expected_paths = expected_collection.get_paths()
+        assert len(actual_paths) == len(expected_paths)
+        for actual_path, expected_path in zip(actual_paths, expected_paths):
+            actual_vertices = np.asarray(actual_path.vertices, dtype=float)
+            expected_vertices = np.asarray(expected_path.vertices, dtype=float)
+            np.testing.assert_allclose(
+                actual_vertices,
+                expected_vertices,
+                rtol=0.0,
+                atol=0.0,
+                equal_nan=True,
+            )
+
+
+def _assert_bar_geometry_equal(actual: Axes, expected: Axes) -> None:
+    """Compare every stacked-bar rectangle in drawing order.
+
+    Args:
+        actual: Axis rendered from mixed nullable storage.
+        expected: Axis rendered from the ordinary-float reference.
+    """
+    actual_rectangles = [patch for patch in actual.patches if isinstance(patch, Rectangle)]
+    expected_rectangles = [patch for patch in expected.patches if isinstance(patch, Rectangle)]
+    assert len(actual_rectangles) == len(actual.patches)
+    assert len(expected_rectangles) == len(expected.patches)
+    actual_geometry = np.asarray(
+        [
+            (patch.get_x(), patch.get_y(), patch.get_width(), patch.get_height())
+            for patch in actual_rectangles
+        ],
+        dtype=float,
+    )
+    expected_geometry = np.asarray(
+        [
+            (patch.get_x(), patch.get_y(), patch.get_width(), patch.get_height())
+            for patch in expected_rectangles
+        ],
+        dtype=float,
+    )
+    np.testing.assert_allclose(
+        actual_geometry,
+        expected_geometry,
+        rtol=0.0,
+        atol=0.0,
+        equal_nan=True,
+    )
+
+
+# =============================================================================
+# Nullable renderer-boundary regressions
+# =============================================================================
+
+
+def test_plot_stack_area_renders_finite_nullable_float64_panel() -> None:
+    """Render finite nullable values instead of passing an object array to Matplotlib."""
+    values = _ordinary_mixed_panel().loc[:, [_FINITE, _NULLABLE_FINITE]]
+    assert isinstance(values, pd.DataFrame)
+    values = values.astype(pd.Float64Dtype())
+    figure, axis = _render_stack(values, use_bar_plot=False)
+    try:
+        assert len(axis.collections) == 2
+        assert _legend_text(axis) == _EXPECTED_LEGEND[:2]
+    finally:
+        plt.close(figure)
+
+
+@pytest.mark.parametrize("use_bar_plot", (False, True), ids=("area", "bar"))
+def test_plot_stack_matches_ordinary_float_for_mixed_nullable_boundaries(
+    use_bar_plot: bool,
+) -> None:
+    """Preserve complete stacking geometry across every material nullable column state.
+
+    Args:
+        use_bar_plot: Exercise stacked-area normalization and the unchanged stacked-bar control.
+    """
+    actual_values = _mixed_nullable_panel()
+    expected_values = _ordinary_mixed_panel()
+    actual_figure, actual_axis = _render_stack(actual_values, use_bar_plot=use_bar_plot)
+    expected_figure, expected_axis = _render_stack(expected_values, use_bar_plot=use_bar_plot)
+
+    try:
+        if use_bar_plot:
+            _assert_bar_geometry_equal(actual_axis, expected_axis)
+        else:
+            _assert_area_paths_equal(actual_axis, expected_axis)
+        assert _legend_text(actual_axis) == _EXPECTED_LEGEND
+        assert _legend_text(actual_axis) == _legend_text(expected_axis)
+    finally:
+        plt.close(actual_figure)
+        plt.close(expected_figure)


### PR DESCRIPTION
## What changed

Normalize extension-backed floating values only at the Matplotlib stacked-area renderer boundary, translating nullable missing observations to NumPy `NaN`, and document the supported input behavior.

## Behavior

Stacked-area plots now accept ordinary, nullable, and mixed floating DataFrames, including ragged and all-missing columns, without passing object arrays containing `pd.NA` into Matplotlib. Ordinary floating geometry, column and legend order, baseline semantics, the existing stacked-bar path, and caller-owned inputs remain unchanged.

## Regression evidence

Before the production fix, the finalized module produced `2 failed, 1 passed`: both nullable stacked-area cases reached Matplotlib's `np.isfinite()` and raised `TypeError`, while the unchanged stacked-bar control passed. After the fix, independently constructed ordinary and nullable mixed panels have exactly matching area paths, bar geometry, and legend text across finite, ragged, all-missing, all-zero, and signed columns. The focused PR 80 and accepted PR 70 interaction set passes all `10` tests.

## Verification

- Focused PR 80 and accepted PR 70 interaction set: `10 passed`.
- Complete affected plotting suite: `416 passed`.
- Sphinx warning-as-error build: passed.
- Full repository suite: `2,770 passed, 18 established warnings`.
- Changed-line Ruff and differential strict Pyright/Pylance: zero PR-introduced diagnostics.
- New-file formatting, existing-file baseline review, public API synchronization, dependency integrity, and whitespace checks: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/plots/stackplot.py`, and `src/qis/plots/tests/stackplot_nullable_input_test.py`.

Out of scope: Stacked-bar annotation-option behavior and colors-list ownership recorded in PR 90, shared legend reductions, date mapping, stacking calculations, baseline policies, public signatures and exports, dependencies, and unrelated rendering paths.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.
