### PR TITLE
fix: keep unsmoothing warmup causal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Charged and reported transaction costs when the opening portfolio target is traded, so initial
   net NAV includes the cost of its executed instrument notionals.
+- Kept rolling AR unsmoothing point-in-time by leaving unidentified warmup coefficients missing
+  and using the causal `InitType.X0` EWMA mean seed instead of the full sample.
 
 ## [5.22.5] - 2026-09-07
 

--- a/docs/private_asset_unsmoothing.md
+++ b/docs/private_asset_unsmoothing.md
@@ -26,9 +26,10 @@ the financing identity. Applying one does not correct the other.
 - **Frequency and annualisation:** use the appraisal frequency. Pass `periods_per_year=12` for
   monthly or `4` for quarterly de-levering unless the index permits reliable inference. A
   per-asset `freq` Series can keep monthly and quarterly sleeves on distinct grids.
-- **NaNs:** rolling unsmoothing has a warm-up and returns NaN where parameters are unidentified.
-  Static GLM returns NaN when all required lags are not observed. It does not pass an
-  uncorrectable observation through as if it had been unsmoothed.
+- **NaNs:** rolling unsmoothing has a warm-up and returns NaN where parameters are unidentified;
+  it never fills those dates from a coefficient estimated later. Static GLM returns NaN when all
+  required lags are not observed. It does not pass an uncorrectable observation through as if it
+  had been unsmoothed.
 
 ## Minimal offline example
 
@@ -75,9 +76,10 @@ Series on the monthly grid. It is a financing adjustment only; it contains no AR
 ## Rolling versus full-sample unsmoothing
 
 `compute_ar_unsmoothed_prices` and `unsmooth_returns_ar1_ewma` estimate rolling EWMA AR states.
-For a backtest, keep the default `MeanAdjType.EWMA` or another explicitly point-in-time mean.
-`MeanAdjType.INSAMPLE` subtracts the full-sample mean and is forward-looking, so it is suitable
-for a fixed-sample exhibit but not for a trading path.
+For a backtest, keep the default `MeanAdjType.EWMA`, which uses the point-in-time `InitType.X0`
+seed, or another explicitly point-in-time mean. Extending the input does not revise an existing
+rolling prefix. `MeanAdjType.INSAMPLE` subtracts the full-sample mean and is forward-looking, so
+it is suitable for a fixed-sample exhibit but not for a trading path.
 
 `unsmooth_returns_glm` fits one static AR(q) model to the whole sample. That is useful for an
 academic full-sample estimate or a supplied fixed `theta`, but an estimated GLM result is

--- a/src/qis/models/unsmoothing/ar_lag.py
+++ b/src/qis/models/unsmoothing/ar_lag.py
@@ -31,19 +31,18 @@ that decays within ~span periods as the EWMA forgets its initial condition).
 The production-relevant parity gate is therefore the current-date max|delta-beta|,
 not the full-history unsmoothed vol.
 
-Guards (defaults reproduce the previous behaviour exactly; ``check_denominator`` and
-``validate_inputs`` are on and inert under the default arguments, ``insufficient_data``
-is the opt-in one):
+Guards (``check_denominator`` and ``validate_inputs`` are on and inert under the default
+arguments, while ``insufficient_data`` is the opt-in one):
 
     ``insufficient_data``  Controls what happens when a column comes out entirely
         NaN. ``set_nans_for_warmup_period`` discards the first ``warmup_period``
         FINITE beta values and blanks the whole column when fewer remain, and the
         rolling tensor already masks its own first ``warmup_period`` rows, so the
