### PR TITLE
fix: normalize nullable OLS inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ batch and also shifts later sample columns.
 
 ### Fixed
 
+- Normalized real-valued pandas regression inputs before statsmodels design construction, so
+  nullable benchmark returns no longer fall through to all-zero alpha, beta, and R-squared
+  statistics.
+
 - Kept risk-adjusted-table returns, ratios, and benchmark regressions within each asset's sampled
   observed history, so a longer neighboring column no longer adds post-termination flat returns.
 

--- a/src/qis/perfstats/tests/risk_table_nullable_regression_test.py
+++ b/src/qis/perfstats/tests/risk_table_nullable_regression_test.py
@@ -1,0 +1,81 @@
+"""Verify benchmark regressions across ordinary and nullable price storage.
+
+The mixed panel is the public path that previously passed a nullable benchmark Series into
+statsmodels beside an ordinary asset. Returns are constructed from a known linear relation so the
+expected regression statistics do not depend on another QIS reduction.
+"""
+
+import warnings
+from numbers import Real
+from typing import cast
+
+import numpy as np
+import pandas as pd
+
+from qis.perfstats.config import PerfParams, PerfStat
+from qis.perfstats.perf_stats import (
+    compute_ra_perf_table_with_benchmark,  # pyright: ignore[reportUnknownVariableType]
+)
+
+
+_FREQUENCY = "ME"
+_ANNUALIZATION_FACTOR = 12.0
+
+
+def _stat(table: pd.DataFrame, asset: str, perf_stat: PerfStat) -> float:
+    """Extract one real-valued statistic using its public table label."""
+    label = perf_stat.value.name
+    if not isinstance(label, str):
+        raise TypeError("expected a string performance-statistic label")
+    value = cast(object, table.loc[asset, label])
+    if isinstance(value, np.ndarray) and value.ndim == 0:
+        value = cast(object, value.item())
+    if not isinstance(value, Real):
+        raise TypeError("expected a real performance statistic")
+    return float(value)
+
+
+def test_benchmark_table_normalizes_a_nullable_benchmark_regressor() -> None:
+    """Report the known mixed-storage alpha, beta, and R-squared without warnings."""
+    dates = pd.date_range("2020-01-31", periods=13, freq=_FREQUENCY)
+    benchmark_returns = np.array(
+        [-0.03, 0.01, 0.02, -0.01, 0.04, 0.00, -0.02, 0.03, 0.01, -0.01, 0.02, 0.04],
+        dtype=np.float64,
+    )
+    asset_returns = 0.002 + 1.5 * benchmark_returns
+    prices = pd.DataFrame(
+        {
+            "Benchmark": 100.0 * np.cumprod(np.r_[1.0, 1.0 + benchmark_returns]),
+            "Asset": 80.0 * np.cumprod(np.r_[1.0, 1.0 + asset_returns]),
+        },
+        index=dates,
+    )
+    prices["Benchmark"] = prices["Benchmark"].astype(pd.Float64Dtype())
+    prices_before = prices.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        table = compute_ra_perf_table_with_benchmark(
+            prices=prices,
+            benchmark="Benchmark",
+            perf_params=PerfParams(
+                freq_vol=_FREQUENCY,
+                freq_drawdown=_FREQUENCY,
+                freq_skewness=_FREQUENCY,
+                freq_reg=_FREQUENCY,
+            ),
+            is_log_returns=False,
+        )
+
+    np.testing.assert_allclose(
+        [
+            _stat(table, "Asset", PerfStat.ALPHA_AN),
+            _stat(table, "Asset", PerfStat.BETA),
+            _stat(table, "Asset", PerfStat.R2),
+        ],
+        [_ANNUALIZATION_FACTOR * 0.002, 1.5, 1.0],
+        rtol=0.0,
+        atol=1.0e-12,
+    )
+    assert 0.0 <= _stat(table, "Asset", PerfStat.ALPHA_PVALUE) <= 1.0
+    pd.testing.assert_frame_equal(prices, prices_before)

