### PR TITLE
fix: normalize backtester price chronology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ batch and also shifts later sample columns.
 
 ### Fixed
 
+- Ordered portfolio-backtester prices, funding rates, and instrument carry chronologically before
+  stateful processing, and rejected ambiguous duplicate or missing price timestamps.
+
 - Normalized real-valued pandas regression inputs before standard and HAC statsmodels design
   construction, so nullable benchmark returns no longer fail or fall through to all-zero alpha,
   beta, and R-squared statistics. Pandas row indexes remain an enforced alignment boundary.

--- a/docs/audit/paper_numbers.json
+++ b/docs/audit/paper_numbers.json
@@ -1,6 +1,6 @@
 {
   "generated_by": "tools/paper_audit.py",
-  "measured_at_commit": "fe261c2053f501672d707ba40b4dde3af2662a2c",
+  "measured_at_commit": "dc4c47e5f1d44c1f3c85eeeaad0ca61bb6f2103c",
   "note": "every number paper.md quotes. Regenerate with python tools/paper_audit.py; the package paper-audit test fails when this file and the repository disagree.",
   "metrics": {
     "active_months": {
@@ -28,16 +28,16 @@
       "paper_phrase": null
     },
     "backtester_nonblank_lines": {
-      "value": 356,
+      "value": 376,
       "how": "nonblank lines of src/qis/portfolio/backtester.py",
       "live": true,
       "paper_phrase": null
     },
     "backtester_physical_lines": {
-      "value": 403,
+      "value": 425,
       "how": "physical lines of src/qis/portfolio/backtester.py",
       "live": true,
-      "paper_phrase": "backtester is 403 lines"
+      "paper_phrase": "backtester is 425 lines"
     },
     "capability_groups": {
       "value": 13,
@@ -46,13 +46,13 @@
       "paper_phrase": "13 capability groups"
     },
     "collected_tests": {
-      "value": 3168,
+      "value": 3201,
       "how": "pytest --collect-only -q, summed over files, core install",
       "live": false,
       "paper_phrase": null
     },
     "commits": {
-      "value": 649,
+      "value": 657,
       "how": "git rev-list --count HEAD",
       "live": false,
       "paper_phrase": null

--- a/docs/portfolio_backtesting.md
+++ b/docs/portfolio_backtesting.md
@@ -15,8 +15,10 @@ units remain fixed until the next rebalance while realised weights drift with pr
 
 ## Data and calculation contract
 
-- **Prices:** a `pandas.DataFrame` of levels, dates in a `DatetimeIndex`, assets in columns. Price
-  units can differ by asset because the engine holds units. Columns must be unique.
+- **Prices:** a `pandas.DataFrame` of levels, unique non-missing dates in a `DatetimeIndex`, assets
+  in columns. The backtester orders price rows chronologically on a local copy before constructing
+  state; duplicate timestamps are rejected because their state-transition order is ambiguous.
+  Price units can differ by asset because the engine holds units. Columns must be unique.
 - **Target weights:** a dictionary, Series, list, array, or date-by-asset DataFrame. Named inputs
   align by ticker; list and array inputs are positional. A fixed vector is reapplied at
   `rebalancing_freq`; a DataFrame supplies its own decision dates and ignores that frequency.
@@ -27,7 +29,8 @@ units remain fixed until the next rebalance while realised weights drift with pr
   assumption is intentional.
 - **Returns and annualisation:** prices produce simple holding-period P&L. `funding_rate`,
   `management_fee`, and `instruments_carry` are annualised decimal rates converted to the price
-  grid. A cash residual earns `funding_rate`, which defaults to zero.
+  grid. Dated funding and carry inputs are ordered chronologically before that alignment. A cash
+  residual earns `funding_rate`, which defaults to zero.
 - **Trading costs:** `rebalancing_costs` is a decimal fraction of absolute traded notional;
   `0.0010` is 10 bp. A scalar applies everywhere, a ticker-indexed Series varies by asset, and a
   date-by-ticker DataFrame is forward-filled through time. Costs are read on the trade date.

--- a/paper.md
+++ b/paper.md
@@ -120,7 +120,7 @@ draw across several aligned panels, so a factor and a residual panel resample to
 
 We organise the package into 13 capability groups, which `src/qis/api.py` names.
 
-The backtester is 403 lines, and that follows from the design assumption rather than from
+The backtester is 425 lines, and that follows from the design assumption rather than from
 compression. Because a strategy is a rule for producing weights, the backtester holds no strategy
 logic: it converts target weights to units at each rebalancing, holds those units until the next
 one, applies costs, and returns the result. The recursion over dates is compiled with `numba`,

--- a/src/qis/portfolio/backtester.py
+++ b/src/qis/portfolio/backtester.py
@@ -30,9 +30,10 @@ nothing else: the weight observed at t is traded at the price ``weight_implement
 observations of the price index later. It does not shift, resample or otherwise touch prices, so
 instrument returns are the same under any lag.
 
-Caller-owned weights are never modified; dated schedules are ordered chronologically on a local
-copy. An instrument with no price on a rebalancing date is not traded and its weight stays in the
-cash balance; allocating that weight over the priced instruments instead is
+Caller-owned dated inputs are never modified. Prices and dated schedules are ordered
+chronologically on local copies, and the price index must contain unique, non-missing timestamps.
+An instrument with no price on a rebalancing date is not traded and its weight stays in the cash
+balance; allocating that weight over the priced instruments instead is
 ``qis.generate_static_weights_schedule``, before the backtest.
 
 ``backtest_rebalanced_portfolio`` is the numba kernel underneath: a genuine recursion in nav and
@@ -49,6 +50,7 @@ from numba import njit
 from typing import Union, Dict, Tuple, List, Optional
 # qis
 from qis.utils.dates import generate_rebalancing_indicators, set_rebalancing_timeindex_on_given_timeindex
+from qis.utils.df_freq import validate_calendar_index
 from qis.utils.df_ops import multiply_df_by_dt
 from qis.utils.df_to_weights import align_weights_to_columns
 from qis.utils.np_ops import repeat_by_columns, repeat_by_rows
@@ -79,7 +81,9 @@ def backtest_model_portfolio(prices: pd.DataFrame,
 
     Args:
         prices: instrument prices, columns are tickers. Costs, carry and fees are applied on
-            this grid
+            this grid. A nonempty input must use a ``DatetimeIndex`` with unique, non-missing
+            timestamps. Rows are ordered chronologically on a local copy before any portfolio
+            state is constructed; the caller-owned object is not modified
         weights: target weights. A Dict or pd.DataFrame is safest, since both are aligned to
             ``prices.columns`` by name; a list or array is positional and must match the
             column count. A fixed weight vector is applied at every date in
@@ -89,9 +93,11 @@ def backtest_model_portfolio(prices: pd.DataFrame,
         rebalancing_freq: calendar anchor for rebalancing when ``weights`` is a fixed vector,
             passed to :func:`generate_rebalancing_indicators`
         initial_nav: starting nav
-        funding_rate: annualised rate applied to positive and negative cash balances
+        funding_rate: annualised rate applied to positive and negative cash balances. Dated rows
+            are ordered chronologically on a local copy before alignment to ``prices``
         management_fee: annualised fee accrued on nav
-        instruments_carry: per-instrument carry, expressed on nav
+        instruments_carry: per-instrument carry, expressed on nav. Dated rows are ordered
+            chronologically on a local copy before alignment to ``prices``
         rebalancing_costs: proportional cost on traded notional, fractional units (0.0010 is
             10 bp). A float applies to every instrument and date; a Series indexed by ticker
             is per-instrument and constant in time; a DataFrame of dates x tickers is
@@ -116,16 +122,28 @@ def backtest_model_portfolio(prices: pd.DataFrame,
         costs, including costs charged on an opening trade
 
     Raises:
-        ValueError: if ``prices`` is not a pd.DataFrame, if the dated-weight implementation lag
-            is neither None nor a non-negative integer, if a weight vector does not match the
-            number of price columns, if the price history starts after the weights do, if two
-            weight dates resolve to the same traded date on the price index, if no weight date
-            is traded at all, if a ``rebalancing_costs`` DataFrame is missing a price column,
-            or if a ``rebalancing_costs`` Series is indexed by dates rather than tickers
+        TypeError: if a nonempty ``prices`` input does not use a ``DatetimeIndex``
+        ValueError: if ``prices`` is not a pd.DataFrame, if its nonempty date index contains
+            ``NaT`` or duplicate timestamps, if the dated-weight implementation lag is neither
+            None nor a non-negative integer, if a weight vector does not match the number of
+            price columns, if the price history starts after the weights do, if two weight dates
+            resolve to the same traded date on the price index, if no weight date is traded at
+            all, if a ``rebalancing_costs`` DataFrame is missing a price column, or if a
+            ``rebalancing_costs`` Series is indexed by dates rather than tickers
         NotImplementedError: if ``weights`` is of an unsupported type
     """
     if not isinstance(prices, pd.DataFrame):
         raise ValueError(f"prices type={type(prices)} must be pd.Dataframe")
+
+    validate_calendar_index(prices, argument_name="prices")
+    # Two state transitions at one timestamp have no unambiguous economic order.
+    if prices.index.has_duplicates:
+        raise ValueError("prices index must be unique")
+
+    # Each row is a portfolio state transition, so all validation and dated companions must use
+    # one chronological grid rather than the caller's physical row order.
+    if not prices.index.is_monotonic_increasing:
+        prices = prices.sort_index(kind="stable")
 
     # The lag applies only to dated schedules; validate it before mapping decision dates
     # onto the price index.
@@ -221,9 +239,11 @@ def backtest_model_portfolio(prices: pd.DataFrame,
                       f"qis.generate_static_weights_schedule()",
                       UserWarning, stacklevel=2)
 
-    # adjust rates at rebealncing
+    # Sort dated funding and carry before multiply_df_by_dt forward-fills them onto the price grid.
     if funding_rate is not None:
-        funding_rate_dt = multiply_df_by_dt(df=funding_rate, dates=prices.index, lag=0)
+        funding_rate_dt = multiply_df_by_dt(
+            df=funding_rate.sort_index(kind="stable"), dates=prices.index, lag=0
+        )
     else:
         funding_rate_dt = pd.Series(0.0, index=prices.index)
 
@@ -233,7 +253,9 @@ def backtest_model_portfolio(prices: pd.DataFrame,
         management_fee_dt = pd.Series(0.0, index=prices.index)
 
     if instruments_carry is not None:
-        instruments_carry_dt = multiply_df_by_dt(df=instruments_carry, dates=prices.index, lag=0)
+        instruments_carry_dt = multiply_df_by_dt(
+            df=instruments_carry.sort_index(kind="stable"), dates=prices.index, lag=0
+        )
     else:
         instruments_carry_dt = pd.Series(0.0, index=prices.index)
 

--- a/src/qis/portfolio/tests/backtester_price_date_order_test.py
+++ b/src/qis/portfolio/tests/backtester_price_date_order_test.py
@@ -1,0 +1,261 @@
+"""Regression tests for chronological portfolio-backtester input handling.
+
+The backtester is a stateful recursion over its price rows, so equivalent timestamped mappings
+must first share one chronological grid. These tests cover the held-unit path, dated decisions,
+calendar validation, missing-history classification, and every dated financial companion aligned
+by the public wrapper.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import qis
+
+
+DATES = pd.DatetimeIndex(
+    ["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05"],
+    tz="America/New_York",
+    name="date",
+)
+PERMUTATION = [2, 0, 3, 1]
+
+
+def _prices() -> pd.DataFrame:
+    """Return a hand-checkable two-asset price path on a named timezone-aware grid."""
+    return pd.DataFrame(
+        {"A": [100.0, 110.0, 121.0, 133.1], "B": [100.0] * len(DATES)},
+        index=DATES,
+    )
+
+
+def _permuted_frame(data: pd.DataFrame) -> pd.DataFrame:
+    """Return DataFrame rows in a deterministic nonchronological order."""
+    return data.iloc[PERMUTATION, :]
+
+
+def _permuted_series(data: pd.Series) -> pd.Series:
+    """Return Series rows in a deterministic nonchronological order."""
+    return data.iloc[PERMUTATION]
+
+
+def test_backtest_model_portfolio_normalizes_fixed_weight_price_order() -> None:
+    """A price-row permutation preserves the chronological one-unit economic path."""
+    chronological = pd.DataFrame({"A": [100.0, 110.0, 121.0, 133.1]}, index=DATES)
+    prices = _permuted_frame(chronological)
+    caller_prices = prices.copy()
+
+    result = qis.backtest_model_portfolio(
+        prices=prices,
+        weights={"A": 1.0},
+        rebalancing_freq="YE",
+        is_rebalanced_at_first_date=True,
+    )
+
+    # Investing the initial 100 at the first chronological price of 100 buys exactly one unit.
+    expected_nav = pd.Series(
+        [100.0, 110.0, 121.0, 133.1],
+        index=DATES,
+        name="Portfolio",
+    )
+    expected_units = pd.DataFrame(1.0, index=DATES, columns=["A"])
+    expected_rebalancing = pd.Series([True, False, False, False], index=DATES)
+    pd.testing.assert_series_equal(result.nav, expected_nav)
+    pd.testing.assert_frame_equal(result.units, expected_units)
+    pd.testing.assert_frame_equal(result.weights, expected_units)
+    pd.testing.assert_series_equal(result.is_rebalancing, expected_rebalancing)
+    pd.testing.assert_frame_equal(result.prices, chronological)
+    pd.testing.assert_frame_equal(prices, caller_prices)
+
+
+def test_backtest_model_portfolio_does_not_revise_a_chronological_prefix() -> None:
+    """Appending a later price cannot change an earlier normalized portfolio path."""
+    full_prices = _permuted_frame(pd.DataFrame({"A": [100.0, 110.0, 121.0, 133.1]}, index=DATES))
+    prefix_dates = pd.DatetimeIndex(DATES[:3])
+    prefix_prices = pd.DataFrame(
+        {"A": [110.0, 100.0, 121.0]},
+        index=pd.DatetimeIndex(
+            [prefix_dates[1], prefix_dates[0], prefix_dates[2]], name=DATES.name
+        ),
+    )
+
+    full_result = qis.backtest_model_portfolio(
+        prices=full_prices,
+        weights={"A": 1.0},
+        rebalancing_freq="YE",
+        is_rebalanced_at_first_date=True,
+    )
+    prefix_result = qis.backtest_model_portfolio(
+        prices=prefix_prices,
+        weights={"A": 1.0},
+        rebalancing_freq="YE",
+        is_rebalanced_at_first_date=True,
+    )
+
+    pd.testing.assert_series_equal(full_result.nav.head(3), prefix_result.nav)
+    pd.testing.assert_frame_equal(full_result.units.head(3), prefix_result.units)
+
+
+@pytest.mark.parametrize(
+    ("lag", "decision_dates", "trade_positions", "expected_nav", "expected_units"),
+    [
+        pytest.param(
+            0,
+            ("2024-01-02", "2024-01-03 12:00"),
+            (0, 2),
+            [100.0, 110.0, 121.0, 121.0],
+            [[1.0, 0.0], [1.0, 0.0], [0.0, 1.21], [0.0, 1.21]],
+            id="same-observation-off-grid",
+        ),
+        pytest.param(
+            1,
+            ("2024-01-02", "2024-01-03 12:00"),
+            (1, 3),
+            [100.0, 100.0, 110.0, 121.0],
+            [
+                [0.0, 0.0],
+                [100.0 / 110.0, 0.0],
+                [100.0 / 110.0, 0.0],
+                [0.0, 1.21],
+            ],
+            id="next-observation-off-grid",
+        ),
+    ],
+)
+def test_backtest_model_portfolio_normalizes_prices_before_mapping_dated_weights(
+    lag: int,
+    decision_dates: tuple[str, str],
+    trade_positions: tuple[int, int],
+    expected_nav: list[float],
+    expected_units: list[list[float]],
+) -> None:
+    """Exact and off-grid decisions use the sorted price grid before implementation lag."""
+    chronological = _prices()
+    prices = _permuted_frame(chronological)
+    dates = pd.DatetimeIndex(decision_dates, tz=DATES.tz)
+    weights = pd.DataFrame([[1.0, 0.0], [0.0, 1.0]], index=dates, columns=prices.columns)
+    caller_prices = prices.copy()
+    caller_weights = weights.copy()
+
+    result = qis.backtest_model_portfolio(
+        prices=prices,
+        weights=weights,
+        weight_implementation_lag=lag,
+    )
+
+    expected_nav_series = pd.Series(expected_nav, index=DATES, name="Portfolio")
+    expected_units_frame = pd.DataFrame(
+        expected_units,
+        index=DATES,
+        columns=chronological.columns,
+    )
+    expected_weights = expected_units_frame.multiply(chronological).divide(
+        expected_nav_series,
+        axis=0,
+    )
+    expected_rebalancing = pd.Series(False, index=DATES)
+    expected_rebalancing.iloc[list(trade_positions)] = True
+    pd.testing.assert_series_equal(result.nav, expected_nav_series)
+    pd.testing.assert_frame_equal(result.units, expected_units_frame)
+    pd.testing.assert_frame_equal(result.weights, expected_weights)
+    pd.testing.assert_series_equal(result.is_rebalancing, expected_rebalancing)
+    pd.testing.assert_frame_equal(prices, caller_prices)
+    pd.testing.assert_frame_equal(weights, caller_weights)
+
+
+def test_backtest_model_portfolio_aligns_permuted_dated_companions() -> None:
+    """Costs, funding, and carry retain their dated meaning on the normalized price grid."""
+    chronological = pd.DataFrame({"A": [100.0] * len(DATES)}, index=DATES)
+    prices = _permuted_frame(chronological)
+    funding = pd.Series([0.0, 0.365, 0.73, 1.095], index=DATES, name="funding")
+    carry = pd.DataFrame({"A": [0.0, 0.365, 0.73, 1.095]}, index=DATES)
+    costs = pd.DataFrame({"A": [0.01, 0.02, 0.03, 0.04]}, index=DATES)
+    permuted_funding = _permuted_series(funding)
+    permuted_carry = _permuted_frame(carry)
+    permuted_costs = _permuted_frame(costs)
+    caller_prices = prices.copy()
+    caller_funding = permuted_funding.copy()
+    caller_carry = permuted_carry.copy()
+    caller_costs = permuted_costs.copy()
+
+    result = qis.backtest_model_portfolio(
+        prices=prices,
+        weights={"A": 0.5},
+        rebalancing_freq="YE",
+        is_rebalanced_at_first_date=True,
+        funding_rate=permuted_funding,
+        instruments_carry=permuted_carry,
+        rebalancing_costs=permuted_costs,
+    )
+
+    # Opening costs leave 49.5 cash. Each later cash balance earns its dated funding rate,
+    # then receives carry on the unchanged 50 notional before it is added back to that notional.
+    expected_nav = pd.Series(
+        [99.5, 99.5995, 99.798699, 100.098095097],
+        index=DATES,
+        name="Portfolio",
+    )
+    expected_costs = pd.DataFrame(
+        {"A": [0.5, 0.0, 0.0, 0.0]},
+        index=DATES,
+    )
+    pd.testing.assert_series_equal(result.nav, expected_nav)
+    pd.testing.assert_frame_equal(result.realized_costs, expected_costs)
+    pd.testing.assert_frame_equal(prices, caller_prices)
+    pd.testing.assert_series_equal(permuted_funding, caller_funding)
+    pd.testing.assert_frame_equal(permuted_carry, caller_carry)
+    pd.testing.assert_frame_equal(permuted_costs, caller_costs)
+
+
+@pytest.mark.parametrize(
+    ("index", "error", "message"),
+    [
+        pytest.param(pd.Index([0, 1, 2]), TypeError, "prices must use a DatetimeIndex", id="type"),
+        pytest.param(
+            pd.DatetimeIndex(["2024-01-02", pd.NaT, "2024-01-04"]),
+            ValueError,
+            "prices index must not contain NaT",
+            id="nat",
+        ),
+        pytest.param(
+            pd.DatetimeIndex(["2024-01-02", "2024-01-02", "2024-01-04"]),
+            ValueError,
+            "prices index must be unique",
+            id="duplicate",
+        ),
+    ],
+)
+def test_backtest_model_portfolio_rejects_ambiguous_price_calendars(
+    index: pd.Index,
+    error: type[Exception],
+    message: str,
+) -> None:
+    """Malformed authoritative calendars fail before portfolio state is constructed."""
+    prices = pd.DataFrame({"A": [100.0, 110.0, 121.0]}, index=index)
+    caller_prices = prices.copy()
+
+    with pytest.raises(error, match=message):
+        qis.backtest_model_portfolio(prices=prices, weights={"A": 1.0})
+
+    pd.testing.assert_frame_equal(prices, caller_prices)
+
+
+def test_backtest_model_portfolio_classifies_missing_history_after_price_sorting() -> None:
+    """A leading unavailable price does not become a false interior hole through row order."""
+    chronological = _prices()
+    chronological.loc[chronological.index[0], "A"] = np.nan
+    prices = _permuted_frame(chronological)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        result = qis.backtest_model_portfolio(
+            prices=prices,
+            weights={"A": 0.0, "B": 1.0},
+            rebalancing_freq="YE",
+            is_rebalanced_at_first_date=True,
+        )
+
+    expected_nav = pd.Series(100.0, index=DATES, name="Portfolio")
+    pd.testing.assert_series_equal(result.nav, expected_nav)


### PR DESCRIPTION
## What changed

Establish chronological price consumption at the public portfolio-backtester boundary while keeping every dated companion input aligned to the same final grid.

Prices representing `100 -> 110 -> 121` produce the expected NAV in date order, but physical row order January 2, January 1, January 3 yields labeled NAV values approximately `100`, `90.9091`, and `110` instead.

## Behavior

Equivalent timestamped prices must produce the same chronological holdings and NAV regardless of input row order; no state transition may consume a future row.

## Regression evidence

A sorted-versus-permuted metamorphic comparison failed at `abdf70e`; the function sorts dated weights but consumes prices in caller row order throughout validation, schedule alignment, return recursion, and output construction.

## Verification

- Focused regression: On accepted `abdf70e`, chronological prices `100, 110, 121` produced NAV `100, 110, 121`, while the same mapping in January 2, January 1, January 3 row order produced NAV `100, 90.9090909091, 110` in that nonchronological order and held `0.9090909091` units instead of one. Dated weights can instead fail early against the wrong physical first row. Independently sorting the mapping restores NAV `100, 110, 121` and one held unit without mutating the caller. Permuted funding and carry schedules separately raise pandas monotonicity errors today, whereas weights and transaction-cost schedules already normalize locally. All nine final regressions passed, and the final consolidated focused/downstream/audit run passed 61 tests.
- Complete affected subsystem: `pytest src/qis/portfolio/` passed 269 tests with 20 existing warnings against the final formatted source.
- Final full suite: `pytest src/qis/` passed 3,201 tests with 20 existing warnings against exact commit `8293017` after the generated paper-audit record was refreshed.
- Static, documentation, API, dependency, or build checks: Exact-scope and whitespace checks passed; Ruff found zero violations on added lines; changed-line Pyright found zero unapproved diagnostics (36 inherited or indirect); the added test is Ruff-format clean and the existing backtester retains only baseline formatting debt; interrogate passed at 73.6%; both Sphinx warning-as-error HTML and linkcheck builds passed; `sync_public_api.py --check` reported all 445 names current; and `uv pip check` reported a compatible environment.

## Scope

Changed files are limited to `CHANGELOG.md`, `src/qis/portfolio/backtester.py`, one focused portfolio test, the owning backtesting documentation, plus `paper.md` and `docs/audit/paper_numbers.json` when the native full-suite audit requires their exact generated line/test/commit measurements.

Out of scope: Redefining return conventions, rebalancing economics, interior missing-price policy, or transaction-cost dtype handling assigned to PR 116.

## Checklist

- [x] Tests cover the changed public behavior or defect.
- [x] Point-in-time code uses no observations later than the decision time.
- [x] Return, frequency, annualisation, and missing-data conventions remain explicit.
- [x] No credentials, proprietary data, local paths, generated outputs, or agent reports are included.
- [x] The changed-lines ruff gate and production docstring gate pass.
- [x] User-visible changes are documented in `CHANGELOG.md` and relevant docs.
- [x] New runtime dependencies or public-signature changes are called out explicitly.