### PR TITLE
fix: fill terminal IID bootstrap draws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+**Seeded `BootstrapType.IID` results produced by earlier qis versions may not reproduce exactly.**
+Every draw now samples its terminal row instead of leaving it mapped to source row zero. When
+`(index_length - 1)` is divisible by `num_data_index`, completing that row consumes another random
+batch and also shifts later sample columns.
+
 ### Added
 
 - Added explicit stack dependency and optional-import boundary checks, including

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Filled every requested IID bootstrap position with a random source index instead of leaving the
+  terminal row deterministically mapped to source row zero.
+
 - Supported Series price bootstrapping in both output modes and restored log-return reconstruction
   for list outputs, with consistent first- or last-price anchoring across one-asset containers.
 

--- a/src/qis/models/bootstrap/bootstrap_numba.py
+++ b/src/qis/models/bootstrap/bootstrap_numba.py
@@ -90,16 +90,26 @@ def bootstrap_indices_iid(num_data_index: int,
                           seed: int = 1
                           ) -> np.ndarray:
     """
-    generate iid bootstrap indices
+    generate IID bootstrap indices for every requested output position.
+
+    Args:
+        num_data_index: number of observations in the source data
+        num_samples: number of independent bootstrap draws
+        index_length: number of positions in each draw
+        seed: seed for the numba random state
+
+    Returns:
+        integer indices of shape ``(index_length, num_samples)``
     """
     np.random.seed(seed)
     set_seed(seed)
     bootstrapped_indices = np.zeros((index_length, num_samples), dtype=np.int64)
     for idx in np.arange(num_samples):
         previous_index, next_index = 0, 0
-        while next_index < index_length-1:
+        while next_index < index_length:
             ran_indices = np.random.randint(low=0, high=num_data_index, size=num_data_index)
-            next_index = np.minimum(previous_index+num_data_index, index_length-1)
+            # Truncate only the final random batch, while still filling the complete output.
+            next_index = np.minimum(previous_index+num_data_index, index_length)
             required_fill = next_index - previous_index
             bootstrapped_indices[previous_index:next_index, idx] = ran_indices[:required_fill]
             previous_index = next_index
