### PR TITLE
fix: preserve ragged periodic return starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ batch and also shifts later sample columns.
 - Kept risk-adjusted-table returns, ratios, and benchmark regressions within each asset's sampled
   observed history, so a longer neighboring column no longer adds post-termination flat returns.
 
+- Preserved missing pre-inception cells in multi-asset periodic-return tables and left periodic
+  and total returns undefined for columns with fewer than two observed price boundaries.
+
 - Anchored continuation price bootstraps to each input series' own last positive finite level, so
   a trailing-ragged asset no longer produces an entirely missing path beside a longer history.
 

--- a/docs/incomplete_and_mixed_frequency_data.md
+++ b/docs/incomplete_and_mixed_frequency_data.md
@@ -83,6 +83,11 @@ heal it. FX mixed-frequency returns replace exact structural zeros with NaN for 
 that intentionally also removes the rare organic zero. None of these policies identifies a stale
 mark or delisting event for you.
 
+For multi-asset periodic tables, `qis.compute_periodic_returns` preserves a leading missing region
+until an asset supplies two observed price boundaries. A column with fewer than two observations
+has neither periodic nor total returns. The table calculation continues to forward-fill internal
+and trailing gaps; that display-oriented convention is not a liquidation or delisting policy.
+
 ## Constraints and failure modes
 
 - Forward-filling a low-frequency NAV then estimating daily volatility treats “no new report” as

--- a/src/qis/plots/derived/returns_heatmap.py
+++ b/src/qis/plots/derived/returns_heatmap.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
-from typing import Union, List, Optional, Tuple, Dict
+from typing import Union, List, Optional, Tuple, Dict, cast
 # qis
 import qis.utils.dates as da
 import qis.perfstats.returns as ret
@@ -303,9 +303,23 @@ def compute_periodic_returns(prices: pd.DataFrame,
                              date_format: str = None,
                              **kwargs
                              ) -> pd.DataFrame:
