### PR TITLE
fix: support Series price bootstrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Supported Series price bootstrapping in both output modes and restored log-return reconstruction
+  for list outputs, with consistent first- or last-price anchoring across one-asset containers.
+
 - Honored `drop_benchmark` in rendered regime plots while retaining the benchmark in classifier
   component tables used by other analytical callers.
 

--- a/src/qis/models/bootstrap/bootstrap_numba.py
+++ b/src/qis/models/bootstrap/bootstrap_numba.py
@@ -35,10 +35,12 @@ import pandas as pd
 from enum import Enum
 from numba import njit
 from numba.typed import List
-from typing import Union, Tuple, Dict
+from typing import Union, Tuple, Dict, cast
 # qis
 import qis.utils.np_ops as npo
 import qis.perfstats.returns as ret
+
+FloatArray = np.ndarray[tuple[int, ...], np.dtype[np.float64]]
 
 
 class BootstrapType(Enum):
@@ -474,9 +476,10 @@ def bootstrap_price_data(prices: Union[pd.Series, pd.DataFrame],
     continuous price series with the return distribution of the original.
 
     Args:
-        prices: price levels, one column per asset
+        prices: Price levels. A Series represents one asset; a DataFrame has one column per asset.
         bootstrap_type: resampling scheme; see :class:`BootstrapType`
-        bootstrap_output: shape of the result; see :class:`BootstrapOutput`
+        bootstrap_output: Shape of the result; see :class:`BootstrapOutput`. Series input supports
+            either output mode; ``DF_TO_LIST_ARRAYS`` returns one-column arrays for that case.
         num_samples: number of independent draws
         index_length: length of each draw
         block_size: mean block length for STATIONARY, exact length for FIXED_BLOCK. 1 is IID
@@ -488,11 +491,15 @@ def bootstrap_price_data(prices: Union[pd.Series, pd.DataFrame],
             today. False starts them from the first price, so the draws are alternative histories
 
     Returns:
-        a DataFrame of paths for SERIES_TO_DF, or a list of arrays for DF_TO_LIST_ARRAYS
+        A DataFrame of paths for SERIES_TO_DF, or a list of arrays for DF_TO_LIST_ARRAYS.
     """
     returns = ret.to_returns(prices=prices, is_log_returns=is_log_returns, drop_first=True)
 
-    bootstrap_returns = bootstrap_data(data=returns,
+    # The list-output Numba kernel always consumes a rows-by-assets matrix, including one asset.
+    bootstrap_input = returns.to_frame() if (
+        bootstrap_output == BootstrapOutput.DF_TO_LIST_ARRAYS and isinstance(returns, pd.Series)
+    ) else returns
+    bootstrap_returns = bootstrap_data(data=bootstrap_input,
                                        bootstrap_type=bootstrap_type,
                                        bootstrap_output=bootstrap_output,
                                        num_samples=num_samples,
@@ -503,23 +510,43 @@ def bootstrap_price_data(prices: Union[pd.Series, pd.DataFrame],
                                        bootstrapped_indices=bootstrapped_indices)
 
     if bootstrap_output == BootstrapOutput.DF_TO_LIST_ARRAYS:
-        if init_to_end:
-            init_value = prices.iloc[-1, :].to_numpy()
+        # Select by position and retain a one-dimensional asset vector for NumPy broadcasting.
+        init_position = -1 if init_to_end else 0
+        init_value: FloatArray
+        if isinstance(prices, pd.Series):
+            init_value = cast(
+                FloatArray,
+                prices.iloc[[init_position]].to_numpy(dtype=np.float64, na_value=np.nan),
+            )
         else:
-            init_value = prices.iloc[0, :].to_numpy()
+            init_value = cast(
+                FloatArray,
+                prices.iloc[[init_position], :]
+                .to_numpy(dtype=np.float64, na_value=np.nan)
+                .reshape(-1),
+            )
 
         bootstrap_sample = List()
-        for returns in bootstrap_returns:
+        for sampled_returns in bootstrap_returns:
+            assert isinstance(sampled_returns, np.ndarray)
+            sampled_returns_float: FloatArray = sampled_returns.astype(np.float64, copy=False)
+            # Unlike log_returns_to_nav(), this path supports NumPy arrays and pandas objects.
             if is_log_returns:
-                bootstrap_sample.append(ret.log_returns_to_nav(log_returns=returns, init_value=init_value))
+                bootstrap_sample.append(ret.returns_to_nav(returns=sampled_returns_float,
+                                                           init_value=init_value,
+                                                           is_log_returns=True))
             else:
-                bootstrap_sample.append(ret.returns_to_nav(returns=returns, init_value=init_value))
+                bootstrap_sample.append(ret.returns_to_nav(returns=sampled_returns_float,
+                                                           init_value=init_value))
 
     elif bootstrap_output == BootstrapOutput.SERIES_TO_DF:
-        if init_to_end:
-            init_value = prices[-1]*np.ones(num_samples)
-        else:
-            init_value = prices[0]*np.ones(num_samples)
+        assert isinstance(prices, pd.Series)
+        init_position = -1 if init_to_end else 0
+        price_anchor = cast(
+            FloatArray,
+            prices.iloc[[init_position]].to_numpy(dtype=np.float64, na_value=np.nan),
+        )
+        init_value = np.repeat(price_anchor, num_samples)
 
         if is_log_returns:
             bootstrap_sample = ret.log_returns_to_nav(log_returns=bootstrap_returns, init_value=init_value)

--- a/src/qis/models/bootstrap/tests/bootstrap_price_series_test.py
+++ b/src/qis/models/bootstrap/tests/bootstrap_price_series_test.py
@@ -1,0 +1,217 @@
+"""Price-bootstrap container and reconstruction boundary regressions.
+
+``bootstrap_price_data`` accepts a Series or DataFrame and exposes two output containers. Fixed
+sample indexes isolate container normalization and price reconstruction from the random bootstrap
+kernels, while independent arithmetic and logarithmic formulas verify both return conventions.
+The matrix also covers both documented price anchors and ordinary versus nullable finite storage.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+# packages
+import numpy as np
+import pandas as pd
+import pytest
+
+# qis / project
+from qis.models.bootstrap.bootstrap_numba import BootstrapOutput, bootstrap_price_data
+
+FloatArray = np.ndarray[tuple[int, ...], np.dtype[np.float64]]
+IntArray = np.ndarray[tuple[int, ...], np.dtype[np.int64]]
+
+PRICE_VALUES: FloatArray = np.array([100.0, 102.0, 101.0, 104.0, 106.0], dtype=np.float64)
+SAMPLE_INDEXES: IntArray = np.array([[0, 3], [1, 2], [2, 1], [3, 0]], dtype=np.int64)
+PATH_COLUMNS = ["path_1", "path_2"]
+
+
+def _price_series(*, nullable: bool) -> pd.Series:
+    """Construct the same named dated prices with ordinary or nullable finite storage.
+
+    Args:
+        nullable: Whether to use pandas' nullable floating-point dtype.
+
+    Returns:
+        Finite price Series used by every container and reconstruction case.
+    """
+    prices = pd.Series(
+        PRICE_VALUES,
+        index=pd.date_range("2024-01-01", periods=len(PRICE_VALUES), freq="D"),
+        name="Asset",
+    )
+    if nullable:
+        prices = prices.astype(pd.Float64Dtype())
+    return prices
+
+
+def _expected_price_paths(
+    prices: pd.Series, *, is_log_returns: bool, init_to_end: bool
+) -> np.ndarray:
+    """Reconstruct fixed sampled paths without using QIS return or NAV helpers.
+
+    Args:
+        prices: Source price history.
+        is_log_returns: Whether to reconstruct from logarithmic rather than arithmetic returns.
+        init_to_end: Whether to anchor the generated paths to the final source price.
+
+    Returns:
+        Expected rows-by-paths price matrix.
+    """
+    values = prices.to_numpy(dtype=float, na_value=np.nan)
+    if is_log_returns:
+        source_returns = np.diff(np.log(values))
+        sampled_growth = np.exp(np.cumsum(source_returns[SAMPLE_INDEXES], axis=0))
+    else:
+        source_returns = values[1:] / values[:-1] - 1.0
+        sampled_growth = np.cumprod(1.0 + source_returns[SAMPLE_INDEXES], axis=0)
+
+    # The first sampled return establishes scale; subsequent returns evolve from the chosen anchor.
+    anchor = values[-1] if init_to_end else values[0]
+    return sampled_growth * (anchor / sampled_growth[0, :])
+
+
+def _bootstrap_list(
+    prices: pd.Series | pd.DataFrame, *, is_log_returns: bool, init_to_end: bool
+) -> object:
+    """Call the public list-output path with the fixed cross-container fixture.
+
+    Args:
+        prices: Series or one-column DataFrame representation.
+        is_log_returns: Whether to reconstruct logarithmic returns.
+        init_to_end: Whether to anchor paths to the final source price.
+
+    Returns:
+        Public list-output result retained as an object for explicit runtime narrowing.
+    """
+    return bootstrap_price_data(
+        prices=prices,
+        bootstrap_output=BootstrapOutput.DF_TO_LIST_ARRAYS,
+        num_samples=len(PATH_COLUMNS),
+        index_length=len(SAMPLE_INDEXES),
+        is_log_returns=is_log_returns,
+        bootstrapped_indices=SAMPLE_INDEXES,
+        init_to_end=init_to_end,
+    )
+
+
+def _list_result_to_matrix(result: object) -> FloatArray:
+    """Stack a list-output result into the rows-by-paths reference shape.
+
+    Args:
+        result: Public bootstrap result expected to contain one-column NumPy paths.
+
+    Returns:
+        Matrix with one generated path per column.
+    """
+    assert isinstance(result, Iterable)
+    assert not isinstance(result, (pd.DataFrame, pd.Series))
+    paths: list[FloatArray] = []
+    for path in result:
+        assert isinstance(path, np.ndarray)
+        path_float: FloatArray = path.astype(np.float64, copy=False)
+        paths.append(path_float)
+    assert [path.shape for path in paths] == [(len(SAMPLE_INDEXES), 1)] * len(PATH_COLUMNS)
+    return np.column_stack([path[:, 0] for path in paths])
+
+
+@pytest.mark.parametrize("nullable", [False, True])
+@pytest.mark.parametrize("is_log_returns", [False, True])
+@pytest.mark.parametrize("init_to_end", [False, True])
+def test_bootstrap_price_data_supports_series_to_dataframe(
+    nullable: bool, is_log_returns: bool, init_to_end: bool
+) -> None:
+    """Use positional anchors and preserve Series input across reconstruction conventions."""
+    prices = _price_series(nullable=nullable)
+    original = prices.copy(deep=True)
+    expected = _expected_price_paths(prices, is_log_returns=is_log_returns, init_to_end=init_to_end)
+
+    actual = bootstrap_price_data(
+        prices=prices,
+        bootstrap_output=BootstrapOutput.SERIES_TO_DF,
+        num_samples=len(PATH_COLUMNS),
+        index_length=len(SAMPLE_INDEXES),
+        is_log_returns=is_log_returns,
+        bootstrapped_indices=SAMPLE_INDEXES,
+        init_to_end=init_to_end,
+    )
+
+    assert isinstance(actual, pd.DataFrame)
+    assert actual.columns.tolist() == PATH_COLUMNS
+    np.testing.assert_allclose(actual.to_numpy(), expected, rtol=1e-13, atol=1e-13)
+    pd.testing.assert_series_equal(prices, original)
+
+
+@pytest.mark.parametrize("nullable", [False, True])
+@pytest.mark.parametrize("is_log_returns", [False, True])
+@pytest.mark.parametrize("init_to_end", [False, True])
+def test_bootstrap_price_data_preserves_one_column_list_parity(
+    nullable: bool, is_log_returns: bool, init_to_end: bool
+) -> None:
+    """Return equivalent one-column list paths for Series and DataFrame representations."""
+    prices = _price_series(nullable=nullable)
+    frame = prices.to_frame()
+    original_series = prices.copy(deep=True)
+    original_frame = frame.copy(deep=True)
+    expected = _expected_price_paths(prices, is_log_returns=is_log_returns, init_to_end=init_to_end)
+    frame_result = _bootstrap_list(frame, is_log_returns=is_log_returns, init_to_end=init_to_end)
+    series_result = _bootstrap_list(prices, is_log_returns=is_log_returns, init_to_end=init_to_end)
+    frame_matrix = _list_result_to_matrix(frame_result)
+    series_matrix = _list_result_to_matrix(series_result)
+
+    np.testing.assert_allclose(frame_matrix, expected, rtol=1e-13, atol=1e-13)
+    np.testing.assert_allclose(series_matrix, expected, rtol=1e-13, atol=1e-13)
+    pd.testing.assert_series_equal(prices, original_series)
+    pd.testing.assert_frame_equal(frame, original_frame)
+
+
+def test_bootstrap_price_data_reconstructs_multi_asset_log_list() -> None:
+    """Reconstruct distinct panel columns without pandas-only NumPy accumulation arguments."""
+    prices = pd.DataFrame(
+        {
+            "Asset": PRICE_VALUES,
+            "Second": np.array([50.0, 49.0, 51.0, 50.0, 52.0]),
+        },
+        index=pd.date_range("2024-01-01", periods=len(PRICE_VALUES), freq="D"),
+    )
+    original = prices.copy(deep=True)
+    expected = np.stack(
+        [
+            _expected_price_paths(column, is_log_returns=True, init_to_end=True)
+            for _, column in prices.items()
+        ],
+        axis=2,
+    )
+
+    result = _bootstrap_list(prices, is_log_returns=True, init_to_end=True)
+
+    assert isinstance(result, Iterable)
+    assert not isinstance(result, (pd.DataFrame, pd.Series))
+    paths: list[FloatArray] = []
+    for path in result:
+        assert isinstance(path, np.ndarray)
+        path_float: FloatArray = path.astype(np.float64, copy=False)
+        paths.append(path_float)
+    assert [path.shape for path in paths] == [(len(SAMPLE_INDEXES), len(prices.columns))] * len(
+        PATH_COLUMNS
+    )
+    for path_index, path in enumerate(paths):
+        np.testing.assert_allclose(path, expected[:, path_index, :], rtol=1e-13, atol=1e-13)
+    pd.testing.assert_frame_equal(prices, original)
+
+
+def test_bootstrap_price_data_rejects_dataframe_for_series_output_without_mutation() -> None:
+    """Retain the established one-Series-only contract of ``SERIES_TO_DF``."""
+    prices = _price_series(nullable=False).to_frame()
+    original = prices.copy(deep=True)
+
+    with pytest.raises(ValueError, match="data must be series"):
+        bootstrap_price_data(
+            prices=prices,
+            bootstrap_output=BootstrapOutput.SERIES_TO_DF,
+            num_samples=len(PATH_COLUMNS),
+            index_length=len(SAMPLE_INDEXES),
+            bootstrapped_indices=SAMPLE_INDEXES,
+        )
+
+    pd.testing.assert_frame_equal(prices, original)


### PR DESCRIPTION
## What changed

Make `bootstrap_price_data()` honor its documented Series input for both output modes.

With a named five-date finite price Series and fixed bootstrap indexes, `SERIES_TO_DF` raises `KeyError` at `prices[0]` or `prices[-1]` under pandas 3.0 for both simple and log returns. `DF_TO_LIST_ARRAYS` sends the Series' one-dimensional array to a two-dimensional Numba index and raises `TypingError`. The equivalent one-column DataFrame succeeds for simple returns, while its log-return/list path reaches the already-recorded NumPy `log_returns_to_nav()` limitation and raises `TypeError` on `cumsum(skipna=True)`.

## Behavior

A Series and its one-column DataFrame representation produce the same sampled price paths, with the selected Series-to-DataFrame or list-of-one-column-arrays container, for simple and log returns and for first- and last-price anchoring. A DataFrame passed to `SERIES_TO_DF` retains its existing descriptive rejection.

## Regression evidence

The read-only matrix reproduced every failure above with fixed indexes `[[0, 3], [1, 2], [2, 1], [3, 0]]`. Independent arithmetic compounding and log-return exponentiation agreed to `1.42e-14`; for a first-price anchor the expected final rows are `[103.921568627451, 104.0]`, and for a last-price anchor they are `[110.156862745098, 110.24]`.

## Verification

- Focused regression: `18 passed`; the permanent matrix crosses ordinary/nullable Series, both output modes, simple/log returns, and first/last anchors, and includes multi-asset log-list and DataFrame-rejection ownership controls.
- Complete affected subsystem: `111 passed` for `src/qis/models/`.
- Final full suite: `2981 passed, 18 warnings`; warnings were the established Seaborn, Matplotlib, and expected missing-initial-price warnings outside this change.
- Static, documentation, API, dependency, or build checks: Global Pyright 1.1.411 changed-line review reported zero unapproved diagnostics; Ruff reported zero violations on added lines; interrogate passed at 73.0%; `format-new` passed for the new Python test; the public-API record was current at 430 names; all 85 installed packages were compatible; and the targeted core-API and executable-example integration checks passed. The final native changed-line lint gate passed with zero violations on added lines; both Sphinx warning-as-error HTML and linkcheck builds passed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/models/bootstrap/bootstrap_numba.py`, and one focused test.

Out of scope: Bootstrap probability kernels, ragged DataFrame anchors, paired-input validation, and a general public NumPy contract for `log_returns_to_nav()` outside price bootstrapping.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.