### PR TITLE
fix: charge initial portfolio transaction costs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,8 @@ jobs:
         cd "$RUNNER_TEMP/qis-quickstart-check"
         "$RUNNER_TEMP/qis-wheel-venv/bin/python" \
           "$GITHUB_WORKSPACE/examples/getting_started/offline_quickstart.py" | tee quickstart.txt
-        grep -F "Final NAV: 120.1104" quickstart.txt
-        grep -F "TE=0.0299, IR=-0.2898" quickstart.txt
+        grep -F "Final NAV: 119.9866" quickstart.txt
+        grep -F "TE=0.0299, IR=-0.2899" quickstart.txt
 
     - name: Run the shipped suite against the installed wheel
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Charged and reported transaction costs when the opening portfolio target is traded, so initial
+  net NAV includes the cost of its executed instrument notionals.
+
 ## [5.22.5] - 2026-09-07
 
 ### Added

--- a/docs/audit/paper_numbers.json
+++ b/docs/audit/paper_numbers.json
@@ -1,6 +1,6 @@
 {
   "generated_by": "tools/paper_audit.py",
-  "measured_at_commit": "ceb68cfc3df38f9037bb0b0177dbd64f950186e1",
+  "measured_at_commit": "88284a06ff1559ad5c234e2ee97e4069f8a99ba4",
   "note": "every number paper.md quotes. Regenerate with python tools/paper_audit.py; the package paper-audit test fails when this file and the repository disagree.",
   "metrics": {
     "active_months": {
@@ -28,16 +28,16 @@
       "paper_phrase": null
     },
     "backtester_nonblank_lines": {
-      "value": 330,
+      "value": 339,
       "how": "nonblank lines of src/qis/portfolio/backtester.py",
       "live": true,
       "paper_phrase": null
     },
     "backtester_physical_lines": {
-      "value": 376,
+      "value": 385,
       "how": "physical lines of src/qis/portfolio/backtester.py",
       "live": true,
-      "paper_phrase": "backtester is 376 lines"
+      "paper_phrase": "backtester is 385 lines"
     },
     "capability_groups": {
       "value": 12,
@@ -46,13 +46,13 @@
       "paper_phrase": "12 capability groups"
     },
     "collected_tests": {
-      "value": 2786,
+      "value": 2793,
       "how": "pytest --collect-only -q, summed over files, core install",
       "live": false,
       "paper_phrase": null
     },
     "commits": {
-      "value": 597,
+      "value": 599,
       "how": "git rev-list --count HEAD",
       "live": false,
       "paper_phrase": null

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,7 +58,7 @@ the runnable file; it is not maintained as a second copy.
 The output records the 2,087-row business-day input, the 33-by-3 quarterly target schedule,
 final target and realised weights, a compact performance table, terminal NAV, and monthly
 tracking error/information ratio against the synthetic 60/40 benchmark. The current deterministic
-terminal NAV is `120.1104`; the repository test checks it and the benchmark-relative output.
+terminal NAV is `119.9866`; the repository test checks it and the benchmark-relative output.
 
 The weight schedule is point-in-time and live-universe-aware: `SEQ_EM` receives no allocation
 before it has a price. A target decided at *t* sets the units held over *[t, t+1]*. Between

--- a/paper.md
+++ b/paper.md
@@ -120,7 +120,7 @@ draw across several aligned panels, so a factor and a residual panel resample to
 
 We organise the package into 12 capability groups, which `src/qis/api.py` names.
 
-The backtester is 376 lines, and that follows from the design assumption rather than from
+The backtester is 385 lines, and that follows from the design assumption rather than from
 compression. Because a strategy is a rule for producing weights, the backtester holds no strategy
 logic: it converts target weights to units at each rebalancing, holds those units until the next
 one, applies costs, and returns the result. The recursion over dates is compiled with `numba`,

--- a/src/qis/portfolio/backtester.py
+++ b/src/qis/portfolio/backtester.py
@@ -16,6 +16,7 @@ Costs are proportional to traded notional, in fractional units:
 
     cost_t = c_t p_t |Δu_t|,   c in fractional units: c = 0.0010 is 10 bp
 
+The same formula applies when the opening target is traded on the first price date.
 ``rebalancing_costs`` takes a float applying everywhere, a Series indexed by ticker for a
 per-instrument cost constant in time, or a (t, n) DataFrame of dates x tickers, forward filled
 onto the price dates so a schedule stated on era boundaries applies from each boundary onward.
@@ -92,8 +93,8 @@ def backtest_model_portfolio(prices: pd.DataFrame,
             is per-instrument and constant in time; a DataFrame of dates x tickers is
             reindexed to ``prices`` dates taking the last schedule row at or before each
             date, so a cost schedule stated on era boundaries applies from each boundary
-            onward. Costs are read at the trade date; dates before the first schedule row
-            are costless
+            onward. Costs are read at every trade date, including an opening trade on the
+            first price date; dates before the first schedule row are costless
         weight_implementation_lag: observations of the price index between a weight being
             observed and traded, so 1 on a business-day panel trades the next business day. It
             selects the entry price for the units only and leaves prices and instrument returns
@@ -108,7 +109,7 @@ def backtest_model_portfolio(prices: pd.DataFrame,
 
     Returns:
         PortfolioData holding the nav, realised weights, units, instrument pnl and realised
-        costs
+        costs, including costs charged on an opening trade
 
     Raises:
         ValueError: if ``prices`` is not a pd.DataFrame, if a weight vector does not match the
@@ -294,10 +295,12 @@ def backtest_rebalanced_portfolio(prices: np.ndarray,
         initial_nav: starting nav
         constant_trade_level: size trades off this notional instead of current nav
         rebalancing_costs: proportional costs on traded notional, shape (t, n); the wrapper
-            broadcasts the scalar and per-instrument forms to this shape. None trades costless
+            broadcasts the scalar and per-instrument forms to this shape. Costs apply to an
+            opening trade as well as later trades; None trades costless
 
     Returns:
-        (nav, units, effective_weights, realized_costs)
+        (nav, units, effective_weights, realized_costs), with opening-trade costs recorded at
+        index zero
 
     Raises:
         ValueError: if ``prices`` and ``is_rebalancing`` disagree on length, or if ``weights``
@@ -331,12 +334,18 @@ def backtest_rebalanced_portfolio(prices: np.ndarray,
 
         current_units[np.isnan(current_units)] = 0
         current_cash_balance = initial_nav - np.nansum(current_units * current_prices)
+        if rebalancing_costs is not None:
+            # Opening targets are real trades; charge their executable absolute notionals.
+            realized_costs_t = rebalancing_costs[0, :] * current_prices * np.abs(current_units)
+            realized_costs_t[np.isnan(current_prices)] = 0.0
+            realized_costs[0, :] = realized_costs_t
+            current_cash_balance -= np.nansum(realized_costs_t)
         current_rebalancing_idx += 1
     else:
         current_units = np.zeros(prices.shape[1])
         current_cash_balance = initial_nav
     units[0, :] = current_units
-    nav[0] = np.nansum(current_units * current_prices) + current_cash_balance  # need to be adjusted when cost are present for is_rebalancing[0] = True
+    nav[0] = np.nansum(current_units * current_prices) + current_cash_balance
     cash_balances[0] = current_cash_balance
 
     # loop over t

--- a/src/qis/portfolio/tests/backtester_initial_costs_test.py
+++ b/src/qis/portfolio/tests/backtester_initial_costs_test.py
@@ -1,0 +1,136 @@
+"""
+Initial portfolio trades use the same absolute-traded-notional cost convention as later trades.
+
+The regression covers every documented cost container, an economically identical delayed trade,
+a cost schedule that starts after inception, and one mixed panel containing long, short, unpriced,
+and zero-weight instruments. These boundaries distinguish a real opening trade from cash or an
+unexecutable target without relying on the backtester's own accounting for expected values.
+"""
+
+from typing import Literal, TypeAlias
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import qis
+
+
+CostForm = Literal["scalar", "series", "frame"]
+CostInput: TypeAlias = float | pd.Series | pd.DataFrame
+
+INITIAL_NAV = 100.0
+COST_RATE = 0.01
+
+
+def _constant_prices(columns: list[str] | None = None) -> pd.DataFrame:
+    """Return a short constant-price panel so all NAV movement comes from trading costs."""
+    tickers = columns if columns is not None else ["A", "B"]
+    dates = pd.bdate_range("2025-01-02", periods=4)
+    return pd.DataFrame(100.0, index=dates, columns=tickers)
+
+
+def _dated_weights(prices: pd.DataFrame, values: list[float], position: int = 0) -> pd.DataFrame:
+    """Return one target row traded at the selected price observation."""
+    return pd.DataFrame([values], index=[prices.index[position]], columns=prices.columns)
+
+
+def _cost_input(prices: pd.DataFrame, cost_form: CostForm) -> CostInput:
+    """Express one constant rate through each documented public cost container."""
+    if cost_form == "scalar":
+        return COST_RATE
+    if cost_form == "series":
+        return pd.Series(COST_RATE, index=prices.columns)
+    return pd.DataFrame(COST_RATE, index=prices.index, columns=prices.columns)
+
+
+@pytest.mark.parametrize("cost_form", ["scalar", "series", "frame"])
+def test_backtest_model_portfolio_charges_initial_trade(cost_form: CostForm) -> None:
+    """Each cost container charges 1% of both 50-unit opening notionals."""
+    prices = _constant_prices()
+    weights = _dated_weights(prices, [0.5, 0.5])
+
+    portfolio = qis.backtest_model_portfolio(
+        prices=prices,
+        weights=weights,
+        initial_nav=INITIAL_NAV,
+        rebalancing_costs=_cost_input(prices, cost_form),
+    )
+
+    expected_units = np.array([0.5, 0.5])
+    expected_costs = np.array([0.5, 0.5])
+    expected_nav = INITIAL_NAV - float(expected_costs.sum())
+    np.testing.assert_allclose(portfolio.units.to_numpy(dtype=float)[0], expected_units)
+    np.testing.assert_allclose(portfolio.realized_costs.to_numpy(dtype=float)[0], expected_costs)
+    np.testing.assert_allclose(
+        portfolio.nav.to_numpy(dtype=float), np.full(len(prices.index), expected_nav)
+    )
+
+
+def test_backtest_model_portfolio_initial_trade_matches_delayed_trade() -> None:
+    """Moving the same opening trade one date later does not change its costs or post-trade NAV."""
+    prices = _constant_prices()
+    initial = qis.backtest_model_portfolio(
+        prices=prices,
+        weights=_dated_weights(prices, [0.5, 0.5]),
+        initial_nav=INITIAL_NAV,
+        rebalancing_costs=COST_RATE,
+    )
+    delayed = qis.backtest_model_portfolio(
+        prices=prices,
+        weights=_dated_weights(prices, [0.5, 0.5], position=1),
+        initial_nav=INITIAL_NAV,
+        rebalancing_costs=COST_RATE,
+    )
+
+    np.testing.assert_allclose(
+        initial.realized_costs.to_numpy(dtype=float)[0],
+        delayed.realized_costs.to_numpy(dtype=float)[1],
+    )
+    np.testing.assert_allclose(
+        initial.nav.to_numpy(dtype=float)[:-1], delayed.nav.to_numpy(dtype=float)[1:]
+    )
+    assert delayed.nav.to_numpy(dtype=float)[0] == INITIAL_NAV
+    np.testing.assert_array_equal(delayed.realized_costs.to_numpy(dtype=float)[0], np.zeros(2))
+
+
+def test_backtest_model_portfolio_preserves_costless_initial_schedule_gap() -> None:
+    """A future first cost row cannot charge an earlier opening trade."""
+    prices = _constant_prices()
+    costs = pd.DataFrame(COST_RATE, index=[prices.index[1]], columns=prices.columns)
+
+    portfolio = qis.backtest_model_portfolio(
+        prices=prices,
+        weights=_dated_weights(prices, [0.5, 0.5]),
+        initial_nav=INITIAL_NAV,
+        rebalancing_costs=costs,
+    )
+
+    np.testing.assert_allclose(portfolio.nav.to_numpy(dtype=float), INITIAL_NAV)
+    np.testing.assert_array_equal(portfolio.realized_costs.to_numpy(dtype=float), np.zeros((4, 2)))
+
+
+def test_backtest_model_portfolio_charges_only_executable_initial_legs() -> None:
+    """Long and short legs pay costs while unavailable and zero-weight legs remain costless."""
+    prices = _constant_prices(["long", "short", "unpriced", "zero_unpriced"])
+    prices.iloc[0, 2:] = np.nan
+    weights = _dated_weights(prices, [0.5, -0.2, 0.7, 0.0])
+    costs = pd.DataFrame(
+        [[0.01, 0.02, 0.03, 0.04]] * len(prices.index),
+        index=prices.index,
+        columns=prices.columns,
+    )
+
+    with pytest.warns(UserWarning, match="stays in the cash balance"):
+        portfolio = qis.backtest_model_portfolio(
+            prices=prices,
+            weights=weights,
+            initial_nav=INITIAL_NAV,
+            rebalancing_costs=costs,
+        )
+
+    expected_costs = np.array([0.5, 0.4, 0.0, 0.0])
+    np.testing.assert_allclose(portfolio.realized_costs.to_numpy(dtype=float)[0], expected_costs)
+    assert portfolio.nav.to_numpy(dtype=float)[0] == pytest.approx(
+        INITIAL_NAV - float(expected_costs.sum())
+    )

--- a/src/qis/tests/test_quickstart.py
+++ b/src/qis/tests/test_quickstart.py
@@ -115,7 +115,7 @@ def test_quickstart_executes_and_reports_sane_results(
     portfolio_data = namespace['portfolio_data']
     nav = portfolio_data.get_portfolio_nav()
     assert bool(nav.notna().all()), 'quickstart nav contains nans'
-    assert float(nav.iloc[-1]) == pytest.approx(120.1104, abs=0.00005)
+    assert float(nav.iloc[-1]) == pytest.approx(119.9866, abs=0.00005)
 
     schedule = namespace['weight_schedule']
     prices = namespace['prices']
@@ -125,6 +125,6 @@ def test_quickstart_executes_and_reports_sane_results(
 
     output = capsys.readouterr().out
     assert 'Prices: business-day frequency, shape=(2087, 3)' in output
-    assert 'Final NAV: 120.1104' in output
-    assert 'TE=0.0299, IR=-0.2898' in output
+    assert 'Final NAV: 119.9866' in output
+    assert 'TE=0.0299, IR=-0.2899' in output
     assert 'no file is written here' in output


### PR DESCRIPTION
## What changed

Charge and report transaction costs when the initial dated target is traded.

A two-asset, 50/50 initial allocation with prices of 100, initial NAV 100, and a 1% cost reports NAV 100 and zero realized costs at inception; the traded notional is 100, so independently expected total cost is 1 and net NAV is 99.

## Behavior

Net NAV equals marked positions plus cash after every trade, including inception, and `realized_costs` records every charged instrument-level cost.

## Regression evidence

The accepted implementation skips the cost branch while building initial units. Branch-level public-API probes reproduced NAV 100 and zero realized costs instead of NAV 99 and costs `[0.5, 0.5]` for scalar, ticker-Series, and date-by-ticker DataFrame costs. Moving the identical trade from the first date to the second produced NAV 99 and `[0.5, 0.5]`, isolating the defect to inception rather than the cost formula or input normalization. A no-initial-trade control remained at NAV 100 with zero units and costs.

## Verification

- Focused regression: The new module failed before the fix with `5 failed, 1 passed`; after the fix, the new and existing transaction-cost modules pass together (`11 passed`).
- Complete affected subsystem: Portfolio suite passed (`50 passed`) with eight existing third-party Seaborn/Matplotlib deprecation warnings.
- Final full suite: `2793 passed` with 18 existing warnings after the integration refinement.
- Static, documentation, API, dependency, or build checks: Changed-line Ruff and strict Pyright report zero new diagnostics; `format-new` leaves the new module formatted; the existing backtester retains only baseline format debt; `git diff --check`, docstring/core-API tests, the 430-name public-API check, and `pip check` pass. The helper's additional perfstats suite also passed (`802 passed`).

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/portfolio/backtester.py`, one focused portfolio test, `src/qis/tests/test_quickstart.py`, `docs/quickstart.md`, `paper.md`, and the script-generated `docs/audit/paper_numbers.json` record.

Out of scope: Fee accrual, subsequent-rebalance formulas, turnover definitions, cost-rate input redesign, and nullable cost-container conversion. The last is retained in the separate nullable compatibility audit after a finite `Float64` DataFrame reproduced a Numba `TypingError`.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.