### PR TITLE
fix: normalize minute annualization aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Ordered dated portfolio-weight schedules chronologically before validation and execution,
   preventing input row order from assigning targets to the wrong trade dates.
 
+- Normalized minute-frequency annualization so explicit, inferred, case-varied, and
+  multiplier-parsed aliases use one clock-hour basis per selected active day.
+
 - Raised the statsmodels minimum to 0.14.2 after the fresh Python 3.10 CI environment
   reproduced a NumPy 2.0 binary incompatibility in the previously allowed 0.14.0 wheel.
 

--- a/src/qis/utils/annualisation.py
+++ b/src/qis/utils/annualisation.py
@@ -4,7 +4,8 @@ annualisation factors: periods per year for a pandas frequency string or a data 
 ``get_annualization_factor`` maps a frequency to periods per year, handling multipliers and
 anchors ('2W' -> 26, 'QE-DEC' -> 4) and falling back to a regex parse, with a UserWarning and a
 factor of 1.0 for a string it cannot read. 'D' is 365 always, 'B' is ``default_trading_days``
-(252 by default), and ``is_calendar=True`` moves the business-day family to 365.
+(252 by default), and ``is_calendar=True`` moves the business-day family to 365. Intraday aliases
+use 24 clock hours within each selected active day; they do not infer an exchange session.
 ``get_annualisation_conversion_factor`` is the ratio of two such factors.
 
 Two inference paths differ on an irregular index. ``infer_annualisation_factor_from_df`` reads