--- a/src/qis/utils/regression.py
+++ b/src/qis/utils/regression.py
@@ -559,13 +559,50 @@ def filter_x_y(x: np.ndarray, y: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np
     return x, y, cond
 
 
-def estimate_ols_alpha_beta(x: Union[np.ndarray, pd.Series, pd.DataFrame],
-                            y: Union[np.ndarray, pd.Series],
-                            order: int = 1,
-                            fit_intercept: bool = True
-                            ) -> Tuple[float, float, float, float]:
+def _to_ols_array(values: Union[np.ndarray, pd.Series, pd.DataFrame]) -> np.ndarray:
+    """Convert real-valued pandas containers without coercing other inputs."""
+    if isinstance(values, pd.DataFrame):
+        is_numeric = all(pd.api.types.is_any_real_numeric_dtype(dtype) for dtype in values.dtypes)
+    elif isinstance(values, pd.Series):
+        is_numeric = pd.api.types.is_any_real_numeric_dtype(values.dtype)
+    else:
+        return values
+
+    if is_numeric:
+        # Avoid object designs when statsmodels adds a constant to pandas extension dtypes.
+        return values.to_numpy(dtype=float, na_value=np.nan)
+    return values.to_numpy()
+
+
+def estimate_ols_alpha_beta(
+    x: Union[np.ndarray, pd.Series, pd.DataFrame],
+    y: Union[np.ndarray, pd.Series],
+    order: int = 1,
+    fit_intercept: bool = True,
+) -> Tuple[float, float, float, float]:
+    """Estimate scalar OLS statistics from numeric NumPy or pandas inputs.
+
+    Real-valued numeric pandas containers are normalized before fitting so ordinary and nullable
+    storage use the same statsmodels design. Nonnumeric or otherwise invalid inputs retain the
+    established warning and four-zero fallback.
+
+    Args:
+        x: One explanatory variable in an array, Series, or one-column DataFrame.
+        y: Dependent observations in an array or Series.
+        order: Polynomial degree passed to the OLS design builder.
+        fit_intercept: Whether to include and report an intercept.
+
+    Returns:
+        Alpha, beta, R-squared, and the conventional alpha p-value. Without an intercept, alpha
+        and its p-value are zero. A failed fit warns and returns four zeros.
+    """
     try:
-        reg_model = fit_ols(x=x, y=y, order=order, fit_intercept=fit_intercept)
+        reg_model = fit_ols(
+            x=_to_ols_array(x),
+            y=_to_ols_array(y),
+            order=order,
+            fit_intercept=fit_intercept,
+        )
     except Exception:
         warnings.warn(f"problem with x={x}, y={y}")
         return 0.0, 0.0, 0.0, 0.0

--- a/src/qis/utils/tests/regression_nullable_test.py
+++ b/src/qis/utils/tests/regression_nullable_test.py
@@ -1,0 +1,121 @@
+"""Verify that numeric pandas storage does not change scalar OLS estimates.
+
+The compact representation matrix covers the one-regressor containers accepted by
+``estimate_ols_alpha_beta``. Nullable dtypes matter because statsmodels cannot fit the object
+design matrix that pandas can otherwise construct when an intercept is added.
+"""
+
+import warnings
+from typing import Union
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from qis.utils.regression import estimate_ols_alpha_beta
+
+
+OlsInput = Union[np.ndarray, pd.Series, pd.DataFrame]
+
+
+def _regressor(storage: str) -> OlsInput:
+    """Build equivalent explanatory data in each supported one-regressor container."""
+    values = [0.0, 1.0, 2.0, 3.0]
+    if storage == "numpy-vector":
+        return np.asarray(values, dtype=np.float64)
+    if storage == "numpy-column":
+        return np.asarray(values, dtype=np.float64)[:, None]
+    if storage == "series-float64":
+        return pd.Series(values, dtype=np.float64, name="x")
+    if storage == "series-Float64":
+        return pd.Series(values, dtype=pd.Float64Dtype(), name="x")
+    if storage == "series-Int64":
+        return pd.Series([0, 1, 2, 3], dtype=pd.Int64Dtype(), name="x")
+    if storage == "frame-float64":
+        return pd.DataFrame({"x": pd.Series(values, dtype=np.float64)})
+    if storage == "frame-Float64":
+        return pd.DataFrame({"x": pd.Series(values, dtype=pd.Float64Dtype())})
+    raise ValueError(f"unknown storage {storage!r}")
+
+
+@pytest.mark.parametrize(
+    "storage",
+    [
+        "numpy-vector",
+        "numpy-column",
+        "series-float64",
+        "series-Float64",
+        "series-Int64",
+        "frame-float64",
+        "frame-Float64",
+    ],
+)
+def test_estimate_ols_alpha_beta_is_invariant_to_numeric_storage(storage: str) -> None:
+    """Match the independently known line for every supported numeric representation."""
+    x = _regressor(storage)
+    y = pd.Series([1.0, 3.0, 5.0, 7.0], name="y")
+    x_before = x.copy()
+    y_before = y.copy(deep=True)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        alpha, beta, r_squared, alpha_pvalue = estimate_ols_alpha_beta(x=x, y=y)
+
+    np.testing.assert_allclose(
+        [alpha, beta, r_squared],
+        [1.0, 2.0, 1.0],
+        rtol=0.0,
+        atol=1.0e-12,
+    )
+    assert 0.0 <= alpha_pvalue <= 1.0
+    if isinstance(x, pd.Series):
+        pd.testing.assert_series_equal(x, x_before)
+    elif isinstance(x, pd.DataFrame):
+        pd.testing.assert_frame_equal(x, x_before)
+    else:
+        np.testing.assert_array_equal(x, x_before)
+    pd.testing.assert_series_equal(y, y_before)
+
+
+def test_estimate_ols_alpha_beta_filters_paired_nullable_missing_rows() -> None:
+    """Drop paired missing rows before fitting the independently known finite line."""
+    x = pd.Series([0.0, 1.0, pd.NA, 3.0, 4.0], dtype=pd.Float64Dtype(), name="x")
+    y = pd.Series([1.0, 3.0, pd.NA, 7.0, 9.0], dtype=pd.Float64Dtype(), name="y")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        alpha, beta, r_squared, _ = estimate_ols_alpha_beta(x=x, y=y)
+
+    np.testing.assert_allclose(
+        [alpha, beta, r_squared],
+        [1.0, 2.0, 1.0],
+        rtol=0.0,
+        atol=1.0e-12,
+    )
+
+
+def test_estimate_ols_alpha_beta_preserves_no_intercept_semantics() -> None:
+    """Keep the established zero-alpha convention when the intercept is disabled."""
+    x = pd.Series([1.0, 2.0, 3.0, 4.0], dtype=pd.Float64Dtype(), name="x")
+    y = pd.Series([2.0, 4.0, 6.0, 8.0], dtype=pd.Float64Dtype(), name="y")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        actual = estimate_ols_alpha_beta(x=x, y=y, fit_intercept=False)
+
+    np.testing.assert_allclose(actual, [0.0, 2.0, 1.0, 0.0], rtol=0.0, atol=1.0e-12)
+
+
+def test_estimate_ols_alpha_beta_keeps_nonnumeric_fallback() -> None:
+    """Do not turn the numeric-storage normalization into string coercion."""
+    x = pd.Series(["0", "1", "2", "3"], name="x")
+    y = pd.Series([1.0, 3.0, 5.0, 7.0], name="y")
+    x_before = x.copy(deep=True)
+    y_before = y.copy(deep=True)
+
+    with pytest.warns(UserWarning, match="problem with x="):
+        actual = estimate_ols_alpha_beta(x=x, y=y)
+
+    assert actual == (0.0, 0.0, 0.0, 0.0)
+    pd.testing.assert_series_equal(x, x_before)
+    pd.testing.assert_series_equal(y, y_before)


### PR DESCRIPTION
## What changed

Convert finite pandas nullable regression inputs to the ordinary numeric representation before statsmodels so valid fits cannot fall through to all-zero statistics.

For `y = 1 + 2x` with `x=[0,1,2,3]`, ordinary storage returns alpha approximately `1`, beta `2`, and R-squared `1`, while identical `Float64` Series emit a warning and return `(0.0, 0.0, 0.0, 0.0)`.

## Behavior

Storage dtype must not change a finite regression, and an internal compatibility exception must not be represented as genuine zero statistics.

## Regression evidence

On Python 3.11.9, NumPy 2.4.6, pandas 3.0.5, and statsmodels 0.14.6 at `501a286`, the exact `y=1+2x` ordinary Series and NumPy fits returned alpha approximately `1`, beta `2`, R-squared `1`, and the ordinary alpha p-value. Identical nullable `Float64` or `Int64` explanatory Series warned and returned `(0.0, 0.0, 0.0, 0.0)`. Ordinary and nullable one-column DataFrame regressors also returned the false-zero fallback. Paired missing nullable rows reached the same defect while every caller-owned input remained unchanged.

## Verification

- Focused regression: Exact finite nullable `Float64` and `Int64` explanatory regressions, one-column DataFrames, and paired-missing inputs returned four false zeros with a warning.
- Public integration: A monthly benchmark/asset path with independently constructed `asset_return = 0.002 + 1.5 * benchmark_return` reported alpha approximately `0.002`, beta `1.5`, and R-squared `1.0` under ordinary storage but four zeros under nullable storage.
- Pass-after focused regression: The final two-module matrix passes all 11 cases without warnings on valid inputs; nullable `Float64`/`Int64`, one-column DataFrames, paired missing rows, NumPy controls, no-intercept semantics, nonnumeric fallback, public labels, and ownership all match their stated contracts.
- Accepted controls: Existing utility regressions, benchmark-source validation, and ordinary terminal-support regressions remain covered by the complete affected-subsystem run.
- Complete affected subsystem: All 915 utility and perfstats tests passed against the final formatted source.
- Documentation and final full suite: Both warning-as-error Sphinx builds passed, followed by all 3,189 repository tests with 20 inherited warnings.
- Static, documentation, API, dependency, or build checks: Ruff reports no changed-file or added-line violations; changed-line Pyright reports zero unapproved diagnostics; interrogate passes at 73.5%; `tools/sync_public_api.py --check` reports 445 current names; `uv pip check` passes; and `git diff --check` passes. Both added Python files pass previewed/executed `format-new` unchanged. `src/qis/utils/regression.py` retains only its accepted formatter debt, and manual formatter-diff review shows no proposed change in the new block.
- Receipt: The clean `static+focused+suite+api+dependencies+full+docs` receipt binds accepted `71f7e68`, rebased commit `2af8816`, and diff SHA-256 `cca1d54cd5900190f7fd72346f6fb0c940a4d65ed428806fbb39f73256175f24`; it was verified at `2026-09-12T17:36:52Z`.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/utils/regression.py`, `src/qis/utils/tests/regression_nullable_test.py`, and `src/qis/perfstats/tests/risk_table_nullable_regression_test.py`.

Out of scope: Replacing statsmodels, changing regression definitions, or globally removing legacy fallback behavior without a separate contract decision.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.