-    """
-    compute returns at specified frequency for datadrfame
-    index are periods, columns are prices.columns
+    """Compute simple periodic returns for a price panel.
+
+    Args:
+        prices: Price levels with dates on the index and assets in columns.
+        freq: Frequency used to sample return boundaries.
+        time_period: Optional date interval applied before return calculation.
+        total_name: Label for the optional whole-period return row.
+        add_total: Whether to append a whole-period return row.
+        date_format: Optional ``strftime`` format for periodic row labels.
+        **kwargs: Reserved for compatibility with plotting callers.
+
+    Returns:
+        Periods by assets. A column remains missing until it supplies two observed price
+        boundaries; internal and trailing gaps retain the established forward-fill behavior.
+
+    Raises:
+        ValueError: If ``prices`` is not a DataFrame.
     """
     if not isinstance(prices, pd.DataFrame):
         raise ValueError("prices must be dataframe")
@@ -319,9 +333,13 @@ def compute_periodic_returns(prices: pd.DataFrame,
     if not prices.index.is_monotonic_increasing:
         prices = prices.sort_index()
 
-    # make sure there are no gaps for heterogeneous price data
-    prices = prices.ffill().bfill()
-    data = ret.to_returns(prices=prices, freq=freq, include_start_date=True, include_end_date=True, drop_first=True)
+    has_return_support = prices.notna().sum(axis=0).to_numpy() >= 2
+
+    # Preserve established gap and tail handling without inventing a pre-inception price.
+    prices = prices.ffill()
+    data = ret.to_returns(prices=prices, freq=freq, include_start_date=True,
+                          include_end_date=True, ffill_nans=False, drop_first=True)
+    data.iloc[:, ~has_return_support] = np.nan
 
     if add_total:
         if freq == 'ME':
@@ -330,7 +348,17 @@ def compute_periodic_returns(prices: pd.DataFrame,
             total_name = total_name or 'Total'
         else:
             total_name = total_name or 'total'
-        total_return = ret.to_total_returns(prices=prices).rename(total_name).to_frame().T
+        # Compute totals only where two observed boundaries exist; the temporary backfill then
+        # avoids changing the ratio while keeping leading missing values out of the shared reducer.
+        total_values = np.full(prices.shape[1], fill_value=np.nan)
+        if np.any(has_return_support):
+            supported_prices = cast(
+                pd.DataFrame, prices.iloc[:, has_return_support]
+            ).bfill()
+            total_values[has_return_support] = ret.to_total_returns(
+                prices=supported_prices
+            ).to_numpy(dtype=float, na_value=np.nan)
+        total_return = pd.DataFrame([total_values], index=[total_name], columns=prices.columns)
         data = pd.concat([data, total_return], axis=0)
 
     if date_format is not None:  # index may include 'Total'

--- a/src/qis/plots/derived/tests/periodic_returns_ragged_start_test.py
+++ b/src/qis/plots/derived/tests/periodic_returns_ragged_start_test.py
@@ -1,0 +1,173 @@
+"""Regression tests for ragged support in multi-asset periodic-return tables.
+
+Periodic returns need two observed price boundaries. These tests distinguish missing
+pre-inception support from a genuine zero return while preserving the established interior- and
+trailing-fill behavior used by periodic tables.
+"""
+
+import warnings
+from typing import cast
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import pytest
+
+import qis
+
+
+def _make_mixed_prices(storage: str = "float64") -> pd.DataFrame:
+    """Create price columns spanning the periodic-table support boundaries.
+
+    Args:
+        storage: Pandas floating dtype used for the panel.
+
+    Returns:
+        A complete, ragged, interior-missing, trailing-missing, and all-missing panel.
+    """
+    index = pd.date_range("2024-01-31", periods=4, freq="ME")
+    return pd.DataFrame(
+        {
+            "Complete": [100.0, 110.0, 110.0, 121.0],
+            "Late": [np.nan, 100.0, 110.0, 121.0],
+            "One": [np.nan, np.nan, 50.0, np.nan],
+            "Interior": [100.0, np.nan, 110.0, 121.0],
+            "Trailing": [100.0, 110.0, np.nan, np.nan],
+            "Missing": [np.nan, np.nan, np.nan, np.nan],
+        },
+        index=index,
+    ).astype(storage)
+
+
+@pytest.mark.parametrize("storage", ["float64", "Float64"])
+def test_compute_periodic_returns_requires_two_observed_boundaries(storage: str) -> None:
+    """Report returns only after a column supplies two observed price boundaries."""
+    prices = _make_mixed_prices(storage=storage)
+    before = prices.copy(deep=True)
+    dates = prices.index
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = qis.compute_periodic_returns(prices=prices, freq="ME", add_total=True)
+
+    # Expected values are direct endpoint ratios; no QIS return helper constructs this oracle.
+    expected = pd.DataFrame(
+        [
+            [0.10, np.nan, np.nan, 0.00, 0.10, np.nan],
+            [0.00, 0.10, np.nan, 0.10, 0.00, np.nan],
+            [0.10, 0.10, np.nan, 0.10, 0.00, np.nan],
+            [0.21, 0.21, np.nan, 0.21, 0.10, np.nan],
+        ],
+        index=pd.Index([dates[1], dates[2], dates[3], "YTD"]),
+        columns=prices.columns,
+    ).astype(storage)
+    pd.testing.assert_frame_equal(actual, expected)
+    pd.testing.assert_frame_equal(prices, before)
+
+
+def test_compute_periodic_returns_counts_support_inside_time_period() -> None:
+    """Require two boundaries inside the requested window, not merely in the source."""
+    prices = cast(pd.DataFrame, _make_mixed_prices().loc[:, ["Late"]])
+    time_period = qis.TimePeriod(start="31Jan2024", end="29Feb2024")
+
+    actual = qis.compute_periodic_returns(
+        prices=prices, freq="ME", time_period=time_period, add_total=True
+    )
+
+    expected = pd.DataFrame(
+        {"Late": [np.nan, np.nan]},
+        index=pd.Index([pd.Timestamp("2024-02-29"), "YTD"]),
+    )
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_compute_periodic_returns_preserves_off_grid_ragged_start() -> None:
+    """Keep pre-inception periods missing when observations fall between month ends."""
+    dates = pd.to_datetime(["2024-01-15", "2024-02-15", "2024-03-15", "2024-04-15"])
+    prices = pd.DataFrame(
+        {
+            "Complete": [100.0, 110.0, 121.0, 133.1],
+            "Late": [np.nan, 100.0, 110.0, 121.0],
+        },
+        index=dates,
+    )
+
+    actual = qis.compute_periodic_returns(prices=prices, freq="ME", add_total=True)
+
+    expected = pd.DataFrame(
+        [
+            [0.000, np.nan],
+            [0.100, np.nan],
+            [0.100, 0.10],
+            [0.100, 0.10],
+            [0.331, 0.21],
+        ],
+        index=pd.Index(
+            [
+                pd.Timestamp("2024-01-31"),
+                pd.Timestamp("2024-02-29"),
+                pd.Timestamp("2024-03-31"),
+                pd.Timestamp("2024-04-15"),
+                "YTD",
+            ]
+        ),
+        columns=prices.columns,
+    )
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_compute_periodic_returns_preserves_yearly_pre_inception_missing() -> None:
+    """Apply the same two-boundary rule when the public frequency selects years."""
+    dates = pd.date_range("2022-12-31", periods=3, freq="YE")
+    prices = pd.DataFrame({"Late": [np.nan, 100.0, 110.0]}, index=dates)
+
+    actual = qis.compute_periodic_returns(prices=prices, freq="YE", add_total=False)
+
+    expected = pd.DataFrame({"Late": [np.nan, 0.10]}, index=dates[1:])
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_compute_periodic_returns_handles_duplicate_labels_by_position() -> None:
+    """Keep column-local support independent when two assets share a label."""
+    dates = pd.date_range("2024-01-31", periods=3, freq="ME")
+    prices = pd.DataFrame(
+        np.column_stack(([np.nan, 100.0, 110.0], [100.0, 100.0, 110.0])),
+        index=dates,
+        columns=["Asset", "Asset"],
+    )
+
+    actual = qis.compute_periodic_returns(prices=prices, freq="ME", add_total=True)
+
+    expected = pd.DataFrame(
+        [[np.nan, 0.00], [0.10, 0.10], [0.10, 0.10]],
+        index=pd.Index([dates[1], dates[2], "YTD"]),
+        columns=prices.columns,
+    )
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_plot_periodic_returns_table_preserves_blank_zero_display() -> None:
+    """Render ragged missing and genuine zero cells using the established blank display."""
+    prices = cast(pd.DataFrame, _make_mixed_prices().loc[:, ["Complete", "Late"]])
+    fig, ax = plt.subplots()
+    try:
+        qis.plot_periodic_returns_table(prices=prices, freq="ME", ax=ax)
+        fig.canvas.draw()
+
+        annotations = {
+            tuple(float(value) for value in text.get_position()): text.get_text()
+            for text in ax.texts
+        }
+        assert annotations == {
+            (0.5, 0.5): "10%",
+            (2.5, 0.5): "10%",
+            (3.5, 0.5): "21%",
+            (1.5, 1.5): "10%",
+            (2.5, 1.5): "10%",
+            (3.5, 1.5): "21%",
+        }
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
## What changed

Preserve missing periodic-return cells until each asset has two observed price boundaries instead of backfilling a later-starting asset before inception.

For month-end prices `late=[NaN, 100, 110]`, `compute_periodic_returns(..., freq='ME', add_total=False)` reports February as `0.0` and March as `0.1`, although two prices can define only the March return.

## Behavior

A pre-inception period is undefined rather than a zero economic return; complete and post-inception histories retain the documented return convention.

## Regression evidence

Validation at `817ec6a` produced February `0.0` versus an independently expected missing value and March `0.1` versus expected `0.1`. The accepted mixed-frequency guide states that leading missing values remain missing and that backfilling invents history.

## Verification

- Focused regression and integration: The permanent module, strategy-factsheet integration module, and accepted PR 109 terminal-support regression passed 40 tests with 10 inherited warnings. The new module contributes seven executed cases, including its ordinary/nullable parameterization and an actual Agg canvas render.
- Complete affected subsystem: All 505 plots tests passed against the final formatted source.
- Final full suite: All 3,142 tests passed with 20 attributable existing warnings on rebased commit `2f997e7`.
- Static, documentation, API, dependency, or build checks: `format-new` preview and execution leave the added test clean; added-line Ruff is clean; differential Pyright reports zero unapproved diagnostics and classifies 166 diagnostics as inherited or indirect; `interrogate` reports 73.3% against a 68% minimum; `git diff --check`, both warning-as-error Sphinx builds, `tools/sync_public_api.py --check` (443 names), and `uv pip check` all pass. The existing `returns_heatmap.py` remains baseline-equivalent for inherited whole-file formatter debt.

## Scope

Changed files are limited to `CHANGELOG.md`, `docs/incomplete_and_mixed_frequency_data.md`, `src/qis/plots/derived/returns_heatmap.py`, and one focused plots test.

Out of scope: Redefining interior-gap, stale-price, delisting, frequency, or rendered true-zero display policy. Missing totals for columns with fewer than two observed boundaries are in scope; they apply the existing total-return boundary rather than redefining its arithmetic.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.