@@ -303,8 +313,9 @@ def generate_bootstrapped_indices(num_data_index: int,
         seed: seed for the numba random state
 
     Returns:
-        integer indices, shape ``(index_length, num_samples)``, every value in
-        ``[0, num_data_index)``
+        integer indices, shape ``(index_length, num_samples)``, with every requested position
+        populated from ``[0, num_data_index)``; dependence between positions follows
+        ``bootstrap_type``
 
     Raises:
         ValueError: if ``bootstrap_type`` is not one of the implemented schemes

--- a/src/qis/models/bootstrap/tests/bootstrap_iid_terminal_row_test.py
+++ b/src/qis/models/bootstrap/tests/bootstrap_iid_terminal_row_test.py
@@ -1,0 +1,71 @@
+"""Regression tests for complete IID bootstrap draws and their public data mapping.
+
+The IID sampler fills in source-length chunks. A non-multiple output length is the smallest
+boundary that proves the partial final chunk is written and that its random draws advance the
+following sample columns consistently.
+"""
+
+# packages
+import numpy as np
+import pandas as pd
+
+# qis / project
+from qis.models.bootstrap.bootstrap_numba import (
+    BootstrapOutput,
+    BootstrapType,
+    bootstrap_data,
+    generate_bootstrapped_indices,
+)
+
+
+def test_generate_bootstrapped_indices_iid_fills_complete_seeded_draw() -> None:
+    """IID sampling fills first, interior, and terminal rows for every sample column."""
+    actual = generate_bootstrapped_indices(
+        num_data_index=5,
+        bootstrap_type=BootstrapType.IID,
+        num_samples=3,
+        index_length=6,
+        seed=7,
+    )
+    expected = np.array(
+        [
+            [4, 0, 0],
+            [1, 4, 0],
+            [3, 0, 0],
+            [3, 4, 3],
+            [4, 0, 0],
+            [1, 3, 2],
+        ],
+        dtype=np.int64,
+    )
+
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_bootstrap_data_iid_maps_complete_draw_without_mutating_source() -> None:
+    """The public data bootstrap maps the terminal IID row instead of reusing source row zero."""
+    source = pd.Series([10.0, 20.0, 30.0, 40.0, 50.0], name="value")
+    original = source.copy()
+
+    actual = bootstrap_data(
+        data=source,
+        bootstrap_type=BootstrapType.IID,
+        bootstrap_output=BootstrapOutput.SERIES_TO_DF,
+        num_samples=3,
+        index_length=6,
+        seed=7,
+    )
+    expected = pd.DataFrame(
+        [
+            [50.0, 10.0, 10.0],
+            [20.0, 50.0, 10.0],
+            [40.0, 10.0, 10.0],
+            [40.0, 50.0, 40.0],
+            [50.0, 10.0, 10.0],
+            [20.0, 40.0, 30.0],
+        ],
+        columns=["path_1", "path_2", "path_3"],
+    )
+
+    pd.testing.assert_frame_equal(actual, expected)
+    pd.testing.assert_series_equal(source, original)


### PR DESCRIPTION
## What changed

Fill every requested row of an IID bootstrap index array, including the last.

`bootstrap_indices_iid()` loops only while `next_index < index_length - 1`, leaving the preallocated final output row at zero for every sample and seed. With five source rows, three samples, output length six, and seed seven, the accepted kernel returns terminal indexes `[0, 0, 0]`; an independent seeded construction returns `[1, 3, 2]`. The public `bootstrap_data()` path therefore maps every terminal observation to source value `10.0` instead of the independently expected `[20.0, 40.0, 30.0]`.

## Behavior

Every output position is an IID uniform draw over all valid source indexes; no output row has a deterministic source value. The returned shape, valid index range, within-version same-seed repeatability, and row-wise mapping into caller data remain unchanged. Corrected seeded IID sequences may differ from earlier qis versions at the terminal row and in later sample columns when the additional terminal fill consumes another random batch.

## Regression evidence

A temporary probe outside the checkout compared the accepted Numba kernel with an independent `numpy.random.RandomState` loop that fills exactly `index_length` positions. The current final row was `[0, 0, 0]` for seeds zero through four, while the independent seed-seven row was `[1, 3, 2]`; a temporary corrected Numba kernel matched the independent full array for output lengths 1, 2, 5, 6, 10, and 11. The existing 13 focused tests all pass on the defective code because zero is a valid index and the unfilled row is reproducible. The permanent regression then failed before the fix with both tests failing: the seeded index array had 10 of 18 mismatched values, and `bootstrap_data()` ended each path at source value `10.0` rather than independently expected `[20.0, 40.0, 30.0]`. After the two-bound loop correction, both regressions pass.

## Verification

- Focused regression: The new two-test module failed `2` tests before the fix; after the final formatted source, it and the existing bootstrap controls passed `15` tests.
- Complete affected subsystem: `pytest src/qis/models/` passed `113` tests.
- Final full suite: `pytest src/qis/` passed `2,984` tests with `18` warnings.
- Static, documentation, API, dependency, or build checks: Changed-line Ruff reported zero violations; differential Pyright reported zero unapproved diagnostics and 42 inherited or indirect diagnostics; Interrogate passed at 73.0%; `git diff --check` passed; the new test file is Ruff-formatted; the production module retains only accepted formatter debt; Sphinx HTML and linkcheck warning-as-error builds passed; the 430-name `PUBLIC_API` is current; and all installed packages are compatible.
- Downstream and generated-record checks: Repository-wide callers, examples, tests, exports, docs, and generated-record tooling were reviewed. The bootstrap convention example and its regression use STATIONARY rather than IID and remained controlled by the models suite. A pinned temporary consumer audit reproduced `docs/audit/consumers.json` exactly: optimalportfolios 101 symbols/832 sites, trendfollowing 87/441, and privateassets 5/9.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/models/bootstrap/bootstrap_numba.py`, and `src/qis/models/bootstrap/tests/bootstrap_iid_terminal_row_test.py`.

Out of scope: Random-number generator replacement, block-bootstrap algorithms, and paired lengths.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.