### PR TITLE
fix: honor benchmark drops in regime plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Honored `drop_benchmark` in rendered regime plots while retaining the benchmark in classifier
+  component tables used by other analytical callers.
+
 - Normalized nullable floating drawdowns before maximum and current reductions so ragged
   `Float64` price histories match ordinary floating inputs without ambiguous `pd.NA` failures;
   risk-table best and worst returns now preserve missing price gaps consistently across pandas

--- a/src/qis/plots/derived/regime_data.py
+++ b/src/qis/plots/derived/regime_data.py
@@ -55,10 +55,17 @@ def plot_regime_data(regime_classifier: RegimeClassifier,
     on the sampled simple returns, so the regime bars sum to the total arithmetic
     Sharpe ratio exactly; LOG is the analog on log(1+r). The additive conventions
     are the natural choice for regime attribution.
+
+    Args:
+        drop_benchmark: Exclude the benchmark from the rendered regime bars while leaving the
+            classifier's component tables unchanged.
     """
     regimes_pa_perf_table, regime_datas = regime_classifier.compute_regimes_pa_perf_table(drop_benchmark=drop_benchmark,
                                                                                           **kwargs)
     data = regime_datas[regime_data_to_plot]
+    if drop_benchmark:
+        # Apply final-table membership without reindexing possibly repeated asset labels.
+        data = data.loc[data.index.isin(regimes_pa_perf_table.index)]
     data = data.dropna(how='all', axis=0)  # remove data wit all rows nans
 
     if drop_sharpe_from_labels:

--- a/src/qis/plots/tests/regime_plot_drop_benchmark_test.py
+++ b/src/qis/plots/tests/regime_plot_drop_benchmark_test.py
@@ -1,0 +1,233 @@
+"""Regression coverage for benchmark removal from regime plots.
+
+Regime classifiers intentionally retain the benchmark in their component tables even when the
+final presentation table drops it. The public ``plot_regime_data()`` option must apply that final
+row selection at the renderer boundary without changing component data, regime columns, colors,
+totals, or caller-owned state.
+
+A deterministic classifier double isolates the accepted final-table/component-table distinction.
+The matrix covers every ``RegimeData`` selection, both bar renderers, and enabled/disabled
+benchmark removal. A nullable component table also reaches a warning-strict canvas draw so the
+assertion protects the user-visible plot rather than only the intermediate artist construction.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Protocol, cast
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+import qis.plots.bars as bars_module
+import qis.plots.derived.regime_data as regime_data_module
+from qis.perfstats.config import RegimeData
+
+
+class _RegimeClassifierProtocol(Protocol):
+    """Test-side interface used by the regime-plot boundary."""
+
+    def compute_regimes_pa_perf_table(
+        self,
+        *,
+        drop_benchmark: bool,
+        **kwargs: object,
+    ) -> tuple[pd.DataFrame, dict[RegimeData, pd.DataFrame]]:
+        """Return the final presentation table and its component tables."""
+        raise NotImplementedError
+
+    def get_regime_ids_colors(self) -> dict[str, str]:
+        """Return the ordered regime-color mapping."""
+        raise NotImplementedError
+
+
+class _RegimeDataModuleProtocol(Protocol):
+    """Typed test-side interface for the public plot helper."""
+
+    def plot_regime_data(
+        self,
+        *,
+        regime_classifier: _RegimeClassifierProtocol,
+        regime_data_to_plot: RegimeData,
+        drop_benchmark: bool,
+        is_use_vbar: bool,
+        add_bar_values: bool = True,
+        ax: Axes | None = None,
+    ) -> Figure:
+        """Render one selected regime component table."""
+        raise NotImplementedError
+
+
+_REGIME_DATA_MODULE = cast(_RegimeDataModuleProtocol, regime_data_module)
+
+
+# =============================================================================
+# Deterministic classifier boundary and independent expectations
+# =============================================================================
+
+_ASSET_A = "Asset A"
+_ASSET_B = "Asset B"
+_BENCHMARK = "Benchmark"
+_EXPECTED_COLORS = ("#a50026", "#006837")
+_INDEX = pd.Index((_BENCHMARK, _ASSET_A, _ASSET_B), name="Instrument")
+
+_COLUMNS = {
+    RegimeData.REGIME_AVG: ("Bear Average", "Bull Average"),
+    RegimeData.REGIME_PA: ("Bear P.a.", "Bull P.a."),
+    RegimeData.REGIME_SHARPE: ("Bear Sharpe", "Bull Sharpe"),
+}
+
+
+class _RegimeClassifier:
+    """Expose filtered final rows beside deliberately unfiltered components."""
+
+    def __init__(self) -> None:
+        self.calls: list[bool] = []
+        self.components = {
+            regime_data: pd.DataFrame(
+                {
+                    columns[0]: pd.array((0.01, 0.02, 0.03), dtype="Float64"),
+                    columns[1]: pd.array((0.04, 0.05, 0.06), dtype="Float64"),
+                },
+                index=_INDEX,
+            )
+            for regime_data, columns in _COLUMNS.items()
+        }
+
+    def compute_regimes_pa_perf_table(
+        self,
+        *,
+        drop_benchmark: bool,
+        **kwargs: object,
+    ) -> tuple[pd.DataFrame, dict[RegimeData, pd.DataFrame]]:
+        """Apply benchmark removal only to the final presentation table."""
+        del kwargs
+        self.calls.append(drop_benchmark)
+        final_labels = (_ASSET_A, _ASSET_B) if drop_benchmark else (_BENCHMARK, _ASSET_A, _ASSET_B)
+        final_table = pd.DataFrame(
+            {"Summary": pd.array((1.0,) * len(final_labels), dtype="Float64")},
+            index=pd.Index(final_labels, name=_INDEX.name),
+        )
+        return final_table, self.components
+
+    def get_regime_ids_colors(self) -> dict[str, str]:
+        """Return colors in the same order as the component columns."""
+        return {"Bear": _EXPECTED_COLORS[0], "Bull": _EXPECTED_COLORS[1]}
+
+
+def _expected_component(
+    classifier: _RegimeClassifier,
+    regime_data: RegimeData,
+    *,
+    drop_benchmark: bool,
+) -> pd.DataFrame:
+    """Select expected rows independently from the plotting implementation."""
+    rows = (_ASSET_A, _ASSET_B) if drop_benchmark else (_BENCHMARK, _ASSET_A, _ASSET_B)
+    return classifier.components[regime_data].loc[list(rows)]
+
+
+# =============================================================================
+# Renderer boundary and user-visible canvas contract
+# =============================================================================
+
+
+@pytest.mark.parametrize("regime_data", tuple(RegimeData))
+@pytest.mark.parametrize("is_use_vbar", (False, True))
+@pytest.mark.parametrize("drop_benchmark", (False, True))
+def test_plot_regime_data_applies_final_row_membership_at_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+    regime_data: RegimeData,
+    is_use_vbar: bool,
+    drop_benchmark: bool,
+) -> None:
+    """Pass exact filtered rows and row-derived totals to either renderer."""
+    classifier = _RegimeClassifier()
+    original_components = {
+        key: value.copy(deep=True) for key, value in classifier.components.items()
+    }
+    captured_data: list[pd.DataFrame] = []
+    captured_colors: list[tuple[str, ...]] = []
+    captured_totals: list[np.ndarray] = []
+    figure = plt.figure()
+
+    def capture_renderer(
+        *,
+        df: pd.DataFrame,
+        colors: list[str],
+        totals: np.ndarray,
+        **kwargs: object,
+    ) -> Figure:
+        """Capture the final renderer boundary without invoking Matplotlib."""
+        del kwargs
+        captured_data.append(df.copy(deep=True))
+        captured_colors.append(tuple(colors))
+        captured_totals.append(np.asarray(totals, dtype=float))
+        return figure
+
+    renderer = "plot_vbars" if is_use_vbar else "plot_bars"
+    monkeypatch.setattr(bars_module, renderer, capture_renderer)
+    try:
+        actual_figure = _REGIME_DATA_MODULE.plot_regime_data(
+            regime_classifier=classifier,
+            regime_data_to_plot=regime_data,
+            drop_benchmark=drop_benchmark,
+            is_use_vbar=is_use_vbar,
+        )
+
+        expected = _expected_component(
+            classifier,
+            regime_data,
+            drop_benchmark=drop_benchmark,
+        )
+        assert actual_figure is figure
+        assert classifier.calls == [drop_benchmark]
+        assert len(captured_data) == 1
+        pd.testing.assert_frame_equal(captured_data[0], expected)
+        assert captured_colors == [_EXPECTED_COLORS]
+        np.testing.assert_allclose(
+            captured_totals[0],
+            np.sum(expected.to_numpy(dtype=float), axis=1),
+            rtol=0.0,
+            atol=0.0,
+        )
+        for key, original in original_components.items():
+            pd.testing.assert_frame_equal(classifier.components[key], original)
+    finally:
+        plt.close(figure)
+
+
+@pytest.mark.parametrize("regime_data", tuple(RegimeData))
+@pytest.mark.parametrize("is_use_vbar", (False, True))
+def test_plot_regime_data_drops_benchmark_on_rendered_canvas(
+    regime_data: RegimeData,
+    is_use_vbar: bool,
+) -> None:
+    """Exclude the benchmark from a warning-strict nullable-data canvas render."""
+    classifier = _RegimeClassifier()
+    original_components = {
+        key: value.copy(deep=True) for key, value in classifier.components.items()
+    }
+    figure, axis = plt.subplots()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _REGIME_DATA_MODULE.plot_regime_data(
+                regime_classifier=classifier,
+                regime_data_to_plot=regime_data,
+                drop_benchmark=True,
+                is_use_vbar=is_use_vbar,
+                add_bar_values=False,
+                ax=axis,
+            )
+            figure.canvas.draw()
+
+        label_axis = axis.get_yticklabels() if is_use_vbar else axis.get_xticklabels()
+        assert [label.get_text() for label in label_axis] == [_ASSET_A, _ASSET_B]
+        for key, original in original_components.items():
+            pd.testing.assert_frame_equal(classifier.components[key], original)
+    finally:
+        plt.close(figure)