@@ -37,7 +38,10 @@ def get_annualization_factor(freq: str,
 
     Args:
         freq: Pandas frequency string (e.g., 'D', 'W-FRI', '2ME', 'QE-DEC')
-        is_calendar: If True, use calendar days (365); if False, use trading days (252)
+        is_calendar: If True, use 365 active days; otherwise use ``default_trading_days``.
+            Intraday frequencies use 24 clock hours within each selected active day.
+        default_trading_days: Active days per year outside calendar mode. This does not imply an
+            exchange-specific intraday session length.
 
     Returns:
         Annualization factor (number of periods per year)
@@ -150,8 +154,9 @@ def get_annualization_factor(freq: str,
             'BA': 1.0,
             'BAS': 1.0,
             'H': an_days * 24.0,
-            'T': an_days * 390.0,  # Trading minutes
-            'MIN': an_days * 390.0,
+            # Generic minute multipliers share the explicit aliases' clock-day basis.
+            'T': an_days * 24.0 * 60.0,
+            'MIN': an_days * 24.0 * 60.0,
         }
 
         if base_freq not in freq_to_annual:

--- a/src/qis/utils/tests/annualisation_minute_alias_test.py
+++ b/src/qis/utils/tests/annualisation_minute_alias_test.py
@@ -1,0 +1,181 @@
+"""Regression tests for minute-frequency annualization consistency.
+
+Minute aliases represent clock intervals within the active days selected by
+``get_annualization_factor``. Equivalent spellings and positive integer multipliers must therefore
+share one base minute count, including aliases inferred from pandas indexes. The integration
+checks keep public Sharpe and EWM-volatility scaling tied to that same independently calculated
+factor.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import qis
+from qis.utils.annualisation import (
+    get_annualization_factor,
+    infer_annualisation_factor_from_df,
+)
+
+
+_CALENDAR_DAYS = 365
+_MINUTES_PER_DAY = 24 * 60
+_TRADING_DAYS = 252
+
+_MINUTE_ALIASES: tuple[tuple[str, int], ...] = (
+    ("min", 1),
+    ("1min", 1),
+    ("T", 1),
+    ("MIN", 1),
+    ("2min", 2),
+    ("5min", 5),
+    ("5T", 5),
+    ("5MIN", 5),
+    ("10min", 10),
+    ("15min", 15),
+    ("15T", 15),
+    ("30min", 30),
+    ("60min", 60),
+)
+
+
+def _ten_minute_returns() -> pd.Series:
+    """Return a finite varying series on a pandas-inferable ten-minute grid."""
+    return pd.Series(
+        (-0.010, 0.015, -0.005, 0.020, 0.010, -0.015, 0.005, 0.025),
+        index=pd.date_range("2026-01-02 09:30", periods=8, freq="10min"),
+        name="Strategy",
+    )
+
+
+def _same_returns_at_frequency(returns: pd.Series, frequency: str) -> pd.DataFrame:
+    """Relabel the deterministic values on an equivalent comparison grid.
+
+    Args:
+        returns: Finite periodic values used by the primary integration path.
+        frequency: Comparison grid applied without changing those values.
+
+    Returns:
+        One-column return frame on the requested regular grid.
+    """
+    return pd.DataFrame(
+        returns.to_numpy(dtype=float),
+        index=pd.date_range(returns.index[0], periods=len(returns), freq=frequency),
+        columns=[returns.name],
+    )
+
+
+@pytest.mark.parametrize(("is_calendar", "active_days"), ((False, 252), (True, 365)))
+@pytest.mark.parametrize(("frequency", "multiplier"), _MINUTE_ALIASES)
+def test_get_annualization_factor_minute_aliases_share_clock_basis(
+    frequency: str,
+    multiplier: int,
+    is_calendar: bool,
+    active_days: int,
+) -> None:
+    """Divide one clock-minute basis by every supported alias multiplier.
+
+    Args:
+        frequency: Direct modern, legacy, or case-varied minute spelling.
+        multiplier: Number of minutes represented by one observation.
+        is_calendar: Whether all calendar days are active.
+        active_days: Independently selected number of active days per year.
+    """
+    expected = active_days * _MINUTES_PER_DAY / multiplier
+
+    actual = get_annualization_factor(frequency, is_calendar=is_calendar)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("is_calendar", "default_trading_days", "active_days"),
+    ((False, 260, 260), (True, 260, _CALENDAR_DAYS)),
+)
+def test_get_annualization_factor_minute_aliases_respect_selected_active_days(
+    is_calendar: bool,
+    default_trading_days: int,
+    active_days: int,
+) -> None:
+    """Apply a custom trading-day count only outside calendar mode.
+
+    Args:
+        is_calendar: Whether the calendar-day override is active.
+        default_trading_days: Caller-supplied active trading days.
+        active_days: Independently expected active-day count.
+    """
+    expected = active_days * _MINUTES_PER_DAY / 10
+
+    actual = get_annualization_factor(
+        "10min",
+        is_calendar=is_calendar,
+        default_trading_days=default_trading_days,
+    )
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("frequency", "expected"),
+    (("B", 252.0), ("D", 365.0), ("h", 252.0 * 24), ("2h", 252.0 * 12), ("ME", 12.0)),
+)
+def test_get_annualization_factor_minute_fix_preserves_other_frequency_factors(
+    frequency: str,
+    expected: float,
+) -> None:
+    """Keep neighboring business, calendar, hourly, and monthly factors unchanged.
+
+    Args:
+        frequency: Unchanged control frequency.
+        expected: Existing independently calculated periods per year.
+    """
+    assert get_annualization_factor(frequency) == expected
+
+
+@pytest.mark.parametrize(
+    ("frequency", "multiplier"),
+    (("min", 1), ("2min", 2), ("5min", 5), ("10min", 10), ("30min", 30), ("60min", 60)),
+)
+def test_infer_annualisation_factor_from_df_uses_minute_clock_basis(
+    frequency: str,
+    multiplier: int,
+) -> None:
+    """Propagate pandas' modern inferred aliases through the same minute contract.
+
+    Args:
+        frequency: Valid pandas frequency used to construct the index.
+        multiplier: Number of minutes represented by one observation.
+    """
+    data = pd.Series(
+        np.arange(8, dtype=float),
+        index=pd.date_range("2026-01-02", periods=8, freq=frequency),
+        name="return",
+    )
+    expected = _TRADING_DAYS * _MINUTES_PER_DAY / multiplier
+
+    assert infer_annualisation_factor_from_df(data) == expected
+
+
+def test_minute_inference_scales_public_ewm_sharpe() -> None:
+    """Scale public EWM Sharpe by the independent five-to-ten-minute ratio."""
+    returns = _ten_minute_returns()
+    five_minute_returns = _same_returns_at_frequency(returns, "5min")
+    five_minute_sharpe = qis.compute_ewm_sharpe(five_minute_returns, span=3)
+    expected = five_minute_sharpe.multiply(np.sqrt(5 / 10)).set_axis(returns.index)
+
+    actual = qis.compute_ewm_sharpe(returns.to_frame(), span=3)
+
+    pd.testing.assert_frame_equal(actual, expected, rtol=1e-14, atol=0.0)
+
+
+def test_minute_inference_scales_public_ewm_volatility() -> None:
+    """Annualize public EWM volatility from its independently scaled periodic result."""
+    returns = _ten_minute_returns()
+    expected_factor = _TRADING_DAYS * _MINUTES_PER_DAY / 10
+    periodic = qis.compute_ewm_vol(returns, span=3, annualize=False)
+    actual = qis.compute_ewm_vol(returns, span=3, annualize=True)
+
+    assert isinstance(periodic, pd.Series)
+    assert isinstance(actual, pd.Series)
+    expected = periodic.multiply(np.sqrt(expected_factor))
+    pd.testing.assert_series_equal(actual, expected, rtol=1e-14, atol=0.0)


### PR DESCRIPTION
## What changed

Make direct and inferred minute aliases use 24 clock hours per selected active day, divided by their positive integer multiplier.

On accepted `4ea64b6`, direct `min`, `5min`, and `15min` aliases use 1,440 minutes per selected day, while generic `2min`, `10min`, `30min`, and uppercase equivalents use 390. Their multiplier-scaled one-minute bases alternate between `362880` and `98280` with the default 252 days, and between `525600` and `142350` in calendar mode.

## Behavior

Let `active_days` be 365 in calendar mode and `default_trading_days` otherwise. The base minute factor is `active_days * 24 * 60`, every n-minute factor is that base divided by n, equivalent direct and pandas-inferred aliases agree, and `60min` agrees with the existing hourly factor. This is a clock-frequency convention, not a claim about an exchange's session length.

## Regression evidence

Against untouched accepted `4ea64b6`, the final permanent regression module produced 19 failures and 22 passes. Exact generic aliases, custom-day cases, pandas inference, and exported EWM volatility and Sharpe consumers all exposed the split 390/1,440-minute bases. With the correction applied, all 41 focused cases pass. The old generic factor understated square-root annualization by about 47.96% relative to the established clock-hour path; the correction multiplies affected annualized volatility and Sharpe scaling by about `1.92154`.

## Verification

- Focused regression: 41 passed after the final format-new result; the same permanent module failed 19 cases and passed 22 against untouched accepted `4ea64b6` before the fix.
- Complete affected subsystem: `src/qis/utils/tests/` passed 78 tests; the workflow's broader affected-consumer check passed all 808 perfstats tests.
- Final full suite: 2,920 tests passed with 18 known warnings.
- Static, documentation, API, dependency, or build checks: Changed-line Ruff and Pyright found zero new diagnostics; the added test passes Ruff format and whole-file Pyright; `git diff --check`, public-API synchronization, core-API/docstring tests, `pip check`, and the Sphinx warning-as-error build all pass. Three old Ruff and three old Pyright diagnostics in `annualisation.py` remain inherited and outside this minimal diff.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/utils/annualisation.py`, and `src/qis/utils/tests/annualisation_minute_alias_test.py`; the public module/function docstrings provide the packaged frequency documentation without adding a second narrative source.

Out of scope: Market-hours calendars, exchange-specific sessions, timezone handling, tick data, and the developer-only `annualisation_run.py` list, whose stale `1M`/`5M`/`15M` labels are a low-value maintenance cleanup rather than part of the public numerical correction.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.