### PR TITLE
fix: add opt-in causal FX spot alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ batch and also shifts later sample columns.
 
 ### Fixed
 
-- Kept FX spot alignment causal by leaving leading gaps unavailable instead of filling them with
-  future observations before cash or futures return conversion.
+- Added opt-in causal FX spot alignment that leaves leading gaps unavailable, while preserving
+  historical leading backfill by default. Both modes normalize source chronology and retain the
+  exact price-panel axes before cash or futures return conversion.
 
 - Filled every requested IID bootstrap position with a random source index instead of leaving the
   terminal row deterministically mapped to source row zero.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ batch and also shifts later sample columns.
 
 ### Fixed
 
+- Kept FX spot alignment causal by leaving leading gaps unavailable instead of filling them with
+  future observations before cash or futures return conversion.
+
 - Filled every requested IID bootstrap position with a random source index instead of leaving the
   terminal row deterministically mapped to source row zero.
 

--- a/src/qis/market_data/fx_hedging.py
+++ b/src/qis/market_data/fx_hedging.py
@@ -297,12 +297,13 @@ def get_aligned_fx_spots(prices: pd.DataFrame,
                          quote_currency: str = 'USD'
                          ) -> pd.DataFrame:
     """
-    the FX spot series belonging to each instrument, on the index of its prices.
+    The FX spot series belonging to each instrument, on the index of its prices.
 
     An instrument panel is quoted in mixed currencies, and converting it needs a spot series per
     instrument rather than per currency. This maps each column of ``prices`` through its currency to
-    the matching spot column, reindexes onto the price dates and masks where the price is missing,
-    so the spots are NaN exactly where the prices are.
+    the matching spot column, reindexes onto the price dates using only current or earlier FX
+    observations, and masks where the price is missing. A spot remains missing until its first FX
+    observation is available.
 
     Args:
         prices: instrument prices, one column per instrument
@@ -313,8 +314,9 @@ def get_aligned_fx_spots(prices: pd.DataFrame,
     Returns:
         spots in the shape of ``prices``, one column per instrument
     """
-    # first backfill and the bbfill so prices will have corresponding fx spots data
-    fx_prices = fx_prices.reindex(index=prices.index, method='ffill').ffill().bfill()
+    # Sort and pre-fill the source so row order cannot carry a later quote backward in time.
+    fx_prices = fx_prices.sort_index().ffill()
+    fx_prices = fx_prices.reindex(index=prices.index, method='ffill')
     fx_prices[quote_currency] = 1.0
 
     fx_spots = {}

