### PR TITLE
fix: honor benchmark drops in volatility regime tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Aligned the README, package keywords, citation keywords, and software BibTeX title around
   performance analytics, portfolio backtesting, risk analysis, and factsheet reporting.
 
+### Fixed
+
+- Honored `drop_benchmark` in volatility-regime performance tables while retaining the benchmark
+  in their component regime data.
+
 ## [5.22.4] - 2026-09-06
 
 ### Fixed

--- a/src/qis/perfstats/regime_classifier.py
+++ b/src/qis/perfstats/regime_classifier.py
@@ -824,6 +824,7 @@ class BenchmarkVolsQuantilesRegime(RegimeClassifier):
                                       prices: pd.DataFrame,
                                       benchmark: str,
                                       perf_params: PerfParams,
+                                      drop_benchmark: bool = False,
                                       **kwargs) -> Tuple[pd.DataFrame, Dict[RegimeData, pd.DataFrame]]:
         """Compute regime performance attribution table.
 
@@ -831,6 +832,7 @@ class BenchmarkVolsQuantilesRegime(RegimeClassifier):
             prices: Asset prices
             benchmark: Benchmark asset name
             perf_params: Performance parameters
+            drop_benchmark: Exclude benchmark from results
 
         Returns:
             Tuple of (performance table, regime data dictionary)
@@ -850,7 +852,9 @@ class BenchmarkVolsQuantilesRegime(RegimeClassifier):
             perf_params=perf_params,
             freq=self.freq,
             is_report_pa_returns=True,
-            is_use_benchmark_means=False
+            is_use_benchmark_means=False,
+            # Match the shared table contract while leaving component regime data intact.
+            drop_benchmark=drop_benchmark
         )
 
     def get_regime_colors(self) -> List[Tuple[float, ...]]:

--- a/src/qis/perfstats/tests/regime_volatility_drop_benchmark_test.py
+++ b/src/qis/perfstats/tests/regime_volatility_drop_benchmark_test.py
@@ -1,0 +1,147 @@
+"""Regression coverage for benchmark removal from volatility-regime tables.
+
+The volatility-quantile classifier shares the regime-table API with the return-quantile and
+positive/negative classifiers. Its ``drop_benchmark`` request must reach the shared table builder:
+only the final presentation table drops that row, while the component data, dynamically derived
+regime metadata, unavailable early windows, and caller-owned prices remain unchanged.
+
+The forwarding test separates delegation from numerical behavior and includes nullable pandas
+storage. The end-to-end test uses an ordinary ragged panel whose monthly volatility rises over
+time, giving four attainable regimes with independently fixed output-schema expectations.
+"""
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.perfstats.config import PerfParams, RegimeData
+from qis.perfstats.regime_classifier import (
+    BenchmarkVolsQuantilesRegime,
+    RegimeClassifier,
+)
+
+
+# =============================================================================
+# Shared deterministic fixtures
+# =============================================================================
+
+_ASSET = "Ragged Asset"
+_BENCHMARK = "Benchmark"
+_DATES = pd.bdate_range("2022-01-03", "2024-12-31")
+_EXPECTED_REGIME_COLORS = ("#a50026", "#fdbf6f", "#b7e075", "#006837")
+_EXPECTED_REGIME_IDS = (
+    "Benchmark vol<5%",
+    "Benchmark vol=(5%, 6%]",
+    "Benchmark vol=(6%, 8%]",
+    "Benchmark vol>8%",
+)
+_PERF_PARAMS = PerfParams(freq="ME")
+
+
+def _price_panel() -> pd.DataFrame:
+    """Create a ragged panel with four attainable monthly volatility regimes.
+
+    Returns:
+        Three years of benchmark and dependent-asset prices with unavailable early windows.
+    """
+    month_numbers = np.asarray(
+        [(date.year - 2022) * 12 + date.month for date in _DATES],
+        dtype=float,
+    )
+    amplitudes = 0.001 + 0.00015 * month_numbers
+    signs = np.where(np.arange(len(_DATES)) % 2 == 0, 1.0, -1.0)
+    benchmark_returns = amplitudes * signs
+    benchmark_prices = 100.0 * np.cumprod(1.0 + benchmark_returns)
+    asset_prices = 80.0 * np.cumprod(1.0 + 0.5 * benchmark_returns)
+    benchmark_prices[_DATES < pd.Timestamp("2022-04-01")] = np.nan
+    asset_prices[:40] = np.nan
+    return pd.DataFrame(
+        {_BENCHMARK: benchmark_prices, _ASSET: asset_prices},
+        index=_DATES,
+    )
+
+
+# =============================================================================
+# Delegation contract
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("requested_drop", "expected_drop"),
+    ((None, False), (False, False), (True, True)),
+)
+def test_volatility_regime_forwards_only_supported_table_options(
+    monkeypatch: pytest.MonkeyPatch,
+    requested_drop: bool | None,
+    expected_drop: bool,
+) -> None:
+    """Forward the explicit benchmark option while tolerating unrelated compatibility kwargs."""
+    calls: list[dict[str, Any]] = []
+    marker_table = pd.DataFrame({"marker": [1.0]}, index=[_ASSET])
+
+    def record_base_call(
+        _self: RegimeClassifier,
+        **kwargs: Any,
+    ) -> tuple[pd.DataFrame, dict[RegimeData, pd.DataFrame]]:
+        """Record one delegation to the shared table implementation."""
+        calls.append(kwargs)
+        return marker_table, {}
+
+    monkeypatch.setattr(
+        RegimeClassifier,
+        "compute_regimes_pa_perf_table",
+        record_base_call,
+    )
+    prices = _price_panel().astype(pd.Float64Dtype())
+    classifier = BenchmarkVolsQuantilesRegime(freq="ME", q=4)
+    call_kwargs: dict[str, Any] = {
+        "prices": prices,
+        "benchmark": _BENCHMARK,
+        "perf_params": _PERF_PARAMS,
+        "unused_option": "preserve tolerant compatibility behavior",
+    }
+    if requested_drop is not None:
+        call_kwargs["drop_benchmark"] = requested_drop
+
+    actual_table, actual_components = classifier.compute_regimes_pa_perf_table(**call_kwargs)
+
+    assert actual_table is marker_table
+    assert actual_components == {}
+    assert len(calls) == 1
+    assert calls[0]["prices"] is prices
+    assert calls[0]["benchmark"] == _BENCHMARK
+    assert calls[0]["perf_params"] is _PERF_PARAMS
+    assert calls[0]["freq"] == "ME"
+    assert calls[0]["drop_benchmark"] is expected_drop
+    assert "unused_option" not in calls[0]
+
+
+# =============================================================================
+# Public numerical and schema contract
+# =============================================================================
+
+
+@pytest.mark.parametrize("drop_benchmark", (False, True))
+def test_volatility_regime_drops_only_final_benchmark_row(drop_benchmark: bool) -> None:
+    """Drop the final benchmark row without changing components, metadata, or caller data."""
+    prices = _price_panel()
+    original_prices = prices.copy()
+    classifier = BenchmarkVolsQuantilesRegime(freq="ME", q=4)
+
+    table, regime_components = classifier.compute_regimes_pa_perf_table(
+        prices=prices,
+        benchmark=_BENCHMARK,
+        perf_params=_PERF_PARAMS,
+        drop_benchmark=drop_benchmark,
+    )
+
+    expected_index = [_ASSET] if drop_benchmark else [_BENCHMARK, _ASSET]
+    assert table.index.tolist() == expected_index
+    assert regime_components
+    for component in regime_components.values():
+        assert component.index.tolist() == [_BENCHMARK, _ASSET]
+    assert tuple(classifier.get_regime_ids()) == _EXPECTED_REGIME_IDS
+    assert tuple(classifier.get_regime_ids_colors().values()) == _EXPECTED_REGIME_COLORS
+    pd.testing.assert_frame_equal(prices, original_prices)


### PR DESCRIPTION
## What changed

Make the volatility-quantile regime classifier honor its existing `drop_benchmark` compatibility request by declaring, documenting, and forwarding the option to the shared regime-table builder.

## Behavior

Omitted and explicit-`False` calls retain the benchmark in the final table. An explicit `True` removes it only from the final presentation table while component regime data, dynamic IDs and colors, unavailable early windows, and caller-owned prices remain unchanged. Unrelated compatibility kwargs remain tolerated but unforwarded.

## Regression evidence

Before the fix, all three delegation cases omitted `drop_benchmark` and the public `True` case incorrectly retained `['Benchmark', 'Ragged Asset']`; four tests failed and one unchanged control passed. After the fix, the unchanged five-case regression passes. Its ordinary ragged panel fixes the expected final and component schemas independently, while the delegation matrix includes nullable storage and exact omitted, `False`, and `True` forwarding.

## Verification

- Focused volatility-regime regression: `5 passed`.
- Complete affected perfstats suite: `802 passed`.
- Sphinx warning-as-error build: passed.
- Complete repository suite: `2,785 passed, 18 established warnings`.
- Changed-line Ruff and differential strict Pyright/Pylance: zero PR-introduced diagnostics.
- New-file formatting, public API synchronization, dependency integrity, and whitespace checks: passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/regime_classifier.py`, and `src/qis/perfstats/tests/regime_volatility_drop_benchmark_test.py`.

Out of scope: Volatility estimation, quantile attainability, return-based classifiers, public exports, dependencies, arbitrary inherited table options, nullable ragged drawdown handling, and plot-level benchmark removal.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.
