### PR TITLE
fix: validate portfolio implementation lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Rejected negative and non-integral dated portfolio implementation lags before schedule mapping,
+  preventing targets from trading before their observation date or wrapping to the history end.
+
 - Ordered dated portfolio-weight schedules chronologically before validation and execution,
   preventing input row order from assigning targets to the wrong trade dates.
 

--- a/docs/audit/paper_numbers.json
+++ b/docs/audit/paper_numbers.json
@@ -1,6 +1,6 @@
 {
   "generated_by": "tools/paper_audit.py",
-  "measured_at_commit": "532d5208e72d2d443a929446629fbe6f6e0752af",
+  "measured_at_commit": "7e9a335972554ca0a6382157428136572653612f",
   "note": "every number paper.md quotes. Regenerate with python tools/paper_audit.py; the package paper-audit test fails when this file and the repository disagree.",
   "metrics": {
     "active_months": {
@@ -28,16 +28,16 @@
       "paper_phrase": null
     },
     "backtester_nonblank_lines": {
-      "value": 345,
+      "value": 356,
       "how": "nonblank lines of src/qis/portfolio/backtester.py",
       "live": true,
       "paper_phrase": null
     },
     "backtester_physical_lines": {
-      "value": 391,
+      "value": 403,
       "how": "physical lines of src/qis/portfolio/backtester.py",
       "live": true,
-      "paper_phrase": "backtester is 391 lines"
+      "paper_phrase": "backtester is 403 lines"
     },
     "capability_groups": {
       "value": 12,
@@ -46,13 +46,13 @@
       "paper_phrase": "12 capability groups"
     },
     "collected_tests": {
-      "value": 2878,
+      "value": 2939,
       "how": "pytest --collect-only -q, summed over files, core install",
       "live": false,
       "paper_phrase": null
     },
     "commits": {
-      "value": 615,
+      "value": 618,
       "how": "git rev-list --count HEAD",
       "live": false,
       "paper_phrase": null

--- a/paper.md
+++ b/paper.md
@@ -120,7 +120,7 @@ draw across several aligned panels, so a factor and a residual panel resample to
 
 We organise the package into 12 capability groups, which `src/qis/api.py` names.
 
-The backtester is 391 lines, and that follows from the design assumption rather than from
+The backtester is 403 lines, and that follows from the design assumption rather than from
 compression. Because a strategy is a rule for producing weights, the backtester holds no strategy
 logic: it converts target weights to units at each rebalancing, holds those units until the next
 one, applies costs, and returns the result. The recursion over dates is compiled with `numba`,

--- a/src/qis/portfolio/backtester.py
+++ b/src/qis/portfolio/backtester.py
@@ -25,10 +25,10 @@ Dates before the first schedule row are costless. A date-indexed Series is rejec
 ambiguous. ``funding_rate`` accrues on the cash balance, ``management_fee`` on nav and
 ``instruments_carry`` per instrument, all annualised and converted to the price grid.
 
-``weight_implementation_lag`` selects the entry price for the units and nothing else: the weight
-observed at t is traded at the price ``weight_implementation_lag`` observations of the price index
-later. It does not shift, resample or otherwise touch prices, so instrument returns are the same
-under any lag.
+``weight_implementation_lag`` is a non-negative integer selecting the entry price for the units and
+nothing else: the weight observed at t is traded at the price ``weight_implementation_lag``
+observations of the price index later. It does not shift, resample or otherwise touch prices, so
+instrument returns are the same under any lag.
 
 Caller-owned weights are never modified; dated schedules are ordered chronologically on a local
 copy. An instrument with no price on a rebalancing date is not traded and its weight stays in the
@@ -41,6 +41,7 @@ cash balance, which is why it is not vectorized. Rolling an optimisation through
 """
 
 # packages
+from numbers import Integral
 import warnings
 import numpy as np
 import pandas as pd
@@ -98,12 +99,12 @@ def backtest_model_portfolio(prices: pd.DataFrame,
             date, so a cost schedule stated on era boundaries applies from each boundary
             onward. Costs are read at every trade date, including an opening trade on the
             first price date; dates before the first schedule row are costless
-        weight_implementation_lag: observations of the price index between a weight being
-            observed and traded, so 1 on a business-day panel trades the next business day. It
-            selects the entry price for the units only and leaves prices and instrument returns
-            untouched. Applies only when ``weights`` is a pd.DataFrame, since a fixed vector has
-            no signal date. A weight whose traded date would fall past the end of the price
-            history is dropped with a warning
+        weight_implementation_lag: non-negative integer observations of the price index between a
+            weight being observed and traded, so 1 on a business-day panel trades the next
+            business day. None means zero. It selects the entry price for the units only and
+            leaves prices and instrument returns untouched. Applies only when ``weights`` is a
+            pd.DataFrame, since a fixed vector has no signal date. A weight whose traded date would
+            fall past the end of the price history is dropped with a warning
         constant_trade_level: size each rebalancing off this notional rather than off current
             nav, so trade size does not compound with performance
         is_rebalanced_at_first_date: rebalance on the first price date as well as on the
@@ -115,15 +116,27 @@ def backtest_model_portfolio(prices: pd.DataFrame,
         costs, including costs charged on an opening trade
 
     Raises:
-        ValueError: if ``prices`` is not a pd.DataFrame, if a weight vector does not match the
-            number of price columns, if the price history starts after the weights do, if two
-            weight dates resolve to the same traded date on the price index, if no weight date
-            is traded at all, if a ``rebalancing_costs`` DataFrame is missing a price column, or
-            if a ``rebalancing_costs`` Series is indexed by dates rather than tickers
+        ValueError: if ``prices`` is not a pd.DataFrame, if the dated-weight implementation lag is
+            not None or a non-negative integer, if a weight vector does not match the number of
+            price columns, if the price history starts after the weights do, if two weight dates
+            resolve to the same traded date on the price index, if no weight date is traded at
+            all, if a ``rebalancing_costs`` DataFrame is missing a price column, or if a
+            ``rebalancing_costs`` Series is indexed by dates rather than tickers
         NotImplementedError: if ``weights`` is of an unsupported type
     """
     if not isinstance(prices, pd.DataFrame):
         raise ValueError(f"prices type={type(prices)} must be pd.Dataframe")
+
+    # The lag applies only to dated schedules; validate it before mapping decision dates
+    # onto the price index.
+    lag = 0
+    if isinstance(weights, pd.DataFrame) and weight_implementation_lag is not None:
+        if (isinstance(weight_implementation_lag, (bool, np.bool_))
+                or not isinstance(weight_implementation_lag, Integral)
+                or weight_implementation_lag < 0):
+            raise ValueError("weight_implementation_lag must be a non-negative integer or None, "
+                             f"got {weight_implementation_lag!r}")
+        lag = int(weight_implementation_lag)
 
     # a nan inside an instrument's own reported history is a data defect rather than a universe
     # change: units are held through it and np.nansum drops the leg from the nav on those dates.
@@ -158,7 +171,6 @@ def backtest_model_portfolio(prices: pd.DataFrame,
         # observations on. Weights are consumed one row per rebalancing flag, so two weight dates
         # resolving to the same traded date would shift every later row and is an error, not a
         # collapse
-        lag = weight_implementation_lag if weight_implementation_lag is not None else 0
         traded_positions = prices.index.searchsorted(portfolio_weights.index) + lag
         is_traded = traded_positions <= len(prices.index) - 1
         if not np.any(is_traded):

--- a/src/qis/portfolio/tests/backtester_negative_lag_test.py
+++ b/src/qis/portfolio/tests/backtester_negative_lag_test.py
@@ -1,0 +1,146 @@
+"""Regression tests for the implementation-lag domain in the portfolio backtester.
+
+Dated targets may trade on their observation or a later price observation, but never before the
+target exists. These tests cover that causal boundary, the complete scalar-validation domain, and
+the unchanged rule that the lag is unused for static weights.
+"""
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import qis
+
+
+def _prices() -> pd.DataFrame:
+    """Return a small price panel with unambiguous schedule positions."""
+    dates = pd.bdate_range("2024-01-02", periods=5)
+    return pd.DataFrame(
+        {
+            "A": [100.0, 101.0, 102.0, 103.0, 104.0],
+            "B": [100.0, 100.0, 100.0, 100.0, 100.0],
+        },
+        index=dates,
+    )
+
+
+def _dated_weights(prices: pd.DataFrame, position: int = 1) -> pd.DataFrame:
+    """Return one dated target whose mapped trade observation is easy to inspect."""
+    return pd.DataFrame(
+        [[1.0, 0.0]],
+        index=prices.index[[position]],
+        columns=prices.columns,
+    )
+
+
+@pytest.mark.parametrize("decision_position", [0, 2], ids=["first-date", "mid-history"])
+@pytest.mark.parametrize("invalid_lag", [-1, np.int64(-1)], ids=["python-int", "numpy-int"])
+def test_backtest_model_portfolio_rejects_negative_implementation_lag_before_mapping(
+    decision_position: int,
+    invalid_lag: Any,
+) -> None:
+    """A negative lag cannot wrap or expose a target before its decision date."""
+    prices = _prices()
+    weights = _dated_weights(prices, position=decision_position)
+    caller_weights = weights.copy()
+
+    with pytest.raises(
+        ValueError,
+        match="weight_implementation_lag must be a non-negative integer or None",
+    ):
+        qis.backtest_model_portfolio(
+            prices=prices,
+            weights=weights,
+            weight_implementation_lag=invalid_lag,
+        )
+
+    pd.testing.assert_frame_equal(weights, caller_weights)
+
+
+@pytest.mark.parametrize(
+    "invalid_lag",
+    [
+        pytest.param(True, id="python-bool"),
+        pytest.param(np.bool_(False), id="numpy-bool"),
+        pytest.param(1.0, id="integral-float"),
+        pytest.param(0.5, id="fractional-float"),
+        pytest.param(np.nan, id="nan"),
+        pytest.param(np.inf, id="positive-infinity"),
+        pytest.param(-np.inf, id="negative-infinity"),
+        pytest.param(pd.NA, id="pandas-missing"),
+    ],
+)
+def test_backtest_model_portfolio_rejects_nonintegral_implementation_lag(
+    invalid_lag: Any,
+) -> None:
+    """Unsupported scalar classes fail at the public boundary with one clear error."""
+    prices = _prices()
+    weights = _dated_weights(prices)
+    caller_weights = weights.copy()
+
+    with pytest.raises(
+        ValueError,
+        match="weight_implementation_lag must be a non-negative integer or None",
+    ):
+        qis.backtest_model_portfolio(
+            prices=prices,
+            weights=weights,
+            weight_implementation_lag=invalid_lag,
+        )
+
+    pd.testing.assert_frame_equal(weights, caller_weights)
+
+
+@pytest.mark.parametrize(
+    ("lag", "expected_trade_position"),
+    [
+        pytest.param(None, 1, id="none"),
+        pytest.param(0, 1, id="python-zero"),
+        pytest.param(np.int64(0), 1, id="numpy-zero"),
+        pytest.param(1, 2, id="python-positive"),
+        pytest.param(np.int64(1), 2, id="numpy-positive"),
+    ],
+)
+def test_backtest_model_portfolio_preserves_valid_implementation_lag(
+    lag: Any,
+    expected_trade_position: int,
+) -> None:
+    """None and non-negative integer scalars retain observation-count scheduling."""
+    prices = _prices()
+    weights = _dated_weights(prices)
+
+    result = qis.backtest_model_portfolio(
+        prices=prices,
+        weights=weights,
+        weight_implementation_lag=lag,
+    )
+
+    expected_rebalancing = pd.Series(False, index=prices.index)
+    expected_rebalancing.iloc[expected_trade_position] = True
+    pd.testing.assert_series_equal(result.is_rebalancing, expected_rebalancing)
+
+
+def test_backtest_model_portfolio_ignores_implementation_lag_for_static_weights() -> None:
+    """The dated-weight-only parameter does not change a static-weight schedule."""
+    prices = _prices()
+    weights = pd.Series({"A": 0.6, "B": 0.4})
+
+    expected = qis.backtest_model_portfolio(
+        prices=prices,
+        weights=weights,
+        rebalancing_freq="QE",
+        is_rebalanced_at_first_date=True,
+    )
+    result = qis.backtest_model_portfolio(
+        prices=prices,
+        weights=weights,
+        rebalancing_freq="QE",
+        weight_implementation_lag=-1,
+        is_rebalanced_at_first_date=True,
+    )
+
+    pd.testing.assert_series_equal(result.nav, expected.nav)
+    pd.testing.assert_frame_equal(result.units, expected.units)
+    pd.testing.assert_frame_equal(result.weights, expected.weights)


### PR DESCRIPTION
## What changed

For dated DataFrame weights, validate `weight_implementation_lag` as `None` or a non-negative integral observation count before schedule mapping.

With a target dated at price position 2 and lag -1, accepted code trades at position 1, so changing the future target changes pre-decision holdings. With a target on the first price date, position -1 is accepted and NumPy-style indexing wraps the trade to the final price date instead of rejecting the causal impossibility.

## Behavior

For the documented dated-DataFrame path, `None` means zero; Python and NumPy integral scalars are accepted only when non-negative; booleans, fractional values, and missing numeric scalars are rejected with a clear `ValueError`. Every mapped trade position must be at or after its decision's insertion position. The parameter remains inapplicable to static weights, and valid zero/positive lag behavior is unchanged.

## Regression evidence

On accepted `7e9a335`, both Python `-1` and `np.int64(-1)` were accepted and traded a 04Jan2024 decision on 03Jan2024. A first-date decision with lag -1 wrapped to the final 08Jan2024 observation. `True` and `False` were accepted as 1 and 0, positive and negative floats failed later with a low-level index error, and `np.nan` reached an unrelated no-trades error.

The permanent regression failed 12 invalid cases before the production fix while its six valid/static controls passed. After validation, all 18 cases pass and caller-owned dated weights remain unchanged on every rejection.

## Verification

- Focused regression: 12 failed and 6 passed before the fix; all 18 pass after the fix.
- Complete affected subsystem: The portfolio subsystem, direct regression, downstream discrete-backtester/reporting controls, and paper audit passed: 285 tests.
- Final full suite: 2,939 passed with 18 accepted third-party/application warnings.
- Supplemental perfstats suite: 808 passed.
- The Sphinx warning-as-error build succeeded.
- Changed-line Ruff and Pyright reported zero new diagnostics.
- The new test passed the Ruff formatter check.
- The public API remains current at 430 names.
- Dependency integrity, `paper_audit.py --check`, and `git diff --check` passed.

## Scope

Changed files are limited to:

- `CHANGELOG.md`
- `docs/audit/paper_numbers.json`
- `paper.md`
- `src/qis/portfolio/backtester.py`
- `src/qis/portfolio/tests/backtester_negative_lag_test.py`

Out of scope: changing valid positive-lag mapping, unsorted-weight normalization, collision or tail-drop policy, static-weight scheduling, signal creation, costs, and portfolio accounting.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.