-        returns frame needs ``2 * warmup_period + 2`` ROWS before any beta
-        survives (see ``min_obs_for_ar_unsmoothing``). Individual columns can also
-        degenerate when they are entirely NaN. The default ``NAN`` keeps the
-        historical silent all-NaN column. ``RAISE`` reports the offending columns.
-        ``PASSTHROUGH`` returns those columns unsmoothed.
+        returns frame needs ``2 * warmup_period + 3`` ROWS before a retained beta
+        can be applied one period later (see ``min_obs_for_ar_unsmoothing``).
+        Individual columns can also degenerate when they are entirely NaN. The default
+        ``NAN`` keeps the historical silent all-NaN column. ``RAISE`` reports the
+        offending columns. ``PASSTHROUGH`` returns those columns unsmoothed.
 
     ``check_denominator``  The inversion ``r_true = numerator / (1 - theta_sum)``
         requires ``theta_sum < 1``. Above that the denominator is non-positive
@@ -108,8 +107,8 @@ def min_obs_for_ar_unsmoothing(ar_order: int,
     The bound does not depend on ``ar_order``.
 
     This is a bound on the row count, not on a column's finite observation count. A column
-    with few finite returns inside a long frame still receives betas, because the tensor
-    backfills across the full index.
+    with few finite returns inside a long frame can still receive betas because the tensor
+    carries its recursive state forward across missing observations.
 
     Args:
         ar_order: Lag order q, must be >= 1.
@@ -128,7 +127,7 @@ def min_obs_for_ar_unsmoothing(ar_order: int,
         return TENSOR_DEFAULT_WARMUP + WARMUP_NONE_MIN_OBS_OFFSET
     if warmup_period < 0:
         raise ValueError(f"warmup_period must be >= 0 or None, got {warmup_period!r}")
-    return 2 * warmup_period + 2
+    return 2 * warmup_period + 3
 
 
 def _validate_ar_inputs(returns: pd.DataFrame,
@@ -327,9 +326,8 @@ def adjust_returns_with_ar(returns: pd.DataFrame,
     identical to clipping the single beta, so the bounds carry the same meaning
     as in the legacy AR(1) path.
 
-    With the default arguments the output is identical to the pre-guard
-    implementation, including the all-NaN column returned for a series shorter
-    than ``min_obs_for_ar_unsmoothing(ar_order, warmup_period)``.
+    Rolling mean adjustments use the point-in-time ``InitType.X0`` seed. Warmup coefficients
+    remain missing until they are identified and are applied only after the one-period lag.
 
     Args:
         returns: Observed period returns (rows = dates, columns = assets).
@@ -337,8 +335,10 @@ def adjust_returns_with_ar(returns: pd.DataFrame,
         span: EWMA span for the rolling beta. Default 20. A q >= 2 fit needs
             more effective observations than AR(1) — for quarterly data use
             ~40 (10y); for monthly ~24-36.
-        mean_adj_type: How to demean returns/lags before beta estimation.
-        warmup_period: Initial periods masked before the first valid beta.
+        mean_adj_type: How to demean returns/lags before beta estimation. EWMA uses the
+            point-in-time ``InitType.X0`` seed; INSAMPLE intentionally uses the full sample.
+        warmup_period: Initial periods masked before the first valid beta. Masked coefficients
+            remain missing rather than being filled from the first later estimate.
             Default 10; raise to ~16 for q >= 2 (the q x q estimate is noisier
             early). The underlying tensor also self-guards via its own warmup.
         max_value_for_beta: Upper bound on theta_sum (sum of betas). Bounds the
@@ -411,12 +411,12 @@ def adjust_returns_with_ar(returns: pd.DataFrame,
     cols = core.columns
     lags_raw = [core.shift(i + 1) for i in range(ar_order)]   # raw lags for the inversion
 
-    # Demean y and the lags consistently (single demean; the tensor does not demean).
+    # Use the point-in-time X0 seed so extending the sample cannot revise rolling means.
     if mean_adj_type != MeanAdjType.NONE:
         y_adj = compute_rolling_mean_adj(data=core, mean_adj_type=mean_adj_type,
-                                         span=span, init_type=InitType.MEAN)
+                                         span=span, init_type=InitType.X0)
         x_lags = [compute_rolling_mean_adj(data=lag, mean_adj_type=mean_adj_type,
-                                           span=span, init_type=InitType.MEAN)
+                                           span=span, init_type=InitType.X0)
                   for lag in lags_raw]
     else:
         y_adj, x_lags = core, lags_raw
@@ -458,8 +458,9 @@ def adjust_returns_with_ar(returns: pd.DataFrame,
         betas = [compute_ewm(data=b, span=span) for b in betas]
 
     if warmup_period is not None:
+        # Preserve unidentified dates; backward fill would import the first future estimate.
         betas = [set_nans_for_warmup_period(a=b, warmup_period=warmup_period)
-                 .reindex(index=core.index).bfill() for b in betas]
+                 .reindex(index=core.index) for b in betas]
 
     # Invert the AR(q) smoothing using lagged betas (align with lagged returns).
     betas_l = [b.shift(1) for b in betas]
@@ -522,8 +523,10 @@ def unsmooth_returns_ar1_ewma(returns: pd.DataFrame,
     Args:
         returns: observed returns of the appraisal-based series, one column per fund
         span: EWM span of the rolling AR(1) beta estimate
-        mean_adj_type: mean subtracted before estimating the beta; see :class:`MeanAdjType`
-        warmup_period: leading periods blanked while the EWM state converges
+        mean_adj_type: Mean subtracted before estimating the beta. EWMA uses the point-in-time
+            ``InitType.X0`` seed; see :class:`MeanAdjType`.
+        warmup_period: Leading periods blanked while the EWM state converges. Blank coefficients
+            remain missing rather than being filled from the first later estimate.
         max_value_for_beta: cap on the estimated beta. The inversion divides by ``1 - beta``, so
             the cap is what keeps the denominator away from zero; the default 0.75 holds it at or
             above 0.25
@@ -576,8 +579,10 @@ def compute_ar_unsmoothed_prices(prices: pd.DataFrame,
             assets, or a Series mapping asset name to frequency for
             mixed-frequency panels (e.g. monthly HFs alongside quarterly PE).
         span: EWMA span for the rolling beta.
-        mean_adj_type: Mean adjustment type for beta regression.
-        warmup_period: Initial warmup periods to mask.
+        mean_adj_type: Mean adjustment type for beta regression. EWMA uses the point-in-time
+            ``InitType.X0`` seed.
+        warmup_period: Initial warmup periods to mask. Masked coefficients remain missing rather
+            than being filled from the first later estimate.
         max_value_for_beta: Upper bound on theta_sum (default 0.75).
         min_value_for_beta: Lower bound on theta_sum (default -0.25). See
             ``adjust_returns_with_ar`` for the rationale behind clipping the sum.

--- a/src/qis/models/unsmoothing/tests/unsmoothing_warmup_causality_test.py
+++ b/src/qis/models/unsmoothing/tests/unsmoothing_warmup_causality_test.py
@@ -1,0 +1,266 @@
+"""Verify that rolling AR unsmoothing publishes only point-in-time estimates.
+
+The rolling estimator must not revise an existing prefix when later returns are appended. These
+tests separate backward-filled warmup coefficients from the full-sample mean seed, then exercise
+the causal availability floor, insufficient-data policies, mixed histories, and public wrappers.
+"""
+
+from collections.abc import Sequence
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.models.linear.ewm import MeanAdjType
+from qis.models.unsmoothing.ar_lag import (
+    InsufficientData,
+    adjust_returns_with_ar,
+    compute_ar_unsmoothed_prices,
+    min_obs_for_ar_unsmoothing,
+    unsmooth_returns_ar1_ewma,
+)
+
+
+Diagnostics = tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]
+
+
+def _seeded_ar_returns(num_periods: int = 50, seed: int = 20260907) -> pd.DataFrame:
+    """Return a deterministic monthly AR(1) sample with a drifting point-in-time state."""
+    rng = np.random.default_rng(seed)
+    innovations = rng.normal(loc=0.001, scale=0.025, size=num_periods)
+    values = np.empty(num_periods, dtype=float)
+    values[0] = innovations[0]
+    for position in range(1, num_periods):
+        values[position] = 0.55 * values[position - 1] + innovations[position]
+    index = pd.date_range("2018-01-31", periods=num_periods, freq="ME")
+    return pd.DataFrame({"asset": values}, index=index)
+
+
+def _adjust_with_diagnostics(
+    returns: pd.DataFrame,
+    *,
+    ar_order: int = 1,
+    mean_adj_type: MeanAdjType = MeanAdjType.EWMA,
+    warmup_period: int | None = 10,
+    apply_ewma_mean_smoother: bool = True,
+    non_negative: bool = False,
+    insufficient_data: InsufficientData = InsufficientData.NAN,
+) -> Diagnostics:
+    """Call the public engine while retaining its three diagnostic panels."""
+    result = adjust_returns_with_ar(
+        returns=returns,
+        ar_order=ar_order,
+        span=20,
+        mean_adj_type=mean_adj_type,
+        warmup_period=warmup_period,
+        apply_ewma_mean_smoother=apply_ewma_mean_smoother,
+        non_negative=non_negative,
+        return_diagnostics=True,
+        insufficient_data=insufficient_data,
+    )
+    assert isinstance(result, tuple)
+    return result
+
+
+def _assert_prefix_equal(shorter: Sequence[pd.DataFrame], longer: Sequence[pd.DataFrame]) -> None:
+    """Assert exact equality, including missing placement, over every diagnostic panel."""
+    for shorter_panel, longer_panel in zip(shorter, longer, strict=True):
+        pd.testing.assert_frame_equal(
+            shorter_panel,
+            longer_panel.head(len(shorter_panel)),
+            check_exact=True,
+        )
+
+
+def test_adjust_returns_with_ar_does_not_retroactively_fill_warmup_prefix() -> None:
+    """A newly identified beta must not be copied into an earlier unidentified prefix."""
+    returns = _seeded_ar_returns(num_periods=6)
+    shorter = _adjust_with_diagnostics(
+        returns.head(5),
+        mean_adj_type=MeanAdjType.NONE,
+        warmup_period=2,
+        apply_ewma_mean_smoother=False,
+    )
+    longer = _adjust_with_diagnostics(
+        returns,
+        mean_adj_type=MeanAdjType.NONE,
+        warmup_period=2,
+        apply_ewma_mean_smoother=False,
+    )
+
+    _assert_prefix_equal(shorter=shorter, longer=longer)
+    assert bool(shorter[0].isna().all().all())
+    assert bool(shorter[1].isna().all().all())
+
+
+@pytest.mark.parametrize("warmup_period", [10, None])
+@pytest.mark.parametrize("non_negative", [False, True])
+def test_adjust_returns_with_ar_ewma_mean_is_prefix_invariant(
+    warmup_period: int | None,
+    non_negative: bool,
+) -> None:
+    """The default point-in-time mean seed must not depend on the eventual sample end."""
+    returns = _seeded_ar_returns()
+    shorter = _adjust_with_diagnostics(
+        returns.head(40),
+        ar_order=2,
+        warmup_period=warmup_period,
+        non_negative=non_negative,
+    )
+    longer = _adjust_with_diagnostics(
+        returns,
+        ar_order=2,
+        warmup_period=warmup_period,
+        non_negative=non_negative,
+    )
+
+    _assert_prefix_equal(shorter=shorter, longer=longer)
+
+
+@pytest.mark.parametrize(
+    ("ar_order", "warmup_period", "expected_floor"),
+    [
+        (1, 0, 3),
+        (2, 0, 3),
+        (1, 1, 5),
+        (2, 1, 5),
+        (1, 3, 9),
+        (2, 3, 9),
+        (1, None, 23),
+        (2, None, 23),
+    ],
+)
+def test_min_obs_for_ar_unsmoothing_matches_causal_availability(
+    ar_order: int,
+    warmup_period: int | None,
+    expected_floor: int,
+) -> None:
+    """The documented row floor is the first length that yields one causal return."""
+    returns = _seeded_ar_returns(num_periods=expected_floor)
+
+    assert min_obs_for_ar_unsmoothing(ar_order, warmup_period) == expected_floor
+    below_floor = _adjust_with_diagnostics(
+        returns.head(-1),
+        ar_order=ar_order,
+        mean_adj_type=MeanAdjType.NONE,
+        warmup_period=warmup_period,
+        apply_ewma_mean_smoother=False,
+    )[0]
+    at_floor = _adjust_with_diagnostics(
+        returns,
+        ar_order=ar_order,
+        mean_adj_type=MeanAdjType.NONE,
+        warmup_period=warmup_period,
+        apply_ewma_mean_smoother=False,
+    )[0]
+
+    assert below_floor.dropna().shape[0] == 0
+    assert at_floor.dropna().shape[0] == 1
+
+
+def test_adjust_returns_with_ar_insufficient_data_uses_causal_floor() -> None:
+    """Raise and passthrough policies must use the same causal availability boundary."""
+    returns = _seeded_ar_returns(num_periods=4)
+
+    with pytest.raises(ValueError, match=r"needs 5 rows.*got 4"):
+        _adjust_with_diagnostics(
+            returns,
+            mean_adj_type=MeanAdjType.NONE,
+            warmup_period=1,
+            apply_ewma_mean_smoother=False,
+            insufficient_data=InsufficientData.RAISE,
+        )
+
+    unsmoothed, betas, r_squared = _adjust_with_diagnostics(
+        returns,
+        mean_adj_type=MeanAdjType.NONE,
+        warmup_period=1,
+        apply_ewma_mean_smoother=False,
+        insufficient_data=InsufficientData.PASSTHROUGH,
+    )
+    pd.testing.assert_frame_equal(unsmoothed, returns)
+    assert bool(betas.eq(0.0).all().all())
+    assert bool(r_squared.isna().all().all())
+
+
+def test_adjust_returns_with_ar_first_output_uses_prior_beta() -> None:
+    """The first available return must use the coefficient estimated one period earlier."""
+    returns = _seeded_ar_returns(num_periods=9)
+    unsmoothed, betas, _ = _adjust_with_diagnostics(
+        returns,
+        mean_adj_type=MeanAdjType.NONE,
+        warmup_period=3,
+        apply_ewma_mean_smoother=False,
+    )
+    position = 8
+    return_values = returns["asset"].to_numpy(dtype=float)
+    beta_values = betas["asset"].to_numpy(dtype=float)
+    expected = (
+        return_values[position] - beta_values[position - 1] * return_values[position - 1]
+    ) / (1.0 - beta_values[position - 1])
+
+    assert bool(unsmoothed.head(position).isna().all().all())
+    assert unsmoothed["asset"].to_numpy(dtype=float)[position] == pytest.approx(expected)
+
+
+def test_adjust_returns_with_ar_mixed_panel_remains_column_local_and_causal() -> None:
+    """Complete, ragged, and all-missing columns must coexist without cross-column leakage."""
+    complete = _seeded_ar_returns()
+    complete_values = complete.to_numpy(dtype=float).reshape(-1)
+    mixed = pd.DataFrame(
+        {
+            "complete": complete_values,
+            "ragged": np.where(np.arange(len(complete_values)) < 5, np.nan, complete_values),
+            "all_missing": np.full(len(complete_values), np.nan),
+        },
+        index=complete.index,
+    )
+    shorter = _adjust_with_diagnostics(mixed.head(40), ar_order=2)
+    longer = _adjust_with_diagnostics(mixed, ar_order=2)
+
+    _assert_prefix_equal(shorter=shorter, longer=longer)
+    assert list(shorter[0].columns) == ["complete", "ragged", "all_missing"]
+    assert bool(np.isnan(shorter[0].to_numpy(dtype=float)[:, 2]).all())
+
+
+def test_unsmooth_returns_ar1_ewma_preserves_prefix_through_public_shim() -> None:
+    """The AR(1) compatibility entry point must retain the engine's causal history."""
+    returns = _seeded_ar_returns()
+
+    shorter = unsmooth_returns_ar1_ewma(returns=returns.head(40))
+    longer = unsmooth_returns_ar1_ewma(returns=returns)
+
+    _assert_prefix_equal(shorter=shorter, longer=longer)
+
+
+@pytest.mark.parametrize("use_frequency_map", [False, True])
+def test_compute_ar_unsmoothed_prices_preserves_prefix_after_return_conversion(
+    use_frequency_map: bool,
+) -> None:
+    """Single- and per-asset frequency paths must preserve causal price reconstruction."""
+    returns = _seeded_ar_returns()
+    prices = 100.0 * (1.0 + returns).cumprod()
+    frequency: str | pd.Series = (
+        pd.Series({"asset": "ME"}, dtype="string") if use_frequency_map else "ME"
+    )
+
+    shorter = compute_ar_unsmoothed_prices(
+        prices=prices.head(40),
+        ar_order=1,
+        freq=frequency,
+        span=20,
+        mean_adj_type=MeanAdjType.EWMA,
+        warmup_period=3,
+        is_log_returns=False,
+    )
+    longer = compute_ar_unsmoothed_prices(
+        prices=prices,
+        ar_order=1,
+        freq=frequency,
+        span=20,
+        mean_adj_type=MeanAdjType.EWMA,
+        warmup_period=3,
+        is_log_returns=False,
+    )
+
+    _assert_prefix_equal(shorter=shorter, longer=longer)


### PR DESCRIPTION
## What changed

Make the rolling AR unsmoother point-in-time by retaining unidentified warmup rows as missing and using a causal seed for its default EWMA mean adjustment.

`adjust_returns_with_ar()` has two forward-looking initialization paths. It masks early beta estimates and then applies `.bfill()` over the full index; it also passes `InitType.MEAN` to the default EWMA demeaning path, whose seed is the full-sample mean. Extending a return history can therefore change both warmup-period results and later values that are already past the warmup floor.

## Behavior

A point-in-time rolling estimate at date t must depend only on observations through t; a result computed on a prefix must equal the same prefix of a longer run.

## Regression evidence

With AR(1), `warmup_period=2`, no demeaning, and no beta smoother, a five-row prefix returns no identified values; adding one observation retroactively makes four common-prefix returns finite by copying the first retained beta (`0.75`) backward. On a seeded monthly default-EWMA sample, the 30-row and 40-row common prefixes have 29 overlapping values, 28 of which change solely because the full-sample mean seed changes; the maximum return change is `0.003123582470313996` and the maximum beta change is `0.00980363139077306`.

## Verification

- Focused regression: The final 19-test module produced 17 failures and 2 controls passing against accepted source `1564cc2`; all 19 pass against the implementation.
- Complete affected subsystem: `pytest src/qis/models/` passes 83 tests.
- Final full suite: `2813 passed` with 18 known warnings.
- Static, documentation, API, dependency, or build checks: `format-new` preview and execution leave the new test unchanged; whole-file Ruff and global Pyright 1.1.411 pass the new module; changed-line Ruff/Pyright report zero attributable diagnostics (79 inherited or indirect); 802 perfstats controls and Sphinx `-W` pass; `sync_public_api.py --check` reports 430 current names; `pip check` reports no broken requirements; and `git diff --check` passes.

## Scope

Changed files are limited to `CHANGELOG.md`, `docs/private_asset_unsmoothing.md`, `src/qis/models/unsmoothing/ar_lag.py`, and one focused test.

Out of scope: Estimator selection, beta clipping, non-negative fitting, static GLM behavior, sibling `joint_lag.py` and `factor_lag.py` engines, the broken `MeanAdjType.INSAMPLE` DataFrame container path, the missing public export promised for `qis.min_obs_for_ar_unsmoothing`, and general EWMA refactoring. The three adjacent findings are retained as unnumbered future audits in the current-status table.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.