### PR TITLE
fix: support nullable ragged drawdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - Normalized nullable floating drawdowns before maximum and current reductions so ragged
-  `Float64` price histories match ordinary floating inputs without ambiguous `pd.NA` failures.
+  `Float64` price histories match ordinary floating inputs without ambiguous `pd.NA` failures;
+  risk-table best and worst returns now preserve missing price gaps consistently across pandas
+  versions.
 
 - Rejected negative and non-integral dated portfolio implementation lags before schedule mapping,
   preventing targets from trading before their observation date or wrapping to the history end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Normalized nullable floating drawdowns before maximum and current reductions so ragged
+  `Float64` price histories match ordinary floating inputs without ambiguous `pd.NA` failures.
+
 - Rejected negative and non-integral dated portfolio implementation lags before schedule mapping,
   preventing targets from trading before their observation date or wrapping to the history end.
 

--- a/src/qis/perfstats/perf_stats.py
+++ b/src/qis/perfstats/perf_stats.py
@@ -352,7 +352,8 @@ def compute_risk_table(prices: pd.DataFrame,
     returns_skew = ret.to_returns(prices=sampled_prices_skew,
                                   return_type=perf_params.return_type,
                                   drop_first=True)
-    pct_returns_dd = dd_sampled_prices.pct_change()
+    # Preserve missing price gaps rather than letting pandas choose an implicit fill policy.
+    pct_returns_dd = dd_sampled_prices.pct_change(fill_method=None)
 
     # ── Bulk vectorised metrics across all assets ──
     # std uses ddof=1 to match the original per-asset numpy call.

--- a/src/qis/perfstats/perf_stats.py
+++ b/src/qis/perfstats/perf_stats.py
@@ -733,22 +733,24 @@ def compute_max_current_drawdown(prices: Union[pd.DataFrame, pd.Series]
     """Compute the realised maximum drawdown and the current drawdown.
 
     Args:
-        prices: Price level Series or DataFrame.
+        prices: Price level Series or DataFrame. Ordinary and nullable floating missing values
+            follow the same drawdown semantics.
 
     Returns:
         Tuple of (max_drawdowns, current_drawdowns). For a DataFrame input, both
-        elements are 1-D ndarrays indexed by column. For a Series input, both
-        elements are scalar floats.
+        elements are 1-D floating ndarrays indexed by column. For a Series input,
+        both elements are scalar floats.
     """
     max_dd_data = compute_rolling_drawdowns(prices=prices)
-    # fmin.reduce keeps nanmin's finite results but does not warn for an all-NaN slice.
+    # Normalize pd.NA before NumPy reduction while retaining warning-free all-NaN semantics.
+    max_dd_values = max_dd_data.to_numpy(dtype=float, na_value=np.nan)
     if isinstance(prices, pd.DataFrame):
-        max_dds = np.fmin.reduce(max_dd_data.to_numpy(), axis=0)
-        current_dds = max_dd_data.iloc[-1, :].to_numpy()
+        max_dds = np.fmin.reduce(max_dd_values, axis=0)
+        current_dds = max_dd_values[-1, :]
     else:
         # Series case: return scalars (not arrays) to match the actual return shape.
-        max_dds = float(np.fmin.reduce(max_dd_data.to_numpy()))
-        current_dds = float(max_dd_data.iloc[-1])
+        max_dds = float(np.fmin.reduce(max_dd_values))
+        current_dds = float(max_dd_values[-1])
     return max_dds, current_dds
 
 

--- a/src/qis/perfstats/tests/drawdown_nullable_ragged_test.py
+++ b/src/qis/perfstats/tests/drawdown_nullable_ragged_test.py
@@ -1,0 +1,142 @@
+"""Regression coverage for nullable maximum and current drawdown reductions.
+
+Drawdown values depend on each column's running peak and observed price history, not on pandas'
+missing-value representation or neighboring column states. The mixed panels below exercise every
+material missingness shape together and independently state the expected reductions.
+"""
+
+import warnings
+from typing import cast
+
+import numpy as np
+import pandas as pd
+from numpy.typing import NDArray
+
+# qis
+from qis.perfstats.config import PerfParams, PerfStat
+from qis.perfstats.perf_stats import compute_max_current_drawdown, compute_risk_table
+
+
+_DATES = pd.date_range("2023-01-31", periods=8, freq="ME")
+_COLUMNS = ("complete", "leading", "interior", "trailing", "missing")
+_EXPECTED_MAXIMUM = np.asarray((-0.25, -0.20, -0.20, -0.20, np.nan), dtype=float)
+_EXPECTED_CURRENT = np.asarray((-0.25, -1.0 / 13.0, -1.0 / 6.0, 0.0, np.nan), dtype=float)
+
+
+def _ordinary_mixed_prices() -> pd.DataFrame:
+    """Create complete, ragged, and all-missing price histories in one panel.
+
+    Returns:
+        Ordinary floating price panel with independently calculable drawdowns.
+    """
+    return pd.DataFrame(
+        {
+            "complete": (100.0, 90.0, 80.0, 100.0, 120.0, 110.0, 100.0, 90.0),
+            "leading": (np.nan, np.nan, 100.0, 80.0, 120.0, 110.0, 130.0, 120.0),
+            "interior": (100.0, 90.0, np.nan, 80.0, 120.0, np.nan, 110.0, 100.0),
+            "trailing": (100.0, 90.0, 80.0, 120.0, np.nan, np.nan, np.nan, np.nan),
+            "missing": (np.nan,) * len(_DATES),
+        },
+        index=_DATES,
+    )
+
+
+def _column_name(perf_stat: PerfStat) -> str:
+    """Return the typed full label carried by a performance statistic."""
+    name = perf_stat.value.name
+    if not isinstance(name, str):
+        raise TypeError(f"expected a string column label, got {type(name)!r}")
+    return name
+
+
+def _assert_drawdown_arrays(
+    maximum_drawdowns: object,
+    current_drawdowns: object,
+) -> None:
+    """Compare public drawdown arrays with the independent positional reference.
+
+    Args:
+        maximum_drawdowns: Public maximum-drawdown result.
+        current_drawdowns: Public current-drawdown result.
+    """
+    assert isinstance(maximum_drawdowns, np.ndarray)
+    assert isinstance(current_drawdowns, np.ndarray)
+    maximum_array = cast(NDArray[np.float64], maximum_drawdowns)
+    current_array = cast(NDArray[np.float64], current_drawdowns)
+    assert maximum_array.dtype == np.dtype(float)
+    assert current_array.dtype == np.dtype(float)
+    np.testing.assert_allclose(maximum_array, _EXPECTED_MAXIMUM, equal_nan=True)
+    np.testing.assert_allclose(current_array, _EXPECTED_CURRENT, equal_nan=True)
+
+
+def test_compute_max_current_drawdown_normalizes_nullable_mixed_panels() -> None:
+    """Match ordinary, nullable, and mixed-storage drawdowns without warnings.
+
+    Complete, leading, interior, trailing, and all-missing columns remain independent when pandas
+    nullable columns introduce ``pd.NA`` at the NumPy reduction boundary. The result order follows
+    the input columns, and normalization must not mutate caller-owned data.
+    """
+    ordinary_prices = _ordinary_mixed_prices()
+    nullable_prices = ordinary_prices.astype("Float64")
+    mixed_prices = ordinary_prices.astype(
+        {"leading": "Float64", "trailing": "Float64", "missing": "Float64"}
+    )
+
+    for prices in (ordinary_prices, nullable_prices, mixed_prices):
+        original_prices = prices.copy(deep=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            maximum_drawdowns, current_drawdowns = compute_max_current_drawdown(prices=prices)
+
+        _assert_drawdown_arrays(maximum_drawdowns, current_drawdowns)
+        pd.testing.assert_frame_equal(prices, original_prices)
+
+
+def test_compute_max_current_drawdown_normalizes_nullable_all_missing_series() -> None:
+    """Return scalar NaNs for an all-missing nullable Series without warnings."""
+    prices = pd.Series(
+        pd.array([pd.NA] * len(_DATES), dtype="Float64"), index=_DATES, name="missing"
+    )
+    original_prices = prices.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        maximum_drawdown, current_drawdown = compute_max_current_drawdown(prices=prices)
+
+    assert isinstance(maximum_drawdown, float)
+    assert isinstance(current_drawdown, float)
+    assert np.isnan(maximum_drawdown)
+    assert np.isnan(current_drawdown)
+    pd.testing.assert_series_equal(prices, original_prices)
+
+
+def test_compute_risk_table_reports_nullable_mixed_drawdowns() -> None:
+    """Carry normalized drawdowns through the public risk-table consumer."""
+    prices = _ordinary_mixed_prices().astype("Float64")
+    original_prices = prices.copy(deep=True)
+
+    table = compute_risk_table(
+        prices=prices,
+        perf_params=PerfParams(freq_vol="ME", freq_drawdown="ME", freq_skewness="ME"),
+    )
+
+    assert tuple(table.index) == _COLUMNS
+    maximum_values = cast(
+        NDArray[np.float64],
+        table[_column_name(PerfStat.MAX_DD)].to_numpy(dtype=float, na_value=np.nan),
+    )
+    current_values = cast(
+        NDArray[np.float64],
+        table[_column_name(PerfStat.CURRENT_DD)].to_numpy(dtype=float, na_value=np.nan),
+    )
+    np.testing.assert_allclose(
+        maximum_values,
+        _EXPECTED_MAXIMUM,
+        equal_nan=True,
+    )
+    np.testing.assert_allclose(
+        current_values,
+        _EXPECTED_CURRENT,
+        equal_nan=True,
+    )
+    pd.testing.assert_frame_equal(prices, original_prices)

--- a/src/qis/perfstats/tests/drawdown_nullable_ragged_test.py
+++ b/src/qis/perfstats/tests/drawdown_nullable_ragged_test.py
@@ -19,6 +19,8 @@ from qis.perfstats.perf_stats import compute_max_current_drawdown, compute_risk_
 
 _DATES = pd.date_range("2023-01-31", periods=8, freq="ME")
 _COLUMNS = ("complete", "leading", "interior", "trailing", "missing")
+_EXPECTED_WORST = np.asarray((-1.0 / 9.0, -0.20, -0.10, -1.0 / 9.0, np.nan), dtype=float)
+_EXPECTED_BEST = np.asarray((0.25, 0.50, 0.50, 0.50, np.nan), dtype=float)
 _EXPECTED_MAXIMUM = np.asarray((-0.25, -0.20, -0.20, -0.20, np.nan), dtype=float)
 _EXPECTED_CURRENT = np.asarray((-0.25, -1.0 / 13.0, -1.0 / 6.0, 0.0, np.nan), dtype=float)
 
@@ -111,7 +113,7 @@ def test_compute_max_current_drawdown_normalizes_nullable_all_missing_series() -
 
 
 def test_compute_risk_table_reports_nullable_mixed_drawdowns() -> None:
-    """Carry normalized drawdowns through the public risk-table consumer."""
+    """Carry normalized drawdowns and two-endpoint returns through the risk table."""
     prices = _ordinary_mixed_prices().astype("Float64")
     original_prices = prices.copy(deep=True)
 
@@ -129,6 +131,16 @@ def test_compute_risk_table_reports_nullable_mixed_drawdowns() -> None:
         NDArray[np.float64],
         table[_column_name(PerfStat.CURRENT_DD)].to_numpy(dtype=float, na_value=np.nan),
     )
+    worst_values = cast(
+        NDArray[np.float64],
+        table[_column_name(PerfStat.WORST)].to_numpy(dtype=float, na_value=np.nan),
+    )
+    best_values = cast(
+        NDArray[np.float64],
+        table[_column_name(PerfStat.BEST)].to_numpy(dtype=float, na_value=np.nan),
+    )
+    np.testing.assert_allclose(worst_values, _EXPECTED_WORST, equal_nan=True)
+    np.testing.assert_allclose(best_values, _EXPECTED_BEST, equal_nan=True)
     np.testing.assert_allclose(
         maximum_values,
         _EXPECTED_MAXIMUM,


### PR DESCRIPTION
## What changed

Normalize nullable missing values at the public maximum/current drawdown reduction boundary.

The ordinary mixed panel returns independently expected drawdowns, but the identical nullable `Float64` panel retains `pd.NA`; object conversion followed by `np.fmin.reduce()` raises `TypeError: boolean value of NA is ambiguous`.

## Behavior

Ordinary and nullable representations of the same ragged price history return equivalent maximum/current drawdowns with stable public scalar/array types.

## Regression evidence

The formatted permanent regression failed on accepted `upstream/main` `05b2bd50`: all-nullable and mixed-storage DataFrames raised `TypeError: boolean value of NA is ambiguous`, an all-missing nullable Series raised `TypeError` while converting `pd.NA` to `float`, and `compute_risk_table()` reached the same DataFrame failure. A fully observed nullable panel already returned floating arrays; object storage arose only in missing-data combinations.

## Verification

- Focused regression: 3 passed after the same 3 tests failed before the fix.
- Complete affected subsystem: 811 perfstats tests passed.
- Final full suite: 2943 tests passed with 18 expected warnings in 301.33 seconds.
- Static, documentation, API, dependency, or build checks: Changed-line Ruff found 0 violations; differential Pyright 1.1.411 found 0 unapproved diagnostics and classified 66 diagnostics as inherited or indirect; new-file Ruff formatting passed, while baseline-aware formatting confirmed that `perf_stats.py` retains inherited format debt without a PR-attributable change; the local typed-label helper avoids partially unknown `PerfStat.to_str()` calls in the new test; interrogate passed at 73.0%; `PUBLIC_API` is current at 430 names; all 85 installed packages are compatible; `git diff --check` passed; and both the Sphinx HTML and link-check builds passed with warnings treated as errors.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/perfstats/perf_stats.py`, and `src/qis/perfstats/tests/drawdown_nullable_ragged_test.py`.

Out of scope: Benchmark-drop forwarding, terminated risk support, and unrelated regime logic.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.