### PR DESCRIPTION
## What changed

Make `plot_regime_data(drop_benchmark=True)` remove the benchmark from the component table actually sent to the renderer.

The helper forwards `drop_benchmark` to the classifier but discards the returned final table and renders an unchanged component from `regime_datas`; a sentinel still passed `['Benchmark', 'Asset']` to `plot_bars()`.

## Behavior

The public plotting option controls rendered benchmark membership for every classifier without changing analytical component tables returned elsewhere.

## Regression evidence

A disposable 48-cell renderer-boundary matrix crossed return-quantile, return-sign, volatility-quantile, and nullable component-table cases with all three `RegimeData` modes, both bar renderers, and `drop_benchmark=False/True`. All 24 true cells retained `Benchmark`; every false control retained the intended two-row input. Six warning-strict real canvas draws across all data modes and both renderers also visibly retained the benchmark.

## Verification

- Focused regression: Before the fix, `12 failed, 6 passed`: all six true renderer cases and all six true canvas cases retained the benchmark, while every false renderer control passed. The final post-refresh focused set, including both accepted classifier-control modules, passed `28 passed`.
- Accepted classifier controls: `10 passed` in the supplied-classifier forwarding and volatility benchmark-drop modules; a warning-strict 36-cell real-classifier matrix also passed after the fix.
- Complete affected subsystem: `434 passed` in `src/qis/plots/tests/`.
- Final full suite: `2962 passed, 18 warnings` in 294.60 seconds.
- Static, documentation, API, dependency, or build checks: Added-line Ruff clean; differential Pyright reported 0 attributable diagnostics and 92 inherited or indirect diagnostics; the new Python file is Ruff-format clean; the existing production module retains only accepted baseline format debt; Interrogate passed at 73.0%; both warning-as-error Sphinx HTML and linkcheck builds passed; `PUBLIC_API` is current at 430 names; `uv pip check` found all 85 packages compatible; `git diff --check` passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/plots/derived/regime_data.py`, and `src/qis/plots/tests/regime_plot_drop_benchmark_test.py`; clarify the public option in the callable docstring rather than adding a separate documentation page.

Out of scope: Changing analytical component tables, classifier final-table semantics, duplicate asset-label policy, and unrelated options. A separate probe found that finite nullable `Float64` regime panels emit two statsmodels-bound warnings and replace valid alpha/beta/R2 results with zeros; retain that evidence under the nullable compatibility audit rather than broadening PR 92.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.