### PR TITLE
fix: align risk-adjusted return frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Raised the statsmodels minimum to 0.14.2 after the fresh Python 3.10 CI environment
   reproduced a NumPy 2.0 binary incompatibility in the previously allowed 0.14.0 wheel.
 
+- Aligned the p.a., log, excess, and Sortino ratio numerators in risk-adjusted performance tables
+  with the configured volatility-frequency boundaries while preserving visible return columns on
+  their native observed endpoints.
+
 ## [5.23.0] - 2026-09-07
 
 ### Fixed

--- a/docs/performance_analytics_and_sharpe.md
+++ b/docs/performance_analytics_and_sharpe.md
@@ -26,6 +26,9 @@ point-in-time safe for a backtest.
 - **Frequency and annualisation:** `freq_vol`, `freq_skewness`, `freq_drawdown`, and `freq_reg`
   are independent pandas frequencies. Annualised volatility multiplies the sampled standard
   deviation by the square root of the periods-per-year factor. The common monthly factor is 12.
+  Full-table return columns retain each asset's native observed endpoints, while p.a., log,
+  excess, and Sortino ratio numerators use the same complete `freq_vol` boundaries as their
+  volatility or downside-volatility denominators.
 - **NaNs:** table calculations respect heterogeneous start and end dates by evaluating each
   asset over its observed history. Price resampling and `qis.to_returns` forward-fill by default;
   direct callers can pass `ffill_nans=False` to `qis.to_returns` when a gap must remain missing.

--- a/docs/performance_analytics_and_sharpe.md
+++ b/docs/performance_analytics_and_sharpe.md
@@ -82,7 +82,7 @@ corresponding annualised volatility. The three conventions answer different ques
 
 | Convention | Numerator and denominator | Full-table columns | Appropriate use |
 |---|---|---|---|
-| P.a. (`SharpeConvention.PA`) | compound annual return divided by annualised volatility | `SHARPE_RF0`, `SHARPE_EXCESS` | investor and factsheet reporting where the numerator should reconcile to CAGR |
+| P.a. (`SharpeConvention.PA`) | compound annual return on complete `freq_vol` boundaries divided by annualised volatility | `SHARPE_RF0`, `SHARPE_EXCESS` | investor and factsheet reporting; the ratio-only CAGR matches the denominator support while visible return columns retain native endpoints |
 | Arithmetic (`SharpeConvention.ARITHMETIC`) | `sqrt(a) * mean(r) / std(r)` | `SHARPE_ARITH`, `SHARPE_ARITH_EXCESS` | inference and additive return decompositions |
 | Log (`SharpeConvention.LOG`) | `sqrt(a) * mean(l) / std(l)` | `SHARPE_LOG_AN`, `SHARPE_LOG_EXCESS` | time-additive analysis in log-return space |
 

--- a/src/qis/docs/reporting_frequencies.md
+++ b/src/qis/docs/reporting_frequencies.md
@@ -72,6 +72,10 @@ Every panel states the frequency its statistics were computed at, so native vers
 quantities are never conflated:
 
 - Cumulative performance is titled `... ({freq}-freq stats) ...` at the reporting frequency.
