### PR TITLE
fix: anchor ragged bootstrap paths per asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ batch and also shifts later sample columns.
 
 ### Fixed
 
+- Anchored continuation price bootstraps to each input series' own last positive finite level, so
+  a trailing-ragged asset no longer produces an entirely missing path beside a longer history.
+
 - Added opt-in causal FX spot alignment that leaves leading gaps unavailable, while preserving
   historical leading backfill by default. Both modes normalize source chronology and retain the
   exact price-panel axes before cash or futures return conversion.

--- a/src/qis/models/bootstrap/bootstrap_numba.py
+++ b/src/qis/models/bootstrap/bootstrap_numba.py
@@ -467,6 +467,38 @@ def bootstrap_ar_process(data: Union[pd.Series, pd.DataFrame],
     return bootstrap_sample
 
 
+def _get_price_anchor(prices: Union[pd.Series, pd.DataFrame], init_to_end: bool) -> FloatArray:
+    """Return one reconstruction anchor per input series.
+
+    Args:
+        prices: Price levels, with one input series per DataFrame column.
+        init_to_end: Whether to continue from each series' last valid price. False preserves the
+            established physical-first-row alternative-history anchor.
+
+    Returns:
+        One-dimensional float array of anchors in input column order.
+    """
+    price_frame = prices.to_frame() if isinstance(prices, pd.Series) else prices
+    price_values = cast(FloatArray, price_frame.to_numpy(dtype=np.float64, na_value=np.nan))
+    if not init_to_end:
+        return price_values[0, :]
+
+    terminal_values = price_values[-1, :]
+    if np.all(np.isfinite(terminal_values) & (terminal_values > 0.0)):
+        return terminal_values
+
+    # Continuation anchors share the positive-finite domain of relative and log returns.
+    valid_prices = np.isfinite(price_values) & (price_values > 0.0)
+    row_positions = np.arange(price_values.shape[0])[:, np.newaxis]
+    last_positions = np.where(valid_prices, row_positions, -1).max(axis=0)
+    anchors = np.full(price_values.shape[1], np.nan, dtype=np.float64)
+    has_anchor = last_positions >= 0
+    # Select by position so duplicate column labels remain independent series.
+    column_positions = np.flatnonzero(has_anchor)
+    anchors[has_anchor] = price_values[last_positions[has_anchor], column_positions]
+    return anchors
+
+
 def bootstrap_price_data(prices: Union[pd.Series, pd.DataFrame],
                          bootstrap_type: BootstrapType = BootstrapType.STATIONARY,
                          bootstrap_output: BootstrapOutput = BootstrapOutput.DF_TO_LIST_ARRAYS,
@@ -498,8 +530,9 @@ def bootstrap_price_data(prices: Union[pd.Series, pd.DataFrame],
         is_log_returns: resample log returns rather than arithmetic ones
         seed: seed for the numba random state
         bootstrapped_indices: precomputed indices, which override the sampling arguments
-        init_to_end: start every path from the last observed price, so the draws continue from
-            today. False starts them from the first price, so the draws are alternative histories
+        init_to_end: Start each path from its input series' last positive finite price, so ragged
+            columns continue from their own terminal observation. False starts every path from the
+            physical first row, so the draws are alternative histories
 
     Returns:
         A DataFrame of paths for SERIES_TO_DF, or a list of arrays for DF_TO_LIST_ARRAYS.
@@ -521,21 +554,7 @@ def bootstrap_price_data(prices: Union[pd.Series, pd.DataFrame],
                                        bootstrapped_indices=bootstrapped_indices)
 
     if bootstrap_output == BootstrapOutput.DF_TO_LIST_ARRAYS:
-        # Select by position and retain a one-dimensional asset vector for NumPy broadcasting.
-        init_position = -1 if init_to_end else 0
-        init_value: FloatArray
-        if isinstance(prices, pd.Series):
-            init_value = cast(
-                FloatArray,
-                prices.iloc[[init_position]].to_numpy(dtype=np.float64, na_value=np.nan),
-            )
-        else:
-            init_value = cast(
-                FloatArray,
-                prices.iloc[[init_position], :]
-                .to_numpy(dtype=np.float64, na_value=np.nan)
-                .reshape(-1),
-            )
+        init_value = _get_price_anchor(prices=prices, init_to_end=init_to_end)
 
         bootstrap_sample = List()
         for sampled_returns in bootstrap_returns:
@@ -552,11 +571,7 @@ def bootstrap_price_data(prices: Union[pd.Series, pd.DataFrame],
 
     elif bootstrap_output == BootstrapOutput.SERIES_TO_DF:
         assert isinstance(prices, pd.Series)
-        init_position = -1 if init_to_end else 0
-        price_anchor = cast(
-            FloatArray,
-            prices.iloc[[init_position]].to_numpy(dtype=np.float64, na_value=np.nan),
-        )
+        price_anchor = _get_price_anchor(prices=prices, init_to_end=init_to_end)
         init_value = np.repeat(price_anchor, num_samples)
 
         if is_log_returns:

--- a/src/qis/models/bootstrap/tests/bootstrap_price_ragged_anchor_test.py
+++ b/src/qis/models/bootstrap/tests/bootstrap_price_ragged_anchor_test.py
@@ -1,0 +1,232 @@
+"""Regression tests for per-series continuation anchors in price bootstraps.
+
+Fixed sampled-return indexes separate price reconstruction from random sampling. The tests cover
+trailing-ragged Series and DataFrame inputs, both public output constructions, arithmetic and log
+returns, duplicate labels, and the public price-plus-fundamentals delegate.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import cast
+
+# packages
+import numpy as np
+import pandas as pd
+import pytest
+
+# qis / project
+from qis.models.bootstrap.bootstrap_numba import (
+    BootstrapOutput,
+    BootstrapType,
+    bootstrap_price_data,
+    bootstrap_price_fundamental_data,
+)
+
+FloatArray = np.ndarray[tuple[int, ...], np.dtype[np.float64]]
+IntArray = np.ndarray[tuple[int, ...], np.dtype[np.int64]]
+
+DATES = pd.date_range("2024-01-01", periods=5, freq="D")
+SAMPLE_INDEXES: IntArray = np.array([[0], [1], [0]], dtype=np.int64)
+COMPLETE_PRICES: FloatArray = np.array([100.0, 110.0, 121.0, 133.1, 146.41], dtype=np.float64)
+RAGGED_PRICES: FloatArray = np.array([50.0, 55.0, 60.5, np.nan, np.nan], dtype=np.float64)
+
+
+def _mixed_prices(*, duplicate_labels: bool = False) -> pd.DataFrame:
+    """Construct complete and trailing-ragged price histories in one panel.
+
+    Args:
+        duplicate_labels: Whether both positional columns use the same label.
+
+    Returns:
+        Mixed price panel with complete and trailing-ragged columns.
+    """
+    labels = ["Asset", "Asset"] if duplicate_labels else ["Complete", "Ragged"]
+    return pd.DataFrame(
+        np.column_stack([COMPLETE_PRICES, RAGGED_PRICES]), index=DATES, columns=labels
+    )
+
+
+def _expected_path(values: FloatArray, *, is_log_returns: bool) -> FloatArray:
+    """Recompound fixed sampled returns from the last positive finite source level.
+
+    Args:
+        values: One source price history.
+        is_log_returns: Whether to derive logarithmic rather than arithmetic returns.
+
+    Returns:
+        Independently reconstructed continuation path.
+    """
+    valid_values = values[np.isfinite(values) & (values > 0.0)]
+    if is_log_returns:
+        source_returns = np.diff(np.log(valid_values))
+        growth = np.exp(np.cumsum(source_returns[SAMPLE_INDEXES[:, 0]]))
+    else:
+        source_returns = valid_values[1:] / valid_values[:-1] - 1.0
+        growth = np.cumprod(1.0 + source_returns[SAMPLE_INDEXES[:, 0]])
+    return growth * (valid_values[-1] / growth[0])
+
+
+def _first_list_path(result: object) -> FloatArray:
+    """Narrow the public list result and return its first path as float64.
+
+    Args:
+        result: Result from the list-output bootstrap path.
+
+    Returns:
+        First rows-by-assets bootstrap path.
+    """
+    assert isinstance(result, Iterable)
+    assert not isinstance(result, (pd.DataFrame, pd.Series))
+    result_iterable = cast(Iterable[object], result)
+    path = next(iter(result_iterable))
+    assert isinstance(path, np.ndarray)
+    return path.astype(np.float64, copy=False)
+
+
+@pytest.mark.parametrize("is_log_returns", [False, True])
+def test_bootstrap_price_data_anchors_mixed_ragged_columns_independently(
+    is_log_returns: bool,
+) -> None:
+    """A longer neighbor cannot replace a ragged asset's own continuation anchor."""
+    prices = _mixed_prices()
+    original = prices.copy(deep=True)
+
+    result = cast(
+        object,
+        bootstrap_price_data(
+            prices=prices,
+            bootstrap_output=BootstrapOutput.DF_TO_LIST_ARRAYS,
+            num_samples=1,
+            index_length=len(SAMPLE_INDEXES),
+            is_log_returns=is_log_returns,
+            bootstrapped_indices=SAMPLE_INDEXES,
+            init_to_end=True,
+        ),
+    )
+    actual = _first_list_path(result)
+    expected = np.column_stack(
+        [
+            _expected_path(COMPLETE_PRICES, is_log_returns=is_log_returns),
+            _expected_path(RAGGED_PRICES, is_log_returns=is_log_returns),
+        ]
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-13, atol=1e-13)
+    pd.testing.assert_frame_equal(prices, original)
+
+
+@pytest.mark.parametrize(
+    "bootstrap_output", [BootstrapOutput.DF_TO_LIST_ARRAYS, BootstrapOutput.SERIES_TO_DF]
+)
+@pytest.mark.parametrize("is_log_returns", [False, True])
+def test_bootstrap_price_data_anchors_ragged_series_in_both_output_modes(
+    bootstrap_output: BootstrapOutput, is_log_returns: bool
+) -> None:
+    """Both Series reconstruction paths continue from the last valid observed level."""
+    prices = pd.Series(RAGGED_PRICES, index=DATES, name="Ragged")
+    original = prices.copy(deep=True)
+
+    result = cast(
+        object,
+        bootstrap_price_data(
+            prices=prices,
+            bootstrap_output=bootstrap_output,
+            num_samples=1,
+            index_length=len(SAMPLE_INDEXES),
+            is_log_returns=is_log_returns,
+            bootstrapped_indices=SAMPLE_INDEXES,
+            init_to_end=True,
+        ),
+    )
+    if bootstrap_output == BootstrapOutput.DF_TO_LIST_ARRAYS:
+        actual = _first_list_path(result)[:, 0]
+    else:
+        assert isinstance(result, pd.DataFrame)
+        actual = cast(FloatArray, result.iloc[:, 0].to_numpy(dtype=np.float64))
+
+    np.testing.assert_allclose(
+        actual,
+        _expected_path(RAGGED_PRICES, is_log_returns=is_log_returns),
+        rtol=1e-13,
+        atol=1e-13,
+    )
+    pd.testing.assert_series_equal(prices, original)
+
+
+def test_bootstrap_price_data_selects_ragged_anchors_by_column_position() -> None:
+    """Duplicate labels do not merge or make per-column anchor selection ambiguous."""
+    prices = _mixed_prices(duplicate_labels=True)
+
+    result = cast(
+        object,
+        bootstrap_price_data(
+            prices=prices,
+            bootstrap_output=BootstrapOutput.DF_TO_LIST_ARRAYS,
+            num_samples=1,
+            index_length=len(SAMPLE_INDEXES),
+            bootstrapped_indices=SAMPLE_INDEXES,
+            init_to_end=True,
+        ),
+    )
+    actual = _first_list_path(result)
+
+    np.testing.assert_allclose(actual[0], [COMPLETE_PRICES[-1], 60.5])
+
+
+@pytest.mark.parametrize("invalid_terminal", [np.nan, 0.0, -5.0, np.inf])
+def test_bootstrap_price_data_skips_invalid_terminal_price_anchors(
+    invalid_terminal: float,
+) -> None:
+    """Continuation anchors obey the positive-finite price endpoint domain."""
+    prices = pd.Series([50.0, 55.0, 60.5, invalid_terminal], name="Ragged")
+    sampled_indexes: IntArray = np.array([[0], [1], [0]], dtype=np.int64)
+
+    result = cast(
+        object,
+        bootstrap_price_data(
+            prices=prices,
+            bootstrap_output=BootstrapOutput.DF_TO_LIST_ARRAYS,
+            num_samples=1,
+            index_length=len(sampled_indexes),
+            bootstrapped_indices=sampled_indexes,
+            init_to_end=True,
+        ),
+    )
+    actual = _first_list_path(result)[:, 0]
+
+    np.testing.assert_allclose(actual, [60.5, 66.55, 73.205])
+
+
+def test_bootstrap_price_fundamental_data_preserves_ragged_price_anchors() -> None:
+    """The public paired wrapper inherits per-series continuation anchoring."""
+    dates = pd.date_range("2024-01-01", periods=6, freq="D")
+    prices = pd.DataFrame(
+        {
+            "Complete": [100.0, 105.0, 110.25, 115.7625, 121.550625, 127.62815625],
+            "Ragged": [50.0, 52.5, 55.125, 57.88125, np.nan, np.nan],
+        },
+        index=dates,
+    )
+    fundamentals = pd.DataFrame(
+        {
+            "Complete": [2.0, 2.1, 2.2, 2.3, 2.4, 2.5],
+            "Ragged": [1.0, 1.1, 1.2, 1.3, 1.4, 1.5],
+        },
+        index=dates,
+    )
+
+    bootstrapped_prices, _ = bootstrap_price_fundamental_data(
+        price_datas={"prices": prices},
+        fundamental_datas={"fundamentals": fundamentals},
+        bootstrap_type=BootstrapType.FIXED_BLOCK,
+        bootstrap_output=BootstrapOutput.DF_TO_LIST_ARRAYS,
+        num_samples=1,
+        index_length=3,
+        block_size=1,
+        seed=7,
+    )
+    actual = np.asarray(bootstrapped_prices["prices"][0], dtype=np.float64)
+
+    np.testing.assert_allclose(actual[0], [127.62815625, 57.88125])
+    assert np.isfinite(actual).all()


### PR DESCRIPTION
## What changed

For `init_to_end=True`, start each bootstrapped continuation path from that input series' own last positive finite price across both public output modes.

With a complete asset beside one whose history ends early, `bootstrap_price_data(init_to_end=True)` uses the physical final row for every column; the ragged asset receives a missing anchor and its otherwise valid path becomes entirely missing.

## Behavior

A continuation path uses the terminal observation that satisfies the same positive-finite endpoint domain as relative and log returns; its anchor is independent of neighboring columns' terminal dates, container shape, and output construction path.

## Regression evidence

A fixed sampled-index probe at `70fb5bd` produced an all-NaN ragged path for simple and log returns in a mixed DataFrame, a ragged Series with list output, and a ragged Series with DataFrame output. Trimming the same source to its last observed value produced `[60.5, 66.55, 73.205]`, matching independent recompounding from the sampled 10% returns. `bootstrap_price_fundamental_data` likewise returned a finite complete path beside an all-NaN ragged path. Existing complete-input results remained finite.

## Verification

- Focused regression: The added module failed all 8 original cases before the fix and passed all 12 final cases after formatting, including four invalid-terminal parameter cells.
- Complete affected subsystem: `src/qis/models/` passed all 125 tests against the exact final commit.
- Final full suite: `src/qis/` passed 3,031 tests with 18 unrelated established warnings against exact commit `74ee14f`; none arose from the changed bootstrap files or focused regressions.
- Static, documentation, API, dependency, or build checks: `git diff --check`, native changed-line Ruff, global Pyright 1.1.411, Interrogate, Sphinx HTML and linkcheck with warnings as errors, `tools/sync_public_api.py --check` (430 names), and `uv pip check` passed. The existing source file and its accepted baseline retain the same whole-file Ruff formatting debt; the new test file is Ruff-formatted. No generated consumer record owns the affected symbol.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/models/bootstrap/bootstrap_numba.py`, and `src/qis/models/bootstrap/tests/bootstrap_price_ragged_anchor_test.py`.

Out of scope: Return sampling distribution, `init_to_end=False` first-observed policy, nullable extension-array conversion, all-missing warning policy, paired input lengths, and imputation.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.