### PR TITLE
fix: normalize dated portfolio weight order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Ordered dated portfolio-weight schedules chronologically before validation and execution,
+  preventing input row order from assigning targets to the wrong trade dates.
+
 - Raised the statsmodels minimum to 0.14.2 after the fresh Python 3.10 CI environment
   reproduced a NumPy 2.0 binary incompatibility in the previously allowed 0.14.0 wheel.
 

--- a/docs/audit/paper_numbers.json
+++ b/docs/audit/paper_numbers.json
@@ -1,6 +1,6 @@
 {
   "generated_by": "tools/paper_audit.py",
-  "measured_at_commit": "12019470523df7b0d6001b250c46eaf9755cf8dd",
+  "measured_at_commit": "532d5208e72d2d443a929446629fbe6f6e0752af",
   "note": "every number paper.md quotes. Regenerate with python tools/paper_audit.py; the package paper-audit test fails when this file and the repository disagree.",
   "metrics": {
     "active_months": {
@@ -28,16 +28,16 @@
       "paper_phrase": null
     },
     "backtester_nonblank_lines": {
-      "value": 339,
+      "value": 345,
       "how": "nonblank lines of src/qis/portfolio/backtester.py",
       "live": true,
       "paper_phrase": null
     },
     "backtester_physical_lines": {
-      "value": 385,
+      "value": 391,
       "how": "physical lines of src/qis/portfolio/backtester.py",
       "live": true,
-      "paper_phrase": "backtester is 385 lines"
+      "paper_phrase": "backtester is 391 lines"
     },
     "capability_groups": {
       "value": 12,
@@ -46,13 +46,13 @@
       "paper_phrase": "12 capability groups"
     },
     "collected_tests": {
-      "value": 2867,
+      "value": 2878,
       "how": "pytest --collect-only -q, summed over files, core install",
       "live": false,
       "paper_phrase": null
     },
     "commits": {
-      "value": 605,
+      "value": 615,
       "how": "git rev-list --count HEAD",
       "live": false,
       "paper_phrase": null

--- a/paper.md
+++ b/paper.md
@@ -120,7 +120,7 @@ draw across several aligned panels, so a factor and a residual panel resample to
 
 We organise the package into 12 capability groups, which `src/qis/api.py` names.
 
-The backtester is 385 lines, and that follows from the design assumption rather than from
+The backtester is 391 lines, and that follows from the design assumption rather than from
 compression. Because a strategy is a rule for producing weights, the backtester holds no strategy
 logic: it converts target weights to units at each rebalancing, holds those units until the next
 one, applies costs, and returns the result. The recursion over dates is compiled with `numba`,

--- a/src/qis/portfolio/backtester.py
+++ b/src/qis/portfolio/backtester.py
@@ -5,7 +5,8 @@ portfolio.
 ``backtest_model_portfolio`` is the entry point and the only one most callers need. It accepts
 target weights as a Dict, Series or DataFrame - aligned to ``prices.columns`` by name - or as a
 list or array, which is positional. A fixed weight vector is applied on the calendar anchor in
-``rebalancing_freq``; a DataFrame of weights supplies its own dates and the anchor is ignored.
+``rebalancing_freq``; a DataFrame of weights supplies its own dates, is ordered chronologically,
+and ignores the anchor.
 
 The simulation holds units between rebalancings, not weights. Units are set at a rebalancing as
 u_t = nav_t w_t / p_t and held until the next one, so realised weights drift with prices and the
@@ -29,9 +30,10 @@ observed at t is traded at the price ``weight_implementation_lag`` observations 
 later. It does not shift, resample or otherwise touch prices, so instrument returns are the same
 under any lag.
 
-Weights are taken as given and never modified. An instrument with no price on a rebalancing date
-is not traded and its weight stays in the cash balance; allocating that weight over the priced
-instruments instead is ``qis.generate_static_weights_schedule``, before the backtest.
+Caller-owned weights are never modified; dated schedules are ordered chronologically on a local
+copy. An instrument with no price on a rebalancing date is not traded and its weight stays in the
+cash balance; allocating that weight over the priced instruments instead is
+``qis.generate_static_weights_schedule``, before the backtest.
 
 ``backtest_rebalanced_portfolio`` is the numba kernel underneath: a genuine recursion in nav and
 cash balance, which is why it is not vectorized. Rolling an optimisation through time is
@@ -80,8 +82,9 @@ def backtest_model_portfolio(prices: pd.DataFrame,
         weights: target weights. A Dict or pd.DataFrame is safest, since both are aligned to
             ``prices.columns`` by name; a list or array is positional and must match the
             column count. A fixed weight vector is applied at every date in
-            ``rebalancing_freq``; a pd.DataFrame supplies its own rebalancing dates and
-            ``rebalancing_freq`` is then ignored
+            ``rebalancing_freq``; a pd.DataFrame supplies its own rebalancing dates, which are
+            ordered chronologically before validation and execution, and
+            ``rebalancing_freq`` is then ignored. The caller-owned object is not modified
         rebalancing_freq: calendar anchor for rebalancing when ``weights`` is a fixed vector,
             passed to :func:`generate_rebalancing_indicators`
         initial_nav: starting nav
@@ -142,6 +145,9 @@ def backtest_model_portfolio(prices: pd.DataFrame,
         assert_list_subset(large_list=prices.columns.to_list(),
                               list_sample=weights.columns.to_list(),
                               message=f"weights columns must be aligned with price columns")
+        # Trade flags are chronological, so keep their consumed targets and reported input
+        # schedule in the same order without mutating the caller-owned DataFrame.
+        weights = weights.sort_index()
         if prices.index[0] > weights.index[0]:
             raise ValueError(f"price dates {prices.index[0]} are after weights start date {weights.index[0]}")
         portfolio_weights = weights[prices.columns]  # alighn

--- a/src/qis/portfolio/tests/backtester_weight_date_order_test.py
+++ b/src/qis/portfolio/tests/backtester_weight_date_order_test.py
@@ -1,0 +1,136 @@
+"""Regression tests for chronological dated-weight scheduling in the portfolio backtester.
+
+The backtester maps decision dates onto the price grid and then consumes one target row per
+trade. Permuting a dated schedule must not change which target is applied at each date, including
+when execution is delayed by an observation. These fixtures make the held-unit path calculable by
+hand and also protect the existing pre-price validation boundary.
+"""
+
+import pandas as pd
+import pytest
+
+import qis
+
+
+def _prices() -> pd.DataFrame:
+    """Return a two-asset panel with a hand-checkable held-unit path."""
+    dates = pd.bdate_range("2024-01-02", periods=6)
+    return pd.DataFrame(
+        {
+            "A": [100.0, 110.0, 120.0, 130.0, 140.0, 150.0],
+            "B": [100.0] * len(dates),
+        },
+        index=dates,
+    )
+
+
+def _weight_schedules(prices: pd.DataFrame) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Return equivalent chronological and deliberately permuted target schedules."""
+    chronological = pd.DataFrame(
+        [[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]],
+        index=prices.index[[0, 2, 4]],
+        columns=prices.columns,
+    )
+    return chronological, chronological.iloc[[2, 0, 1]]
+
+
+@pytest.mark.parametrize(
+    ("lag", "trade_positions", "expected_nav", "expected_units"),
+    [
+        pytest.param(
+            0,
+            [0, 2, 4],
+            [100.0, 110.0, 120.0, 120.0, 120.0, 124.28571428571428],
+            [
+                [1.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.2],
+                [0.0, 1.2],
+                [0.42857142857142855, 0.6],
+                [0.42857142857142855, 0.6],
+            ],
+            id="same-observation",
+        ),
+        pytest.param(
+            1,
+            [1, 3, 5],
+            [
+                100.0,
+                100.0,
+                109.0909090909091,
+                118.18181818181817,
+                118.18181818181817,
+                118.18181818181816,
+            ],
+            [
+                [0.0, 0.0],
+                [0.9090909090909091, 0.0],
+                [0.9090909090909091, 0.0],
+                [0.0, 1.1818181818181817],
+                [0.0, 1.1818181818181817],
+                [0.3939393939393939, 0.5909090909090908],
+            ],
+            id="next-observation",
+        ),
+    ],
+)
+def test_backtest_model_portfolio_normalizes_dated_weight_order(
+    lag: int,
+    trade_positions: list[int],
+    expected_nav: list[float],
+    expected_units: list[list[float]],
+) -> None:
+    """A row permutation preserves the chronological target and held-unit paths."""
+    prices = _prices()
+    chronological, permuted = _weight_schedules(prices)
+    caller_weights = permuted.copy()
+
+    result = qis.backtest_model_portfolio(
+        prices=prices,
+        weights=permuted,
+        weight_implementation_lag=lag,
+    )
+
+    # These values follow directly from nav_t * target_t / price_t at each dated trade.
+    expected_nav_series = pd.Series(expected_nav, index=prices.index, name="Portfolio")
+    expected_units_frame = pd.DataFrame(expected_units, index=prices.index, columns=prices.columns)
+    expected_realised_weights = expected_units_frame.multiply(prices).divide(
+        expected_nav_series,
+        axis=0,
+    )
+    expected_rebalancing = pd.Series(False, index=prices.index)
+    expected_rebalancing.iloc[trade_positions] = True
+
+    pd.testing.assert_series_equal(result.nav, expected_nav_series)
+    pd.testing.assert_frame_equal(result.units, expected_units_frame)
+    pd.testing.assert_frame_equal(result.weights, expected_realised_weights)
+    pd.testing.assert_series_equal(result.is_rebalancing, expected_rebalancing)
+
+    assert isinstance(result.input_weights, pd.DataFrame)
+    pd.testing.assert_frame_equal(result.input_weights, chronological)
+    target_turnover = result.get_turnover(
+        is_unit_based_traded_volume=False,
+        roll_period=None,
+        add_total=False,
+    )
+    assert isinstance(target_turnover, pd.DataFrame)
+    pd.testing.assert_frame_equal(target_turnover, chronological.diff().abs())
+
+    # Normalizing the local schedule must not reorder the caller-owned DataFrame.
+    pd.testing.assert_frame_equal(permuted, caller_weights)
+
+
+def test_backtest_model_portfolio_checks_earliest_weight_date_after_normalizing() -> None:
+    """A pre-price target cannot evade validation by appearing after a later row."""
+    prices = _prices()
+    weights = pd.DataFrame(
+        [[0.0, 1.0], [1.0, 0.0]],
+        index=[prices.index[2], prices.index[0] - pd.Timedelta(days=1)],
+        columns=prices.columns,
+    )
+    caller_weights = weights.copy()
+
+    with pytest.raises(ValueError, match="price dates .* are after weights start date"):
+        qis.backtest_model_portfolio(prices=prices, weights=weights)
+
+    pd.testing.assert_frame_equal(weights, caller_weights)


### PR DESCRIPTION
## What changed

Establish chronological weight-row order before mapping dated targets to traded price observations.

Passing the same dated weight rows in chronological and reversed order produces different trades and NAV because `searchsorted()` maps dates while the kernel still consumes weight rows in supplied order.

## Behavior

Normalize a dated DataFrame schedule chronologically before date validation, execution mapping, kernel consumption, and storage as `PortfolioData.input_weights`. Equivalent schedules must produce identical trade dates, units, realised weights, NAV, and target-derived reporting regardless of row order, while the caller-owned DataFrame remains unchanged.

## Regression evidence

On the hand-checkable two-asset path, permuting the same three target rows changed final NAV from `124.285714` to `128.333333` at lag 0 and from `118.181818` to `125.874126` at lag 1. Trade dates were unchanged, proving that the kernel consumed the wrong targets. The permuted schedule also produced non-chronological stored input weights and different target-turnover attribution. A pre-price row hidden behind a later first row bypassed the documented start-date rejection and was silently traded.

## Verification

- Focused regression: The permanent three-case module first failed with `3 failed`: both lag variants produced the supplied-order NAV path and the hidden pre-price row did not raise. It then passed with `3 passed` after chronological normalization. A private off-grid probe reached the same date-mapping and row-consumption mechanism.
- Complete affected subsystem: `201 passed, 18 warnings` in `src/qis/portfolio/`, including the focused regression and established scheduling, accounting, reporting, and ownership controls.
- Final full suite: `2878 passed, 18 warnings` in `src/qis/`; the warnings are the established Seaborn/Matplotlib deprecations and two existing leading-price warnings.
- Static, documentation, API, dependency, or build checks: Changed-line Ruff and differential Pyright found no attributable diagnostics; the new test is Ruff-format clean; inherited `backtester.py` format debt is unchanged; the supplemental perfstats suite passed with `808 passed`; Sphinx `-W`, the 430-name public-API check, dependency integrity, generated paper-audit consistency, and whitespace checks passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/portfolio/backtester.py`, one focused portfolio test, `paper.md`, and its generated `docs/audit/paper_numbers.json` measurement record.

Out of scope: Negative lags, collision semantics already enforced, price-index normalization, and portfolio optimization.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.