+- Static risk-adjusted tables keep their visible cumulative and annualised returns on native
+  observed endpoints. Their p.a., log, excess, and Sortino ratios sample numerator and denominator
+  on the same complete reporting-frequency boundaries, so an off-grid partial period does not
+  enter only one side of a ratio.
 - Running drawdowns and time-under-water are labelled with the **native** price-grid frequency
   (e.g. `(B-freq)`), because they are computed on the unresampled path. This is why the
   panel max-drawdown is frequency-invariant while the risk-table max-drawdown (computed on

--- a/src/qis/docs/sharpe_conventions.md
+++ b/src/qis/docs/sharpe_conventions.md
@@ -33,6 +33,14 @@ definitions are in institutional use:
     C_pa   = (P_M / P_0)^(1/T) - 1
     SR_pa  = C_pa / [sqrt(a) * std(r_m)]
 
+In a static risk-adjusted table, `P_0, ..., P_M` are the complete `freq_vol`
+boundaries used by the volatility denominator. The visible `PA_RETURN` and
+`PA_EXCESS_RETURN` columns retain the asset's native observed endpoints, so they
+need not equal the ratio-only CAGR numerators when the history starts or ends
+between reporting boundaries. They coincide when the input endpoints already
+fall on the `freq_vol` grid. The log and Sortino ratios follow the same
+same-support rule.
+
 Relations. `C_pa = exp(a * mean(l_m)) - 1`, so (P) is the exponential map of
 (L)'s numerator; empirically `SR_pa ≈ SR_log` to about 0.01 for the series in
 this project. The wedge to the arithmetic object is the volatility drag:
@@ -181,8 +189,11 @@ unchanged (Section 2), and Sepp (2020) provides the exact bridge.
 ## 7. Decision for qis: keep p.a. default, make the convention explicit
 
 qis is a reporting library in the BarclayHedge / PerformanceAnalytics
-tradition; its audience reconciles against tear sheets. Do not silently change
-the meaning of existing outputs. Instead:
+tradition; its audience reconciles against tear sheets. The p.a. convention
+remains the default, and corrections to its sampling support are documented
+explicitly. In particular, visible native-endpoint return columns remain
+unchanged while ratio-only numerators share the denominator's complete
+`freq_vol` boundaries.
 
 1. **`SharpeConvention` enum** (house style: enum-driven modes):
 
@@ -193,8 +204,8 @@ the meaning of existing outputs. Instead:
 
 2. **Touchpoints**: `PerfParams` gains `sharpe_convention: SharpeConvention =
    SharpeConvention.PA`; `PerfStat`-driven tables, `compute_ra_returns`, and
-   the factsheet layers read it. Default unchanged (PA), so all existing
-   factsheets are byte-stable.
+   the factsheet layers read it. The selected convention remains unchanged when
+   sampling support is normalised.
 3. **Self-documenting labels**: column and legend text carries the convention,
    e.g. `Sharpe (p.a.)` vs `Sharpe (arith)`, mirroring
    PerformanceAnalytics' explicit `geometric` flag and Morningstar Direct's
@@ -206,8 +217,9 @@ the meaning of existing outputs. Instead:
    regime bars tie to the headline CAGR.
 5. **Regression guard**: a unit test pinning one reference series to all three
    conventions with the identity `SR_pa ≈ SR_log` and the wedge
-   `SR_arith - SR_pa ≈ sigma/2` within tolerance, so future edits cannot
-   silently swap conventions.
+   `SR_arith - SR_pa ≈ sigma/2` within tolerance, plus an off-grid regression
+   that reconciles ratio-only numerators to the same boundaries as risk, so
+   future edits cannot silently swap conventions or sampling support.
 
 ## 8. Regime-conditional Sharpe ratios under each convention
 

--- a/src/qis/perfstats/perf_stats.py
+++ b/src/qis/perfstats/perf_stats.py
@@ -16,7 +16,9 @@ daily returns, not a rescaling of it. State the frequency wherever a number is q
 Sharpe is not one statistic. The table emits the conventions side by side as distinct columns,
 so the choice is made by picking a column rather than by a flag: ``SHARPE_RF0`` over p.a.
 return, ``SHARPE_EXCESS`` over p.a. excess return, ``SHARPE_LOG_AN`` and ``SHARPE_LOG_EXCESS``
-on annualised log returns, and the arithmetic pair from ``compute_sharpe_arithmetic``,
+on annualised log returns, with those ratio-only numerators sampled on the same complete
+``freq_vol`` boundaries as risk. Visible return columns retain native observed endpoints. The
+arithmetic pair is computed by ``compute_sharpe_arithmetic``,
 
     SR = sqrt(af) E[r] / sqrt(Var[r])
 

--- a/src/qis/perfstats/perf_stats.py
+++ b/src/qis/perfstats/perf_stats.py
@@ -34,7 +34,7 @@ statistics belong in ``qis/perfstats/regime_classifier.py``.
 import numpy as np
 import pandas as pd
 from scipy.stats import kurtosis, skew
-from typing import Callable, Union, Tuple, Optional, Literal
+from typing import Callable, Union, Tuple, Optional, Literal, cast
 
 # qis
 import qis.utils.regression as ols
@@ -269,9 +269,9 @@ def compute_performance_table(prices: Union[pd.DataFrame, pd.Series],
         TypeError: If ``prices`` is not a DataFrame.
 
     Note:
-        ``compute_ra_perf_table`` calls both this and ``compute_risk_table``, which
-        independently resample the same price data. This duplication is acceptable for
-        typical universes but could be optimised via a shared cache for large panels.
+        ``compute_ra_perf_table`` calls this once on the native history for its visible return
+        columns and once on ``freq_vol`` boundaries for ratio-only numerators. This duplication
+        keeps both public contracts explicit and could be cached for unusually large panels.
     """
     if not isinstance(prices, pd.DataFrame):
         raise TypeError(f"must be pd.Dataframe")
@@ -473,7 +473,9 @@ def compute_ra_perf_table(prices: Union[pd.DataFrame, pd.Series],
     Returns:
         DataFrame indexed by asset with all performance and risk columns merged.
         Overlapping columns (e.g. START_DATE, END_DATE) are present once, taken
-        from the performance table.
+        from the performance table. Visible return columns retain each asset's native observed
+        endpoints. The p.a., log, excess, and Sortino ratio numerators instead use complete
+        ``freq_vol`` boundaries so they describe the same sample as their risk denominators.
     """
     if perf_params is None:
         perf_params = PerfParams(freq=pd.infer_freq(prices.index))
@@ -482,21 +484,41 @@ def compute_ra_perf_table(prices: Union[pd.DataFrame, pd.Series],
         prices = prices.to_frame()
 
     perf_table = compute_performance_table(prices=prices, perf_params=perf_params)
-
-    # is we only need sharpe we only comptute vol without higher order risk
     risk_table = compute_risk_table(prices=prices, perf_params=perf_params)
+
+    # Pair ratio-only returns with the sampled risk boundaries while preserving the visible
+    # performance columns above on their native observed endpoints.
+    sampled_prices_vol = cast(
+        pd.DataFrame,
+        ret.prices_at_freq(prices=prices, freq=perf_params.freq_vol),
+    )
+    ratio_perf_table = compute_performance_table(
+        prices=sampled_prices_vol,
+        perf_params=perf_params,
+    )
 
     # ── Derive ratio metrics from vol ──
     vol = risk_table[PerfStat.VOL.to_str()]
-    perf_table[PerfStat.SHARPE_RF0.to_str()] = perf_table[PerfStat.PA_RETURN.to_str()] / vol
-    perf_table[PerfStat.SHARPE_EXCESS.to_str()] = perf_table[PerfStat.PA_EXCESS_RETURN.to_str()] / vol
-    perf_table[PerfStat.SHARPE_LOG_AN.to_str()] = perf_table[PerfStat.AN_LOG_RETURN.to_str()] / vol
-    perf_table[PerfStat.SHARPE_LOG_EXCESS.to_str()] = perf_table[PerfStat.AN_LOG_EXCESS_RETURN.to_str()] / vol
+    perf_table[PerfStat.SHARPE_RF0.to_str()] = (
+        ratio_perf_table[PerfStat.PA_RETURN.to_str()] / vol
+    )
+    perf_table[PerfStat.SHARPE_EXCESS.to_str()] = (
+        ratio_perf_table[PerfStat.PA_EXCESS_RETURN.to_str()] / vol
+    )
+    perf_table[PerfStat.SHARPE_LOG_AN.to_str()] = (
+        ratio_perf_table[PerfStat.AN_LOG_RETURN.to_str()] / vol
+    )
+    perf_table[PerfStat.SHARPE_LOG_EXCESS.to_str()] = (
+        ratio_perf_table[PerfStat.AN_LOG_EXCESS_RETURN.to_str()] / vol
+    )
     # SHARPE_ARITH / SHARPE_ARITH_EXCESS arrive via risk_table: they are computed in
     # compute_risk_table where numerator and denominator share the simple-return series
 
     if PerfStat.DOWNSIDE_VOL.to_str() in risk_table.columns:
-        perf_table[PerfStat.SORTINO_RATIO.to_str()] = perf_table[PerfStat.PA_EXCESS_RETURN.to_str()] / risk_table[PerfStat.DOWNSIDE_VOL.to_str()]
+        perf_table[PerfStat.SORTINO_RATIO.to_str()] = (
+            ratio_perf_table[PerfStat.PA_EXCESS_RETURN.to_str()]
+            / risk_table[PerfStat.DOWNSIDE_VOL.to_str()]
+        )
     if PerfStat.MAX_DD.to_str() in risk_table.columns:
         perf_table[PerfStat.CALMAR_RATIO.to_str()] = -1.0*perf_table[PerfStat.PA_EXCESS_RETURN.to_str()] / risk_table[PerfStat.MAX_DD.to_str()]
 

--- a/src/qis/perfstats/tests/ra_frequency_normalization_test.py
+++ b/src/qis/perfstats/tests/ra_frequency_normalization_test.py
@@ -1,0 +1,295 @@
+"""Regression coverage for risk-adjusted table frequency normalization.
+
+The p.a., log, excess, and Sortino ratios must pair return numerators with risk denominators
+derived from the same ``freq_vol`` price boundaries. Mixed complete and leading-ragged histories
+exercise column-local support, while off-grid endpoints distinguish ratio inputs from the native
+return columns that the public table continues to expose. Expected statistics are calculated here
+from explicit pandas and NumPy operations rather than through QIS performance helpers.
+"""
+
+from numbers import Real
+
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.typing import NDArray
+
+from qis.perfstats.config import PerfParams, PerfStat, ReturnTypes
+from qis.perfstats.perf_stats import compute_ra_perf_table
+
+
+_FREQUENCY = "QE"
+_ANNUALIZATION_FACTOR = 4.0
+_RETURN_DAYS_PER_YEAR = 365.25
+_FUNDING_DAYS_PER_YEAR = 365.0
+_ANNUAL_RATE = 0.04
+_TOLERANCE = 1e-12
+_ASSETS = ("Complete", "Leading ragged")
+
+_RATIO_STATS = (
+    PerfStat.SHARPE_RF0,
+    PerfStat.SHARPE_EXCESS,
+    PerfStat.SHARPE_LOG_AN,
+    PerfStat.SHARPE_LOG_EXCESS,
+    PerfStat.SORTINO_RATIO,
+)
+
+
+def _column_name(perf_stat: PerfStat) -> str:
+    """Return the full table label carried by a performance statistic."""
+    name = perf_stat.value.name
+    if not isinstance(name, str):
+        raise TypeError(f"expected a string column label, got {type(name)!r}")
+    return name
+
+
+def _stat(table: pd.DataFrame, asset: str, perf_stat: PerfStat) -> float:
+    """Extract one real-valued statistic from a performance table."""
+    value: object = table.loc[asset, _column_name(perf_stat)]
+    if isinstance(value, np.ndarray) and value.ndim == 0:
+        value = value.item()
+    if not isinstance(value, Real):
+        raise TypeError("expected a real statistic")
+    return float(value)
+
+
+def _series(frame: pd.DataFrame, column: str) -> pd.Series:
+    """Select one column while keeping the pandas shape explicit to static checkers."""
+    values: object = frame.loc[:, column]
+    if not isinstance(values, pd.Series):
+        raise TypeError("expected a Series column")
+    return values
+
+
+def _values(series: pd.Series) -> NDArray[np.float64]:
+    """Convert a real-valued Series to a typed NumPy vector for reference arithmetic."""
+    values: NDArray[np.float64] = series.to_numpy(dtype=np.float64)
+    return values
+
+
+def _elapsed_years(index: pd.DatetimeIndex) -> float:
+    """Convert explicit datetime boundaries to the return annualization basis."""
+    start: object = index[0]
+    end: object = index[-1]
+    if not isinstance(start, pd.Timestamp) or not isinstance(end, pd.Timestamp):
+        raise TypeError("expected timestamp boundaries")
+    return (end - start).days / _RETURN_DAYS_PER_YEAR
+
+
+def _price_panel() -> pd.DataFrame:
+    """Create complete and leading-ragged daily histories with off-grid endpoints."""
+    dates = pd.bdate_range("2021-01-15", "2025-05-16")
+    steps = np.arange(len(dates), dtype=float)
+    log_returns = 0.0002 + 0.006 * np.sin(steps / 17.0) - 0.004 * np.cos(steps / 31.0)
+    complete = 100.0 * np.exp(np.cumsum(log_returns))
+    # Put a material move after the last complete quarter so native and sampled support differ.
+    complete[-1] *= 1.12
+
+    ragged = 0.75 * complete
+    ragged[dates < pd.Timestamp("2021-08-17")] = np.nan
+    return pd.DataFrame({"Complete": complete, "Leading ragged": ragged}, index=dates)
+
+
+def _rates(prices: pd.DataFrame) -> pd.Series:
+    """Create a constant annual rate on a calendar-daily observation grid."""
+    price_index = pd.DatetimeIndex(prices.index)
+    dates = pd.date_range(price_index[0] - pd.Timedelta(days=1), price_index[-1])
+    return pd.Series(_ANNUAL_RATE, index=dates, name="risk_free_rate")
+
+
+def _sample_prices(prices: pd.DataFrame) -> pd.DataFrame:
+    """Sample complete quarters independently with pandas calendar operations."""
+    price_index = pd.DatetimeIndex(prices.index)
+    dates = pd.date_range(price_index[0], price_index[-1], freq=_FREQUENCY)
+    return prices.ffill().reindex(dates, method="ffill").ffill()
+
+
+def _annualized_compound_return(period_returns: pd.Series) -> float:
+    """Annualize compounded periodic returns over their explicit calendar boundaries."""
+    return_index = pd.DatetimeIndex(period_returns.index)
+    num_years = _elapsed_years(return_index)
+    # Row zero establishes the price boundary; it does not represent a realized return interval.
+    total_return = float(np.prod(1.0 + _values(period_returns)[1:]) - 1.0)
+    return float((1.0 + total_return) ** (1.0 / num_years) - 1.0)
+
+
+def _expected_statistics(
+    prices: pd.Series,
+    return_type: ReturnTypes,
+    with_rates: bool,
+) -> dict[PerfStat, float]:
+    """Calculate the ratio family from one canonical sampled price history."""
+    prices = prices.dropna()
+    price_index = pd.DatetimeIndex(prices.index)
+    price_values = _values(prices)
+    simple_values = np.full(price_values.shape, np.nan, dtype=np.float64)
+    simple_values[1:] = price_values[1:] / price_values[:-1] - 1.0
+    simple_returns = pd.Series(simple_values, index=price_index)
+    # return_type selects the risk denominator; CAGR numerators compound simple returns in
+    # both modes.
+    if return_type == ReturnTypes.LOG:
+        risk_values = np.diff(np.log(price_values))
+    else:
+        risk_values = simple_values[1:]
+
+    vol = float(np.sqrt(_ANNUALIZATION_FACTOR) * np.std(risk_values, ddof=1))
+    negative_values = risk_values[risk_values < 0.0]
+    downside_vol = float(np.sqrt(_ANNUALIZATION_FACTOR) * np.std(negative_values, ddof=1))
+
+    pa_return = _annualized_compound_return(simple_returns)
+    excess_values = np.empty(simple_values.shape, dtype=np.float64)
+    if with_rates:
+        elapsed_days: NDArray[np.float64] = (
+            price_index.to_series().diff().dt.days.to_numpy(dtype=np.float64)
+        )
+        excess_values[:] = simple_values - _ANNUAL_RATE * elapsed_days / _FUNDING_DAYS_PER_YEAR
+        excess_values[0] = 0.0
+        excess_returns = pd.Series(excess_values, index=price_index)
+        pa_excess_return = _annualized_compound_return(excess_returns)
+    else:
+        excess_returns = simple_returns
+        excess_values[:] = simple_values
+        pa_excess_return = pa_return
+
+    return {
+        PerfStat.SHARPE_RF0: pa_return / vol,
+        PerfStat.SHARPE_EXCESS: pa_excess_return / vol,
+        PerfStat.SHARPE_LOG_AN: float(np.log1p(pa_return) / vol),
+        PerfStat.SHARPE_LOG_EXCESS: float(np.log1p(pa_excess_return) / vol),
+        PerfStat.SORTINO_RATIO: pa_excess_return / downside_vol,
+        PerfStat.SHARPE_ARITH: float(
+            np.sqrt(_ANNUALIZATION_FACTOR)
+            * np.mean(simple_values[1:])
+            / np.std(simple_values[1:], ddof=1)
+        ),
+        PerfStat.SHARPE_ARITH_EXCESS: float(
+            np.sqrt(_ANNUALIZATION_FACTOR)
+            * np.mean(excess_values[1:])
+            / np.std(excess_values[1:], ddof=1)
+        ),
+    }
+
+
+@pytest.mark.parametrize("return_type", [ReturnTypes.LOG, ReturnTypes.RELATIVE])
+@pytest.mark.parametrize("with_rates", [False, True], ids=["zero-rate", "funded"])
+def test_compute_ra_perf_table_aligns_ratio_numerators_with_risk_boundaries(
+    return_type: ReturnTypes,
+    with_rates: bool,
+) -> None:
+    """Match ratio outputs to one sampled-support oracle for complete and ragged assets."""
+    prices = _price_panel()
+    sampled_prices = _sample_prices(prices)
+    rates = _rates(prices) if with_rates else None
+    perf_params = PerfParams(
+        freq_vol=_FREQUENCY,
+        return_type=return_type,
+        rates_data=rates,
+    )
+
+    actual = compute_ra_perf_table(prices=prices, perf_params=perf_params)
+    same_support = compute_ra_perf_table(prices=sampled_prices, perf_params=perf_params)
+
+    for asset in _ASSETS:
+        expected = _expected_statistics(_series(sampled_prices, asset), return_type, with_rates)
+        for perf_stat in _RATIO_STATS:
+            # Pin each ratio to a calculation independent of the QIS performance helpers.
+            np.testing.assert_allclose(
+                _stat(actual, asset, perf_stat),
+                expected[perf_stat],
+                rtol=0.0,
+                atol=_TOLERANCE,
+            )
+            # Equivalent pre-sampled input must converge to the same public result.
+            np.testing.assert_allclose(
+                _stat(actual, asset, perf_stat),
+                _stat(same_support, asset, perf_stat),
+                rtol=0.0,
+                atol=_TOLERANCE,
+            )
+
+
+def test_compute_ra_perf_table_preserves_native_returns_and_independent_ratios() -> None:
+    """Keep native return columns, arithmetic Sharpes, Calmar, and caller inputs unchanged."""
+    prices = _price_panel()
+    rates = _rates(prices)
+    prices_before = prices.copy(deep=True)
+    rates_before = rates.copy(deep=True)
+    sampled_prices = _sample_prices(prices)
+    perf_params = PerfParams(freq_vol=_FREQUENCY, rates_data=rates)
+
+    table = compute_ra_perf_table(prices=prices, perf_params=perf_params)
+
+    for asset in _ASSETS:
+        native = _series(prices, asset).dropna()
+        native_index = pd.DatetimeIndex(native.index)
+        num_years = _elapsed_years(native_index)
+        native_values = _values(native)
+        total_return = float(native_values[-1] / native_values[0] - 1.0)
+        pa_return = float((1.0 + total_return) ** (1.0 / num_years) - 1.0)
+        native_return_values = np.full(native_values.shape, np.nan, dtype=np.float64)
+        native_return_values[1:] = native_values[1:] / native_values[:-1] - 1.0
+        native_elapsed_days: NDArray[np.float64] = (
+            native_index.to_series().diff().dt.days.to_numpy(dtype=np.float64)
+        )
+        native_excess_values = (
+            native_return_values - _ANNUAL_RATE * native_elapsed_days / _FUNDING_DAYS_PER_YEAR
+        )
+        native_excess_values[0] = 0.0
+        native_excess_returns = pd.Series(native_excess_values, index=native_index)
+        pa_excess_return = _annualized_compound_return(native_excess_returns)
+        expected = _expected_statistics(
+            _series(sampled_prices, asset).dropna(), ReturnTypes.LOG, True
+        )
+
+        visible_returns: dict[PerfStat, float] = {
+            PerfStat.TOTAL_RETURN: total_return,
+            PerfStat.PA_RETURN: pa_return,
+            PerfStat.PA_EXCESS_RETURN: pa_excess_return,
+            PerfStat.AN_LOG_RETURN: float(np.log1p(pa_return)),
+            PerfStat.AN_LOG_EXCESS_RETURN: float(np.log1p(pa_excess_return)),
+        }
+        for perf_stat, expected_return in visible_returns.items():
+            np.testing.assert_allclose(
+                _stat(table, asset, perf_stat),
+                expected_return,
+                rtol=0.0,
+                atol=_TOLERANCE,
+            )
+        # Arithmetic Sharpe already owns a same-support return path and must not move with this fix.
+        for perf_stat in (PerfStat.SHARPE_ARITH, PerfStat.SHARPE_ARITH_EXCESS):
+            np.testing.assert_allclose(
+                _stat(table, asset, perf_stat),
+                expected[perf_stat],
+                rtol=0.0,
+                atol=_TOLERANCE,
+            )
+        # Calmar deliberately pairs native excess return with its separately sampled drawdown.
+        np.testing.assert_allclose(
+            _stat(table, asset, PerfStat.CALMAR_RATIO),
+            -_stat(table, asset, PerfStat.PA_EXCESS_RETURN) / _stat(table, asset, PerfStat.MAX_DD),
+            rtol=0.0,
+            atol=_TOLERANCE,
+        )
+
+    pd.testing.assert_frame_equal(prices, prices_before)
+    pd.testing.assert_series_equal(rates, rates_before)
+
+
+def test_compute_ra_perf_table_preserves_sampled_series_dataframe_parity() -> None:
+    """Converge for already-sampled input and retain equivalent public pandas shapes."""
+    sampled_series = _series(_sample_prices(_price_panel()), "Complete")
+    sampled = sampled_series.to_frame()
+    perf_params = PerfParams(freq_vol=_FREQUENCY)
+
+    frame_table = compute_ra_perf_table(prices=sampled, perf_params=perf_params)
+    series_table = compute_ra_perf_table(prices=sampled_series, perf_params=perf_params)
+
+    pd.testing.assert_frame_equal(series_table, frame_table)
+    expected = _expected_statistics(sampled_series, ReturnTypes.LOG, False)
+    for perf_stat in _RATIO_STATS:
+        np.testing.assert_allclose(
+            _stat(frame_table, "Complete", perf_stat),
+            expected[perf_stat],
+            rtol=0.0,
+            atol=_TOLERANCE,
+        )

--- a/src/qis/perfstats/tests/sharpe_conventions_test.py
+++ b/src/qis/perfstats/tests/sharpe_conventions_test.py
@@ -14,9 +14,13 @@ return conventions (with excess variants under rates_data):
     VOL                 = sqrt(a) * std(returns at freq_vol per return_type)
 
 sharpe conventions (with excess variants under rates_data):
-    SHARPE_RF0          = PA_RETURN / VOL                               (p.a., qis default)
-    SHARPE_LOG_AN       = AN_LOG_RETURN / VOL = sqrt(a)*mean(l)/std(l)  (log)
+    SHARPE_RF0          = C_pa(freq_vol boundaries) / VOL                (p.a., qis default)
+    SHARPE_LOG_AN       = log1p(C_pa(freq_vol boundaries)) / VOL         (log)
     SHARPE_ARITH        = sqrt(a) * mean(r_m) / std(r_m)                (arithmetic)
+
+Visible PA_RETURN and AN_LOG_RETURN use native endpoints and may differ from the ratio-only
+numerators when those endpoints are off-grid. This reference fixture is already month-end aligned;
+ra_frequency_normalization_test.py owns the off-grid contract.
 
 identities checked:
     SR_log ~= SR_pa (exp-map twins), SR_arith - SR_pa ~= sigma_ann / 2 (volatility drag),
@@ -161,7 +165,7 @@ def test_return_conventions() -> None:
 
 
 def test_sharpe_conventions() -> None:
-    """pin the three sharpe conventions and their cross-convention identities at rf=0"""
+    """Pin the three Sharpe conventions on an already month-end-aligned history."""
     prices, table, _, simple_returns, log_returns, _ = _compute_tables()
 
     sr_pa = float(table[PerfStat.SHARPE_RF0.to_str()].iloc[0])
@@ -179,7 +183,8 @@ def test_sharpe_conventions() -> None:
                           / log_returns.std(ddof=1).iloc[0])
     _check_value('SHARPE_LOG_AN', sr_log, sr_log_manual, atol=1e-10)
 
-    # 3. SHARPE_RF0 is the p.a. (compound) sharpe: C_pa / sigma_ann
+    # 3. SHARPE_RF0 is C_pa / sigma_ann on complete freq_vol boundaries. This fixture's
+    # native endpoints are those boundaries, so its visible PA_RETURN is the same C_pa.
     _check_value('SHARPE_RF0', sr_pa, float(table[PerfStat.PA_RETURN.to_str()].iloc[0]) / vol)
 
     # 4. rf=0: every excess sharpe collapses to its plain counterpart
@@ -242,7 +247,7 @@ def test_excess_sharpe_conventions() -> None:
 
     vol = stat(PerfStat.VOL)
 
-    # compound excess: SHARPE_EXCESS = PA_EXCESS_RETURN / vol, numerator below plain
+    # The aligned fixture's visible PA_EXCESS_RETURN is also the ratio-only sampled numerator.
     pa_excess_manual = _compute_expected_pa_excess_return(prices=prices)
     _check_value('PA_EXCESS_RETURN', stat(PerfStat.PA_EXCESS_RETURN), pa_excess_manual)
     if not stat(PerfStat.PA_EXCESS_RETURN) < stat(PerfStat.PA_RETURN):


### PR DESCRIPTION
## What changed

Derive the p.a., log, excess, and Sortino ratios from fully observed price boundaries sampled on `freq_vol`, without changing the public native-endpoint return columns or independently sampled drawdown ratios.

On a seeded daily 15%-volatility history ending mid-period, the current p.a. Sharpe was `0.632054` versus a monthly same-support oracle of `0.599969`, and `0.609396` versus a quarterly oracle of `0.668067`. A terminal-move fixture made the mechanism especially visible: quarterly p.a. Sharpe was `0.825296` while the numerator and denominator on the same quarterly boundaries gave `0.711749`.

## Behavior

`TOTAL_RETURN`, `PA_RETURN`, and the corresponding visible return columns retain their established native-endpoint contract and frequency invariance. Ratio-only p.a./log/excess numerators use the same complete `freq_vol` boundaries as `VOL` or `DOWNSIDE_VOL`. Preserve the configured `return_type` of the displayed `VOL`, the existing three Sharpe conventions, and lagged funding. Arithmetic Sharpe is already internally paired and must remain unchanged. Calmar and maximum-drawdown-to-volatility remain outside this normalization because QIS intentionally samples drawdown independently.

## Regression evidence

On current accepted code, the permanent mixed-panel regression failed all four log/simple × funded/unfunded off-grid cases. For the fully observed asset, zero-rate log-vol `SHARPE_RF0` was `0.369055` versus the independent same-boundary result `0.195989`; after the ratio-only correction, all six focused cases pass. The test also reconciles every affected ratio to an independently calculated sampled-support result and to an equivalent pre-sampled input.

## Verification

- Focused regression and downstream integrations: `19 passed`; this includes all six new cases, existing Sharpe and funding contracts, native-return frequency invariance, frequency-dependent risk, the executable quickstart, and a rendered risk-adjusted factsheet table.
- Complete affected subsystem: `808 passed` in `src/qis/perfstats/tests/`.
- Final full suite: `2874 passed, 18 warnings` in `src/qis/`; warnings are the established Seaborn/Matplotlib deprecations plus two existing leading-price warnings from the rendered factsheet control.
- Static, documentation, API, dependency, or build checks: zero new changed-line Ruff or differential Pyright diagnostics; the new test is Ruff-format-clean; the existing production file retains only accepted baseline format debt; Sphinx `-W` passed; `PUBLIC_API` remains at 430 names; `pip check` found no broken requirements; `git diff --check` passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/perf_stats.py`, relevant packaged convention documentation, and one focused perfstats test.

Out of scope: Choosing new Sharpe conventions, changing frequency defaults, or reorganizing the performance-table architecture.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.