--- a/src/qis/market_data/fx_hedging.py
+++ b/src/qis/market_data/fx_hedging.py
@@ -294,35 +294,43 @@ def compute_fx_optimal_hedge(asset_price_local_ccy: pd.Series,
 def get_aligned_fx_spots(prices: pd.DataFrame,
                          asset_ccy_map: Union[pd.Series, Dict],
                          fx_prices: pd.DataFrame,
-                         quote_currency: str = 'USD'
+                         quote_currency: str = 'USD',
+                         bfill_fx: bool = True
                          ) -> pd.DataFrame:
     """
     The FX spot series belonging to each instrument, on the index of its prices.
 
     An instrument panel is quoted in mixed currencies, and converting it needs a spot series per
     instrument rather than per currency. This maps each column of ``prices`` through its currency to
-    the matching spot column, reindexes onto the price dates using only current or earlier FX
-    observations, and masks where the price is missing. A spot remains missing until its first FX
-    observation is available.
+    the matching spot column, reindexes onto the price dates, and masks where the price is missing.
+    By default, leading gaps are filled from the first available FX observation to preserve the
+    historical behavior. Set ``bfill_fx=False`` for causal alignment, where a spot remains missing
+    until its first observation is available.
 
     Args:
         prices: instrument prices, one column per instrument
         asset_ccy_map: instrument to currency, as a Series indexed by instrument or a dict
         fx_prices: FX spots, one column per currency
         quote_currency: the numeraire, whose spot column is set to one
+        bfill_fx: if True, fill leading gaps from the first available FX observation
 
     Returns:
-        spots in the shape of ``prices``, one column per instrument
+        spots with the same index, columns, shape, and row order as ``prices``
     """
     # Sort and pre-fill the source so row order cannot carry a later quote backward in time.
     fx_prices = fx_prices.sort_index().ffill()
-    fx_prices = fx_prices.reindex(index=prices.index, method='ffill')
+    price_order = prices.index.argsort(kind='stable')
+    fx_prices = fx_prices.reindex(index=prices.index[price_order], method='ffill')
+    if bfill_fx:
+        fx_prices = fx_prices.bfill()
+    # Restore the caller's exact row order after performing all time-directed fills.
+    fx_prices = fx_prices.iloc[np.argsort(price_order, kind='stable')]
+    fx_prices.index = prices.index
     fx_prices[quote_currency] = 1.0
 
-    fx_spots = {}
-    for asset, ccy in asset_ccy_map.items():
-        fx_spots[asset] = fx_prices[ccy]
-    fx_spots = pd.DataFrame.from_dict(fx_spots, orient='columns')
+    mapped_currencies = [asset_ccy_map[asset] for asset in prices.columns]
+    fx_spots = fx_prices.loc[:, mapped_currencies].copy()
+    fx_spots.columns = prices.columns
     fx_spots = fx_spots.where(prices.notna())
     return fx_spots
 

--- a/src/qis/market_data/tests/fx_spot_alignment_causality_test.py
+++ b/src/qis/market_data/tests/fx_spot_alignment_causality_test.py
@@ -1,0 +1,145 @@
+"""Causal alignment regressions for public FX spot and return helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.market_data.fx_hedging import (
+    compute_cash_fx_adjusted_returns,
+    compute_futures_fx_adjusted_returns,
+    get_aligned_fx_spots,
+)
+
+
+@pytest.mark.parametrize("nullable", [False, True], ids=["numpy-missing", "nullable-missing"])
+def test_fx_spot_alignment_uses_only_current_and_prior_observations(nullable: bool) -> None:
+    """Mixed FX panels preserve causal gaps, controls, labels, and caller-owned inputs."""
+    dates = pd.date_range("2024-01-01", periods=6, freq="D")
+    prices = pd.DataFrame(
+        {
+            "EUR_ASSET": [100.0, 101.0, 102.0, 103.0, 104.0, 105.0],
+            "GBP_ASSET": [200.0, 201.0, np.nan, 203.0, 204.0, 205.0],
+            "JPY_ASSET": [300.0, 301.0, 302.0, 303.0, 304.0, 305.0],
+            "USD_ASSET": [50.0, 51.0, 52.0, 53.0, np.nan, 55.0],
+        },
+        index=dates,
+    )
+    fx_prices = pd.DataFrame(
+        {
+            "EUR": [1.10, 1.20, 1.30],
+            "GBP": [1.30, np.nan, 1.40],
+            "JPY": [np.nan, np.nan, np.nan],
+        },
+        index=dates[[1, 3, 4]],
+    )
+    if nullable:
+        prices = prices.astype("Float64")
+        fx_prices = fx_prices.astype("Float64")
+    asset_ccy_map = {
+        "EUR_ASSET": "EUR",
+        "GBP_ASSET": "GBP",
+        "JPY_ASSET": "JPY",
+        "USD_ASSET": "USD",
+    }
+    original_prices = prices.copy(deep=True)
+    original_fx_prices = fx_prices.copy(deep=True)
+
+    actual = get_aligned_fx_spots(prices, asset_ccy_map, fx_prices)
+
+    # This explicit table is an as-of oracle independent of the production fill operations.
+    expected = pd.DataFrame(
+        {
+            "EUR_ASSET": [np.nan, 1.10, 1.10, 1.20, 1.30, 1.30],
+            "GBP_ASSET": [np.nan, 1.30, np.nan, 1.30, 1.40, 1.40],
+            "JPY_ASSET": [np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
+            "USD_ASSET": [1.0, 1.0, 1.0, 1.0, np.nan, 1.0],
+        },
+        index=dates,
+    )
+    if nullable:
+        actual = actual.astype("Float64")
+        expected = expected.astype("Float64")
+    pd.testing.assert_frame_equal(actual, expected, check_dtype=False)
+    pd.testing.assert_frame_equal(prices, original_prices)
+    pd.testing.assert_frame_equal(fx_prices, original_fx_prices)
+
+
+@pytest.mark.parametrize(
+    "source_order",
+    [(0, 1, 2), (2, 1, 0), (1, 2, 0)],
+    ids=["ascending-source", "descending-source", "unsorted-source"],
+)
+@pytest.mark.parametrize(
+    "target_order",
+    [(0, 1, 2, 3), (3, 2, 1, 0), (2, 0, 3, 1)],
+    ids=["ascending-target", "descending-target", "unsorted-target"],
+)
+def test_fx_spot_alignment_is_independent_of_input_row_order(
+    source_order: tuple[int, ...],
+    target_order: tuple[int, ...],
+) -> None:
+    """Source and target row order cannot change the timestamp-based as-of result."""
+    dates = pd.date_range("2024-01-01", periods=4, freq="D")
+    source_values = (1.10, 1.15, 1.20)
+    price_values = (100.0, 101.0, 102.0, 103.0)
+    expected_values = (np.nan, 1.10, 1.15, 1.20)
+    source_dates = pd.DatetimeIndex([dates[position + 1] for position in source_order])
+    target_dates = pd.DatetimeIndex([dates[position] for position in target_order])
+    fx_prices = pd.DataFrame(
+        {"EUR": [source_values[position] for position in source_order]}, index=source_dates
+    )
+    prices = pd.DataFrame(
+        {"ASSET": [price_values[position] for position in target_order]}, index=target_dates
+    )
+
+    actual = get_aligned_fx_spots(prices, {"ASSET": "EUR"}, fx_prices)
+
+    expected = pd.DataFrame(
+        {"ASSET": [expected_values[position] for position in target_order]}, index=target_dates
+    )
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+FxReturnConverter = Callable[[pd.DataFrame, pd.DataFrame, int, bool], pd.DataFrame]
+
+
+@pytest.mark.parametrize(
+    ("converter", "includes_fx_notional"),
+    [
+        (compute_cash_fx_adjusted_returns, True),
+        (compute_futures_fx_adjusted_returns, False),
+    ],
+    ids=["cash", "futures"],
+)
+@pytest.mark.parametrize("is_log_returns", [False, True], ids=["simple", "log"])
+def test_fx_adjusted_returns_require_two_causally_available_spots(
+    converter: FxReturnConverter,
+    includes_fx_notional: bool,
+    is_log_returns: bool,
+) -> None:
+    """Cash and futures returns stay missing until both endpoint spots are observable."""
+    dates = pd.date_range("2024-01-01", periods=4, freq="D")
+    prices = pd.DataFrame({"ASSET": [100.0, 101.0, 102.0, 103.0]}, index=dates)
+    fx_prices = pd.DataFrame({"EUR": [1.10, 1.20]}, index=dates[[1, 3]])
+    aligned_spots = get_aligned_fx_spots(prices, {"ASSET": "EUR"}, fx_prices)
+
+    actual = converter(prices, aligned_spots, 1, is_log_returns)
+
+    # Derive the observable returns directly from endpoint prices and spots, without the helper.
+    expected_d2 = 102.0 / 101.0 - 1.0
+    local_d3 = 103.0 / 102.0 - 1.0
+    fx_d3 = 1.20 / 1.10 - 1.0
+    expected_d3 = local_d3 * (1.0 + fx_d3)
+    if includes_fx_notional:
+        expected_d3 += fx_d3
+    if is_log_returns:
+        expected_values = [np.nan, np.nan, math.log1p(expected_d2), math.log1p(expected_d3)]
+    else:
+        expected_values = [np.nan, np.nan, expected_d2, expected_d3]
+    expected = pd.DataFrame({"ASSET": expected_values}, index=dates)
+    pd.testing.assert_frame_equal(actual, expected)

--- a/src/qis/market_data/tests/fx_spot_alignment_causality_test.py
+++ b/src/qis/market_data/tests/fx_spot_alignment_causality_test.py
@@ -41,15 +41,15 @@ def test_fx_spot_alignment_uses_only_current_and_prior_observations(nullable: bo
         prices = prices.astype("Float64")
         fx_prices = fx_prices.astype("Float64")
     asset_ccy_map = {
-        "EUR_ASSET": "EUR",
-        "GBP_ASSET": "GBP",
-        "JPY_ASSET": "JPY",
         "USD_ASSET": "USD",
+        "JPY_ASSET": "JPY",
+        "GBP_ASSET": "GBP",
+        "EUR_ASSET": "EUR",
     }
     original_prices = prices.copy(deep=True)
     original_fx_prices = fx_prices.copy(deep=True)
 
-    actual = get_aligned_fx_spots(prices, asset_ccy_map, fx_prices)
+    actual = get_aligned_fx_spots(prices, asset_ccy_map, fx_prices, bfill_fx=False)
 
     # This explicit table is an as-of oracle independent of the production fill operations.
     expected = pd.DataFrame(
@@ -97,12 +97,49 @@ def test_fx_spot_alignment_is_independent_of_input_row_order(
         {"ASSET": [price_values[position] for position in target_order]}, index=target_dates
     )
 
-    actual = get_aligned_fx_spots(prices, {"ASSET": "EUR"}, fx_prices)
+    actual = get_aligned_fx_spots(prices, {"ASSET": "EUR"}, fx_prices, bfill_fx=False)
 
     expected = pd.DataFrame(
         {"ASSET": [expected_values[position] for position in target_order]}, index=target_dates
     )
     pd.testing.assert_frame_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "target_order",
+    [(0, 1, 2, 3), (3, 2, 1, 0), (2, 0, 3, 1)],
+    ids=["ascending-target", "descending-target", "unsorted-target"],
+)
+def test_fx_spot_alignment_backfills_by_default_in_price_order(
+    target_order: tuple[int, ...],
+) -> None:
+    """Default alignment preserves historical backfill and the exact price axes."""
+    dates = pd.date_range("2024-01-01", periods=4, freq="D")
+    target_dates = pd.DatetimeIndex([dates[position] for position in target_order])
+    prices = pd.DataFrame(
+        {
+            "USD_ASSET": [50.0 + position for position in target_order],
+            "EUR_ASSET": [100.0 + position for position in target_order],
+        },
+        index=target_dates,
+    )
+    # Reverse both the source chronology and mapping insertion order to isolate the public axes.
+    fx_prices = pd.DataFrame({"EUR": [1.20, 1.10]}, index=dates[[3, 1]])
+    asset_ccy_map = {"EUR_ASSET": "EUR", "USD_ASSET": "USD"}
+
+    actual_default = get_aligned_fx_spots(prices, asset_ccy_map, fx_prices)
+    actual_explicit = get_aligned_fx_spots(prices, asset_ccy_map, fx_prices, bfill_fx=True)
+
+    expected_eur = (1.10, 1.10, 1.10, 1.20)
+    expected = pd.DataFrame(
+        {
+            "USD_ASSET": [1.0] * len(target_order),
+            "EUR_ASSET": [expected_eur[position] for position in target_order],
+        },
+        index=target_dates,
+    )
+    pd.testing.assert_frame_equal(actual_default, expected)
+    pd.testing.assert_frame_equal(actual_explicit, expected)
 
 
 FxReturnConverter = Callable[[pd.DataFrame, pd.DataFrame, int, bool], pd.DataFrame]
@@ -126,7 +163,7 @@ def test_fx_adjusted_returns_require_two_causally_available_spots(
     dates = pd.date_range("2024-01-01", periods=4, freq="D")
     prices = pd.DataFrame({"ASSET": [100.0, 101.0, 102.0, 103.0]}, index=dates)
     fx_prices = pd.DataFrame({"EUR": [1.10, 1.20]}, index=dates[[1, 3]])
-    aligned_spots = get_aligned_fx_spots(prices, {"ASSET": "EUR"}, fx_prices)
+    aligned_spots = get_aligned_fx_spots(prices, {"ASSET": "EUR"}, fx_prices, bfill_fx=False)
 
     actual = converter(prices, aligned_spots, 1, is_log_returns)
 


### PR DESCRIPTION
## What changed

Preserve historical leading FX backfill by default while offering explicit causal alignment, with both modes independent of source and target row order and exact to the price panel's axes.

Before this correction, `get_aligned_fx_spots()` reindexed and forward filled, then called `.bfill()`, so a price date before the first FX observation received that later spot.

## Behavior

`bfill_fx=True` preserves historical leading backfill by default; `bfill_fx=False` uses only information available at or before each price date and leaves earlier observations missing. Both modes normalize chronology internally and return the exact index, columns, shape, metadata, and row order of `prices`.

## Regression evidence

A branch-level mixed-panel probe on Python 3.11.9, pandas 3.0.5, and NumPy 2.4.6 returned EUR spot `1.1` on 2024-01-01 even though the first EUR observation was dated 2024-01-02; the independent backward-looking as-of oracle returned missing. The same failure occurred for ordinary `float64`/`np.nan` and nullable `Float64`/`pd.NA` inputs. Passing the aligned output to the cash and futures conversion helpers also fabricated a finite 2024-01-02 converted return where the causal oracle remained missing, in both simple and log modes. After removing only the backward fill, eight of nine ascending, descending, and unsorted source/target order combinations still failed through future fill or a pandas monotonicity error. The revised 18-case suite adds three independent default-backfill oracles across ascending, descending, and unsorted price rows; all cases pass under the requested dual-mode contract.

## Verification

- Fail-before: all 18 revised cases failed against published commit `3943804` because the public helper did not accept `bfill_fx`.
- Focused regression and public API controls: `255 passed` across the 18-case alignment file and `src/qis/tests/test_core_api.py` on the final formatted source.
- Complete affected subsystem: `68 passed` in `src/qis/market_data/tests/`.
- Final full suite and Sphinx build: Both warning-as-error Sphinx builds passed, and the complete repository suite passed with `3018 passed, 18 warnings` on clean commit `24ab9a5`.
- Static, API, dependency, and formatting checks: Ruff reported zero violations; changed-line Pyright reported zero unapproved diagnostics and classified 14 diagnostics as inherited or indirect; interrogate passed at 73.0%; the 430-name public API record was current; dependency compatibility and `git diff --check` passed. `format-new` reformatted only the added test file; the production file retains matching pre-existing formatter debt and was not broadly changed.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/market_data/fx_hedging.py`, and one focused market-data test.

Out of scope: Missing FX data acquisition, interpolation, rate alignment, frequency resampling, malformed mapping diagnostics retained for PR 104, and maintainer-owned release bookkeeping.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.
